### PR TITLE
Add deb Pre-Depends support

### DIFF
--- a/lib/fpm/target/deb.rb
+++ b/lib/fpm/target/deb.rb
@@ -12,6 +12,10 @@ class FPM::Target::Deb < FPM::Package
             "For = dependencies, allow iterations on the specified version.  Default is to be specific.") do |x|
       settings.target[:ignore_iteration] = true
     end
+
+    opts.on("--pre-depends DEPENDENCY", "Add DEPENDENCY as Pre-Depends.") do |dep|
+      (settings.target[:pre_depends] ||= []) << dep
+    end
   end
 
   def needs_md5sums
@@ -149,4 +153,8 @@ class FPM::Target::Deb < FPM::Package
       return dep
     end
   end # def fix_dependency
+
+  def pre_dependencies
+    self.settings[:pre_depends] || []
+  end # def pre_dependencies
 end # class FPM::Target::Deb

--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -6,6 +6,10 @@ Maintainer: <%= maintainer or "<unknown>" %>
 <%   properdeps = dependencies.collect { |d| fix_dependency(d) }.flatten -%>
 Depends: <%= properdeps.flatten.join(", ") %>
 <% end -%>
+<% if !pre_dependencies.empty? -%>
+<%   properpredeps = pre_dependencies.collect { |d| fix_dependency(d) }.flatten -%>
+Pre-Depends: <%= properpredeps.flatten.join(", ") %>
+<% end -%>
 <% if !conflicts.empty? -%>
 Conflicts: <%= conflicts.join(", ") %>
 <% end -%>


### PR DESCRIPTION
This commit adds Pre-Depends support for Debian packages.

See the following link for details on Pre-Depends.

http://www.debian.org/doc/debian-policy/ch-relationships.html
