### PR TITLE
allow suffixes in gems and dependences

### DIFF
--- a/bin/fpm
+++ b/bin/fpm
@@ -60,6 +60,10 @@ def main(args)
       settings.source_type = st
     end
 
+    opts.on("-S PACKAGE_SUFFIX", "which suffix to append to package and dependances") do |sfx|
+      settings.suffix = sfx
+    end
+
     opts.on("--prefix PREFIX",
             "A path to prefix files with when building the target package. This may not be necessary for all source types. For example, the 'gem' type will prefix with your gem directory (gem env | grep -A1 PATHS:)") do |prefix|
       settings.prefix = prefix

--- a/lib/fpm/builder.rb
+++ b/lib/fpm/builder.rb
@@ -34,7 +34,8 @@ class FPM::Builder
       paths, root,
       :version => settings.version,
       :name => settings.package_name,
-      :prefix => settings.prefix
+      :prefix => settings.prefix,
+      :suffix => settings.suffix
     )
 
     @paths = paths

--- a/lib/fpm/source.rb
+++ b/lib/fpm/source.rb
@@ -28,6 +28,7 @@ class FPM::Source
     @paths = paths
     @root = root
 
+    self[:suffix] = params[:suffix]
     get_source(params)
     get_metadata
 

--- a/lib/fpm/source/gem.rb
+++ b/lib/fpm/source/gem.rb
@@ -63,7 +63,7 @@ class FPM::Source::Gem < FPM::Source
           self[field] = spec.send(field)
         end
 
-        self[:name] = "rubygem-#{spec.name}"
+        self[:name] = "rubygem#{self[:suffix]}-#{spec.name}"
         self[:maintainer] = spec.author
         self[:url] = spec.homepage
 
@@ -78,7 +78,7 @@ class FPM::Source::Gem < FPM::Source
           else
             reqs = dep.version_requirements
           end
-          "rubygem-#{dep.name} #{reqs}"
+          "rubygem#{self[:suffix]}-#{dep.name} #{reqs}"
         end
       end # ::Gem::Package
     end # File.open (the gem)


### PR DESCRIPTION
this provides a new option which is only effective for gems right now which suffixing packages and dependences, this is convenient for packaging gems for both 1.8 and 1.9.2 (or rubinius, jruby, ...) on the same system

fpm -S 19 -t deb -s gem bundler
fpm -S 18 -t deb -s gem bundler

dependences will require the same suffix be present, so the trick described in the wiki still works.
