### PR TITLE
Re-enable use of both description and summary fields

### DIFF
--- a/lib/fpm/builder.rb
+++ b/lib/fpm/builder.rb
@@ -40,7 +40,8 @@ class FPM::Builder
       :exclude => settings.exclude,
       :maintainer => settings.maintainer,
       :provides => [],
-      :description => settings.description
+      :description => settings.description,
+      :summary => settings.summary
     )
 
     @edit = !!settings.edit

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -47,7 +47,10 @@ class FPM::Package
   # (Not all packages support this)
   attr_accessor :provides
 
-  # a summary or description of the package
+  # a one-line summary of the package
+  attr_accessor :summary
+
+  # a description of the package
   attr_accessor :description
 
   # hash of paths for maintainer/package scripts (postinstall, etc)
@@ -72,6 +75,8 @@ class FPM::Package
     @maintainer = source[:maintainer] || "<#{ENV["USER"]}@#{Socket.gethostname}>"
     @architecture = source[:architecture] || %x{uname -m}.chomp
     @description = source[:description].gsub(/^\s*$/," .") || "no description given"
+    # make sure summary is only one line!
+    @summary = source[:summary].split(/\n+/)[0] || "no summary given"
     @provides = source[:provides] || []
     @scripts = source[:scripts]
   end # def initialize

--- a/lib/fpm/source.rb
+++ b/lib/fpm/source.rb
@@ -12,6 +12,7 @@ class FPM::Source
     category
     url
     description
+    summary
   ).each do |attr|
     attr = :"#{attr}"
     define_method(attr) { self[attr] }

--- a/lib/fpm/source/rpm.rb
+++ b/lib/fpm/source/rpm.rb
@@ -7,7 +7,7 @@ class FPM::Source::RPM < FPM::Source
     self[:version] = %x{rpm -q --qf '%{version}' -p #{@paths.first}}
     self[:iteration] = %x{rpm -q --qf '%{release}' -p #{@paths.first}}
     self[:summary] = %x{rpm -q --qf '%{summary}' -p #{@paths.first}}
-    #self[:description] = %x{rpm -q --qf '%{description}' -p #{@paths.first}}
+    self[:description] = %x{rpm -q --qf '%{description}' -p #{@paths.first}}
     self[:dependencies] = %x{rpm -qRp #{@paths.first}}.split("\n")\
       .collect { |line| line.strip }
 

--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -37,5 +37,6 @@ Standards-Version: 3.9.1
 Section: <%= category or "unknown" %> 
 Priority: extra
 Homepage: <%= url or "http://nourlgiven.example.com/" %>
-Description: <%= description or "no description given" %>
+Description: <%= summary or "no summary given" %>
+<%= description or "no description given" %>
 

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -4,7 +4,7 @@ Version: <%= version %>
 Epoch: <%= epoch %>
 <% end %>
 Release: <%= iteration or 1 %>
-Summary: <%= description %>
+Summary: <%= summary %>
 BuildArch: <%= architecture %>
 AutoReqProv: no
 


### PR DESCRIPTION
RPM summaries must be no longer than one line, therefore using the description field for the summary tag in rpm spec files is problematic.

There are a number of ways this could be fixed. I decided to bring back the summary field so that both can be used in spec and control files.
