### PR TITLE
Still working on python/deb packages

### DIFF
--- a/lib/fpm/source/python.rb
+++ b/lib/fpm/source/python.rb
@@ -102,7 +102,11 @@ class FPM::Source::Python < FPM::Source
     self[:version] = metadata["version"]
     self[:url] = metadata["url"]
 
-    # sanitize name
+    # Sanitize package name.
+    # Some PyPI packages can be named 'python-foo', so we don't want to end up
+    # with a package named 'python-python-foo'.
+    # But we want packages named like 'pythonweb' to be suffixed
+    # 'python-pythonweb'.
     if metadata["name"].start_with? "#{self[:package_prefix]}-"
       self[:name] = metadata["name"]
     else


### PR DESCRIPTION
Here are some other modifications:
- avoid strange dependencies name like "pythonweb" (on PyPI) to be renamed "python-web" (instead of normally python-pythonweb")
- sanitize deb python package output to follow the same principle as before (python-dateutil -> python-dateutil instead of python-python-dateutil)

Tell me what you think of this ! :)
