### PR TITLE
Check for empty lines in the description field

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -71,7 +71,7 @@ class FPM::Package
     @license = source[:license] || "unknown"
     @maintainer = source[:maintainer] || "<#{ENV["USER"]}@#{Socket.gethostname}>"
     @architecture = source[:architecture] || %x{uname -m}.chomp
-    @description = source[:description] || "no description given"
+    @description = source[:description].gsub(/^\s*$/," .") || "no description given"
     @provides = source[:provides] || []
     @scripts = source[:scripts]
   end # def initialize

--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -38,4 +38,4 @@ Section: <%= category or "unknown" %>
 Priority: extra
 Homepage: <%= url or "http://nourlgiven.example.com/" %>
 Description: <%= description or "no description given" %>
-  <%= description or "no description given"%>
+


### PR DESCRIPTION
The description field cannot contain empty lines in a debian control
file. Adds " ." to empty lines. Also removes double printing of the
description in the control file.
