### PR TITLE
whitespace/LF fix for debian template

### DIFF
--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -20,8 +20,7 @@ Homepage: <%= url or "http://nourlgiven.example.com/" %>
 Description: <%= name %> (FPM-generated package)
 <% max_len = 74 -%>
 <% if description -%>
-<%= description.gsub(/^$/, ".").gsub(/(.{1,#{max_len}})( +|$)\n?|(.{#{max_len}})/,"  \\1\\3\n") %>
+<%= description.gsub(/^$/, ".").gsub(/(.{1,#{max_len}})( +|$)\n?|(.{#{max_len}})/,"  \\1\\3\n") -%>
 <% else -%>
 <%= "no description given" %>
 <% end -%>
-


### PR DESCRIPTION
Hi,
 I've fixed the debian template file - there were some stray line feeds in there that would cause a Packages file to become corrupt.

remove bogus whitespace from debian template - it'll break a debian Packages file if it ends up in there.

cheers,
 Andrew.
