### PR TITLE
Fix inconsistent RubyGems behaviour when using --binpath option

### DIFF
--- a/lib/fpm/source/gem.rb
+++ b/lib/fpm/source/gem.rb
@@ -120,8 +120,10 @@ class FPM::Source::Gem < FPM::Source
     args = ["gem", "install", "--quiet", "--no-ri", "--no-rdoc",
        "--install-dir", installdir, "--ignore-dependencies"]
     if self[:settings][:bin_path]
-      args += ["--bindir", File.join(tmpdir, self[:settings][:bin_path])]
+      tmp_bin_path = File.join(tmpdir, self[:settings][:bin_path])
+      args += ["--bindir", tmp_bin_path]
       @paths << self[:settings][:bin_path]
+      FileUtils.mkdir_p(tmp_bin_path) # Fixes #27
     end
 
     args << gem


### PR DESCRIPTION
Educated guess: in certain versions, RubyGems doesn't recursively create the directory specified by --binpath. 

1.3.7 certainly doesn't, but I haven't tested on anything newer. 
