### PR TITLE
Corrected deb output filename

### DIFF
--- a/lib/fpm/target/deb.rb
+++ b/lib/fpm/target/deb.rb
@@ -27,5 +27,13 @@ class FPM::Target::Deb < FPM::Package
     system("ar -qc #{params[:output]} debian-binary control.tar.gz data.tar.gz")
 
   end # def build
+
+  def default_output
+    if iteration
+      "#{name}_#{version}-#{iteration}_#{architecture}.#{type}"
+    else
+      "#{name}_#{version}_#{architecture}.#{type}"
+    end
+  end # def default_output
 end # class FPM::Deb
 


### PR DESCRIPTION
Hi,

The default .deb filenames that fpm creates, using - instead of _ to separate package name from version from architecture, is not considered "legal". While this seems only cosmetic, It appears that using dput to upload packages to a reprepro-managed repository fails because of this non-compliant filename.

This patch corrects this detail and makes reprepro, as well as it's administrator, happy.

Cheers,
Marc
