### PR TITLE
`--prefix` and `-s dir` don't work well together.

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -145,12 +145,14 @@ class FPM::Package
   end # def template
 
   def render_spec
-    # find all files in paths given.
-    paths = []
-    @source.paths.each do |path|
-      Find.find(path) { |p| paths << p }
+    if @settings[:deb] != "deb"
+      # find all files in paths given.
+      paths = []
+      @source.paths.each do |path|
+        Find.find(path) { |p| paths << p }
+      end
+      #@logger.info(:paths => paths.sort)
     end
-    #@logger.info(:paths => paths.sort)
     template.result(binding)
   end # def render_spec
 


### PR DESCRIPTION
If you use `--prefix` and `-s dir`, the directory you specify (prefixed with the path you sent to `--prefix`) currently needs to exist in order to build spec files for non-deb targets.

I don't know if the paths **actually** need to exist in order to build those spec files, but I know that the `deb` target doesn't need them, so this patch works around that.
