### PR TITLE
Fix #153: Maintainer is not used when building rpm targets

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -18,6 +18,9 @@ let's detect it intelligently
 -%>
 License: <%= license %>
 URL: <%= url or "http://nourlgiven.example.com/" %>
+<% if !maintainer.empty? -%>
+Packager: <%= maintainer %>
+<% end -%>
 Source0:  %{_sourcedir}/data.tar.gz
 BuildRoot: %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 


### PR DESCRIPTION
This patch adds the "Packager" to the RPM spec file. By default, this is `user@hostname` or it's specified using `-m` on the command line.
