### PR TITLE
pass -U to easy_install to always fetch package

### DIFF
--- a/lib/fpm/source/python.rb
+++ b/lib/fpm/source/python.rb
@@ -60,7 +60,7 @@ class FPM::Source::Python < FPM::Source
     end
 
     safesystem(self[:settings][:easy_install], "-i", self[:settings][:pypi],
-               "--editable", "--build-directory", @tmpdir, want_pkg)
+               "--editable", "-U", "--build-directory", @tmpdir, want_pkg)
 
     # easy_install will put stuff in @tmpdir/packagename/, flatten that.
     #  That is, we want @tmpdir/setup.py, and start with


### PR DESCRIPTION
When calling easy_install with a build directory
on a machine/environment where the target package is
already available, include -U to force the package
to be redownloaded.

Otherwise, easy_install does nothing and fpm errors
out with:
Unexpected directory layout after easy_install
