### PR TITLE
fpm fails weirdly if python-setuptools isn't installed under Debian

### DIFF
--- a/lib/fpm/source/python.rb
+++ b/lib/fpm/source/python.rb
@@ -47,7 +47,11 @@ class FPM::Source::Python < FPM::Source
       want_pkg = "#{package}==#{version}"
     end
 
-    system(self[:settings][:easy_install], "--editable", "--build-directory", @tmpdir, want_pkg)
+    return_value = system(self[:settings][:easy_install], "--editable", "--build-directory", @tmpdir, want_pkg)
+
+    if return_value.nil?
+        raise "The execution of #{self[:settings][:easy_install]} failed"
+    end
 
     # easy_install will put stuff in @tmpdir/packagename/, flatten that.
     #  That is, we want @tmpdir/setup.py, and start with


### PR DESCRIPTION
It currently fails like this:

➜  ~  /var/lib/gems/1.8/gems/fpm-0.3.6/bin/fpm -s python -t deb pypeg  
Trying to download pypeg (using: easy_install)
/var/lib/gems/1.8/gems/fpm-0.3.6/bin/../lib/fpm/source/python.rb:57:in `download': Unexpected directory layout after easy_install. Maybe file a bug? The directory is /home/pierre/python-build20110708-19782-8i0xrp (RuntimeError)
    from /var/lib/gems/1.8/gems/fpm-0.3.6/bin/../lib/fpm/source/python.rb:34:in`get_source'
    from /var/lib/gems/1.8/gems/fpm-0.3.6/bin/../lib/fpm/source.rb:38:in `initialize'
[...]

My trivial patch should improve this.
## 

Pierre
