### PR TITLE
Add new option to pass --define arguments to rpmbuild.

### DIFF
--- a/lib/fpm/program.rb
+++ b/lib/fpm/program.rb
@@ -99,6 +99,7 @@ class FPM::Program
     FPM::Source::Python.flags(FPM::Flags.new(opts, "python", "python source only"),
                               @settings)
     FPM::Target::Deb.flags(FPM::Flags.new(opts, "deb", "deb target only"), @settings)
+    FPM::Target::Rpm.flags(FPM::Flags.new(opts, "rpm", "rpm target only"), @settings)
 
     # Process fpmrc first
     fpmrc(opts)


### PR DESCRIPTION
Hey,

This lets me pass defines to rpmbuild like so:

<pre>fpm --category 'System/Administration' -n kiwi-puppet -v 1.5 --url 'http://kiwiup.com' -d puppet -a noarch -m 'Naresh V. <nvenkateshappa@kiwiup.com>'  -t rpm -s dir --prefix /etc --exclude .git  puppet --rpm-rpmbuild-define '_source_filedigest_algorithm md5' --rpm-rpmbuild-define '_binary_filedigest_algorithm md5'</pre>
