### PR TITLE
Use -E in gem install command 

### DIFF
--- a/lib/fpm/source/gem.rb
+++ b/lib/fpm/source/gem.rb
@@ -118,7 +118,7 @@ class FPM::Source::Gem < FPM::Source
 
     ::FileUtils.mkdir_p(installdir)
     args = ["gem", "install", "--quiet", "--no-ri", "--no-rdoc",
-       "--install-dir", installdir, "--ignore-dependencies"]
+       "--install-dir", installdir, "--ignore-dependencies", "-E"]
     if self[:settings][:bin_path]
       tmp_bin_path = File.join(tmpdir, self[:settings][:bin_path])
       args += ["--bindir", tmp_bin_path]


### PR DESCRIPTION
 -E, --[no-]env-shebang           Rewrite the shebang line on installed  scripts to use /usr/bin/env

This would make the created deb less platform/computer specific. There might be reasons to make this an option on the fpm level, but I can't think of one.
