### PR TITLE
Replace dashes in python version strings

### DIFF
--- a/lib/fpm/source/python.rb
+++ b/lib/fpm/source/python.rb
@@ -99,7 +99,7 @@ class FPM::Source::Python < FPM::Source
     self[:architecture] = metadata["architecture"]
     self[:description] = metadata["description"]
     self[:license] = metadata["license"]
-    self[:version] = metadata["version"]
+    self[:version] = metadata["version"].gsub(/-/, "_")
     self[:name] = "#{self[:package_prefix]}#{self[:suffix]}-#{metadata["name"]}"
     self[:url] = metadata["url"]
 


### PR DESCRIPTION
Dashes are not allowed in RPM version strings, so any version string
needs to have them replaced with something more safe.

This may be needed in other source types, but I just did python for now.
