### PR TITLE
Allow --inputs to actually work.

### DIFF
--- a/lib/fpm/program.rb
+++ b/lib/fpm/program.rb
@@ -18,7 +18,6 @@ class FPM::Program
     @settings.source = {}   # source settings
     @settings.target = {}   # target settings
     @settings.config_files ||= []
-    @settings.inputs_path = nil # file path to read a list of paths from
     @settings.paths = [] # Paths to include in the package
 
     # Maintainer scripts - https://github.com/jordansissel/fpm/issues/18
@@ -63,13 +62,13 @@ class FPM::Program
     read_from_stdin = args.length == 1 && args.first == '-'
 
     ok = true
-    if @settings.inputs_path 
+    if @settings.source[:inputs]
       if read_from_stdin
         $stderr.puts "Error: setting --inputs conflicts with passing '-' as the only argument"
         ok = false
       end
-      unless File.file?(@settings.inputs_path)
-        $stderr.puts "Error: '#{@settings.inputs_path}' does not exist"
+      unless File.file?(@settings.source[:inputs])
+        $stderr.puts "Error: '#{@settings.source[:inputs]}' does not exist"
         ok = false
       end
     end
@@ -79,8 +78,8 @@ class FPM::Program
     if read_from_stdin
       paths_iolike = $stdin
     end
-    if @settings.inputs_path
-      paths_iolike = File.open(@settings.inputs_path, 'r')
+    if @settings.source[:inputs]
+      paths_iolike = File.open(@settings.source[:inputs], 'r')
     end
 
     paths = []


### PR DESCRIPTION
Obviously this can go one of two ways:
1. Get rid of the extra variable and use the source hash (which I've done)
2. Forget about the :inputs pair in the source hash and use the extra variable inputs_path.

It seems to me that perhaps there is reason to allow the individual targets access to the file path inputs (if not now, maybe in the future) so I've chosen the first option.

I've tested and it actually works at least, with one caveat. All files in the file path need to have their leading / stripped (which is contrary to the %files section in an RPM spec file, but the same as the .install file in a DEB). Perhaps to be more universal, fpm should strip the leading / out automatically but I'll leave that for your discussion and a later pull request ;)
