### PR TITLE
Added functionality to build RPMS of jruby

### DIFF
--- a/examples/jruby/Makefile
+++ b/examples/jruby/Makefile
@@ -1,5 +1,5 @@
 NAME=jruby
-VERSION=1.6.0.RC2
+VERSION=1.6.1
 DOWNLOAD=http://jruby.org.s3.amazonaws.com/downloads/$(VERSION)/$(TARBALL)
 TARBALL=$(NAME)-bin-$(VERSION).tar.gz
 TARDIR=$(NAME)-$(VERSION)
@@ -7,13 +7,15 @@ TARDIR=$(NAME)-$(VERSION)
 PREFIX=/opt/jruby
 
 .PHONY: default
-default: package
+default: deb
+package: deb
 
 .PHONY: clean
 clean:
 	rm -f $(NAME)-* $(NAME)_* || true
 	rm -fr $(TARDIR) || true
 	rm -f *.deb
+        rm -f *.rpm
 
 $(TARBALL):
 	wget "$(DOWNLOAD)"
@@ -21,7 +23,13 @@ $(TARBALL):
 $(TARDIR): $(TARBALL)
 	tar -zxf $(TARBALL)
 
-.PHONY: package
-package: $(TARDIR)
+.PHONY: deb
+deb: $(TARDIR)
 	fpm -s dir -t deb -v $(VERSION) -n $(NAME) -d "sun-java6-bin (>> 0)" \
 		-a all -d "sun-java6-jre (>> 0)" --prefix $(PREFIX) -C $(TARDIR) .
+
+.PHONY: rpm
+rpm: $(TARDIR)
+	fpm -s dir -t rpm -v $(VERSION) -n $(NAME) -d "jdk >= 1.6.0" \
+		-a all --prefix $(PREFIX) -C $(TARDIR) .
+


### PR DESCRIPTION
Left deb as default but now you can 'make rpm' if that's your kink.
Wurks gud, (though your jdk dependency may vary):

[eric@leterel ~/fpm/jruby]$ rpm -q --requires -p jruby-1.6.1.noarch.rpm
jdk >= 1.6.0
rpmlib(PayloadFilesHavePrefix) <= 4.0-1
rpmlib(CompressedFileNames) <= 3.0.4-1
[eric@leterel ~/fpm/jruby]$ sudo rpm -Uvh ./jruby-1.6.1.noarch.rpm
Preparing...                ########################################### [100%]
   1:jruby                  ########################################### [100%]
[eric@leterel ~/fpm/jruby]$ /opt/jruby/bin/jruby -e 'puts "hello world"'
hello world
