### PR TITLE
Allow RPM generation to specify configuration files.

### DIFF
--- a/lib/fpm/target/rpm.rb
+++ b/lib/fpm/target/rpm.rb
@@ -26,9 +26,17 @@ class FPM::Target::Rpm < FPM::Package
     # find all files in paths given.
     paths = []
     @source.paths.each do |path|
-      # files can only be listed once in the spec
-      Find.find(path) { |p| paths << p unless @config_files.include?(p) }
+      Find.find(path) { |p| paths << p }
     end
+
+    # Ensure all paths are absolute and don't start with '.'
+    paths.collect! { |p| p.gsub(/^\.\//, "/").gsub(/^[^\/]/, "/\\0") }
+    @config_files.collect! { |c| c.gsub(/^\.\//, "/").gsub(/^[^\/]/, "/\\0") }
+
+    # Remove config files from the main path list, as files cannot be listed
+    # twice (rpmbuild complains).
+    paths -= @config_files
+
     #@logger.info(:paths => paths.sort)
     template.result(binding)
   end # def render_spec

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -94,9 +94,8 @@ rm -rf $RPM_BUILD_ROOT
 <% end -%>
 %files
 %defattr(-,root,root,-)
-<%# Trim leading '.' from paths if they are './blah...' -%>
-<%# Also ensure paths start with '/' -%>
-<%= @config_files.collect { |c| '%config ' + c.gsub(/^\.\//, "/").gsub(/^[^\/]/, "/\\0") }.join("\n") %>
-<%= @source.paths.collect { |p| p.gsub(/^\.\//, "/").gsub(/^[^\/]/, "/\\0") }.join("\n") %>
+<%# Output config files and then regular files. -%>
+<%= @config_files.collect { |c| '%config ' + c }.join("\n") %>
+<%= paths.join("\n") %>
 
 %changelog


### PR DESCRIPTION
Right now --config-files is ignored for the rpm target, so this patch pulls each referenced file into the %files section prefaced by %config. If it was already listed in the sources path array it will be removed from there as files cannot be listed twice in the spec (at least without rpmbuild complaining bitterly).

As a general principle I think there should be tests for this but the current framework is a bit hard to manage. It should be possible to test the template outputs with given inputs pretty easily if Test::Unit or Rspec were in place but I'm hesistant to make that part of this patch. If desired I'll submit another pull request with support for either framework added.
