### PR TITLE
prevent rpmbuild from repacking jar files

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -1,3 +1,5 @@
+%define __jar_repack 0
+
 Name: <%= name %>
 Version: <%= version %>
 <% if epoch -%>


### PR DESCRIPTION
brp-java-repack-jars can have issues repacking jar files when the filenames are too long so stop repacking the jar files.

http://osdir.com/ml/linux.redhat.fedora.java/2008-09/msg00040.html explains the rationale behind repacking jars.

http://code.google.com/p/cassandra-rpm/source/browse/trunk/files/install/share/casandra.spec is an example of the %define __jar_repack 0.

This has been tested on rhel6.1 
