### PR TITLE
Allow specifying BASEDIR for Solaris packages

### DIFF
--- a/lib/fpm/builder.rb
+++ b/lib/fpm/builder.rb
@@ -46,6 +46,7 @@ class FPM::Builder
       :suffix => settings.suffix,
       :exclude => settings.exclude,
       :maintainer => settings.maintainer,
+      :basedir => settings.basedir,
       :provides => [],
       :replaces => [],
       :conflicts => [],

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -66,6 +66,9 @@ class FPM::Package
   # Array of configuration files
   attr_accessor :config_files
 
+  # solaris basedir
+  attr_accessor :basedir
+
 	# target-specific settings
 	attr_accessor :settings
 
@@ -118,6 +121,7 @@ class FPM::Package
     @conflicts = source[:conflicts] || []
     @scripts = source[:scripts]
     @config_files = source[:config_files] || []
+    @basedir = source[:basedir] || "/usr/local"
 
     # Target-specific settings, mirrors :settings metadata in FPM::Source
     @settings = params[:settings] || {}

--- a/lib/fpm/program.rb
+++ b/lib/fpm/program.rb
@@ -20,6 +20,7 @@ class FPM::Program
     @settings.config_files ||= []
     @settings.inputs_path = nil # file path to read a list of paths from
     @settings.paths = [] # Paths to include in the package
+    @settings.basedir = nil # basedir for Solaris packages
 
     # Maintainer scripts - https://github.com/jordansissel/fpm/issues/18
     @settings.scripts ||= {}
@@ -215,6 +216,10 @@ class FPM::Program
             "A path to prefix files with when building the target package. This may not be necessary for all source types. For example, the 'gem' type will prefix with your gem directory (gem env | grep -A1 PATHS:)") do |prefix|
       @settings.prefix = prefix
     end # --prefix
+
+    opts.on("-b BASEDIR", "--basedir BASEDIR", "the basedir to use for Solaris packages") do |basedir|
+      @settings.basedir = basedir
+    end
 
     opts.on("-e", "--edit", "Edit the specfile before building") do
       @settings.edit = true

--- a/templates/solaris.erb
+++ b/templates/solaris.erb
@@ -1,5 +1,5 @@
 CLASSES=none
-BASEDIR=/usr/local
+BASEDIR=<%= basedir %>
 TZ=PST
 PATH=/sbin:/usr/sbin:/usr/bin:/usr/sadm/install/bin
 PKG=<%= name %>


### PR DESCRIPTION
This provides the --basedir option, which allows specifying the BASEDIR parameter for Solaris packages.
