### PR TITLE
enable setting BASEDIR for Solaris packages, via --prefix

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -66,6 +66,9 @@ class FPM::Package
   # Array of configuration files
   attr_accessor :config_files
 
+  # Package path prefix
+  attr_accessor :prefix
+
 	# target-specific settings
 	attr_accessor :settings
 
@@ -118,6 +121,7 @@ class FPM::Package
     @conflicts = source[:conflicts] || []
     @scripts = source[:scripts]
     @config_files = source[:config_files] || []
+    @prefix = source[:prefix] || "/"
 
     # Target-specific settings, mirrors :settings metadata in FPM::Source
     @settings = params[:settings] || {}

--- a/lib/fpm/target/solaris.rb
+++ b/lib/fpm/target/solaris.rb
@@ -59,7 +59,8 @@ class FPM::Target::Solaris < FPM::Package
       prototype.puts("i postinstall") if self.scripts["post-install"]
 
       # TODO(sissel): preinstall/postinstall
-      IO.popen("pkgproto data=/").each_line do |line|
+      # strip @prefix, since BASEDIR will set prefix via the pkginfo file
+      IO.popen("pkgproto data/#{@prefix}=").each_line do |line|
         type, klass, path, mode, user, group = line.split
         # Override stuff in pkgproto
         # TODO(sissel): Make this tunable?

--- a/templates/solaris.erb
+++ b/templates/solaris.erb
@@ -1,5 +1,5 @@
 CLASSES=none
-BASEDIR=/usr/local
+BASEDIR=<%= prefix %>
 TZ=PST
 PATH=/sbin:/usr/sbin:/usr/bin:/usr/sadm/install/bin
 PKG=<%= name %>


### PR DESCRIPTION
As discussed in #124, this implements BASEDIR using --prefix.  Same feature was originally requested in #55.
