### PR TITLE
Remove dashes from the version in rpm targets

### DIFF
--- a/lib/fpm/target/rpm.rb
+++ b/lib/fpm/target/rpm.rb
@@ -28,6 +28,16 @@ class FPM::Target::Rpm < FPM::Package
     end
   end
 
+  def version
+    if @version.kind_of?(String) and @version.include?("-")
+      @logger.info("Package version '#{@version}' includes dashes, converting" \
+                   " to underscores")
+      @version = @version.gsub(/-/, "_")
+    end
+
+    return @version
+  end
+
   def build!(params)
     raise "No package name given. Can't assemble package" if !@name
     # TODO(sissel): Abort if 'rpmbuild' tool not found.


### PR DESCRIPTION
RPMs do not allow dashes in the main part of the version string.

I ripped this code right out of the Deb target file, and it seems to work.

This has been tested with `-t rpm` (of course) in conjunction with `-s gem` and `-s python`.
