### PR TITLE
Fix Issue 82 (empty url tag)

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -15,7 +15,12 @@ TODO: [Jay] rpms require a license
 let's detect it intelligently
 -%>
 License: <%= license %>
-URL: <%= url or "http://nourlgiven.example.com/" %>
+<% if url and url.length > 0 -%>
+<% actualurl = url -%>
+<% else -%>
+<% actualurl = "http://nourlgiven.example.com/" -%>
+<% end -%>
+URL: <%= actualurl %>
 Source0:  %{_sourcedir}/data.tar.gz
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 


### PR DESCRIPTION
rpmspecs to not like empty tags, so check if the url tag is empty.

If so, then provide the same output as a nil url.

Issue: 82

Hopefully my ruby is not too horrible.
