### PR TITLE
Restore support for multiple specified paths in the Dir source.

### DIFF
--- a/lib/fpm/source/dir.rb
+++ b/lib/fpm/source/dir.rb
@@ -51,7 +51,7 @@ class FPM::Source::Dir < FPM::Source
       end
     else
       # Prefix everything with "./" as per the Debian way if needed ...
-      path = paths[0].match(/^(\.\/|\.)/) ? paths[0] : "./%s" % paths[0]
+      path = paths.map { |p| p.match(/^(\.\/|\.)/) ? p : "./%s" % p }
       tar(tar_path, path)
     end
 


### PR DESCRIPTION
I'm using fpm like this, to package up various directories from a subdirectory, pkg:

fpm -s dir \
    -t rpm \
    -n mypkg \
    -v 1.0 \
    -C pkg \
    dir1 dir2 dir3

This worked in 0.3.7, but in 0.3.8 only the first directory would be included in data.tar.gz. rpmbuild complained about this, since it had been given all the directories in the spec file. 

The culprit appears to be the prefixing of paths with "./" added in 0.3.8, like this:

lib/fpm/source/dir.rb:
      path = paths[0].match(/^(.\/|.)/) ? paths[0] : "./%s" % paths[0]

where only the first path is used.

The attached commit changes this to prefix all paths given. 

Thanks!
