### PR TITLE
Return complete list of MD5 sums from checksum

### DIFF
--- a/lib/fpm/builder.rb
+++ b/lib/fpm/builder.rb
@@ -201,10 +201,9 @@ class FPM::Builder
 
   private
   def checksum(paths)
-    md5sums = []
-    paths.each do |path|
+    paths.collect do |path|
       next if !File.exists?(path)
-      md5sums += %x{find #{path} -type f -print0 | xargs -0 md5sum}.split("\n")
-    end
+      %x{find #{path} -type f -printf %P\\\\0 | xargs -0 md5sum}.split("\n")
+    end.flatten
   end # def checksum
 end


### PR DESCRIPTION
Before this patch, the method almost correctly computed the list of MD5 sums but returned the result of calling paths.each, not the md5sums list.  Now paths.collect.flatten is the return value.

The find(1) call was changed slightly to use the %P formatter so the output lines look like this:

```
0123456789abcdef0123456789abcdef path/to/file
```

Instead of this:

```
0123456789abcdef0123456789abcdef ./path/to/file
```

The difference is cosmetic but looks like everyone else's packages.
