### PR TITLE
Add support for --iteration to rpm output.

### DIFF
--- a/lib/fpm/program.rb
+++ b/lib/fpm/program.rb
@@ -153,7 +153,7 @@ class FPM::Program
     end # --version
 
     opts.on("--iteration ITERATION",
-            "(optional) Set the iteration value for this package.") do |iteration|
+            "(optional) Set the iteration value for this package ('release' for RPM).") do |iteration|
       @settings.iteration = iteration
     end # --iteration
 

--- a/lib/fpm/target/rpm.rb
+++ b/lib/fpm/target/rpm.rb
@@ -28,6 +28,14 @@ class FPM::Target::Rpm < FPM::Package
     end
   end
 
+  def iteration
+    if @iteration.nil? || @iteration.empty?
+      '1'
+    else
+      @iteration
+    end
+  end
+
   def version
     if @version.kind_of?(String) and @version.include?("-")
       @logger.info("Package version '#{@version}' includes dashes, converting" \


### PR DESCRIPTION
The rpm equivalent of iteration is 'release', and it defaults to 1
unless overriden by the user.

 -- Not sure if this patch covers everything that needs to be done, but it Worked For Me[tm].
