### PR TITLE
md5sum errors when files in the package have spaces in their name

### DIFF
--- a/lib/fpm/builder.rb
+++ b/lib/fpm/builder.rb
@@ -211,7 +211,7 @@ class FPM::Builder
           "%s  %s" % [i[0], i[1].sub(/#{path}\//, '').sub(/\.\//, '')]
         end
       elsif File.exists? path
-        %x{md5sum #{path}}
+        %x{md5sum "#{path}"}
       else
         next
       end


### PR DESCRIPTION
md5sum `lib/fpm/builder.rb:214` is passed unquoted strings so it chokes on them giving output like:

```
md5sum: /opt/lib/ruby/gems/1.9.1/gems/passenger-3.0.9/doc/Users: No such file or directory
md5sum: guide: No such file or directory
md5sum: Apache: No such file or directory
md5sum: with: No such file or directory
md5sum: comments.html: No such file or directory
```

This changes simply (dumbly) sticks double-quotes around the input to md5sum.
