### PR TITLE
Provide the installed size (for Debian packages)

### DIFF
--- a/lib/fpm/builder.rb
+++ b/lib/fpm/builder.rb
@@ -112,7 +112,9 @@ class FPM::Builder
           end
         end
       end
-
+      if @package.needs_installed_size
+        @package.installed_size = @package.settings[:installed_size] || get_installed_size
+      end
       generate_md5sums if @package.needs_md5sums
       generate_specfile
       edit_specfile if @edit
@@ -219,4 +221,12 @@ class FPM::Builder
       end
     end.flatten
   end # def checksum
+
+  private
+  def get_installed_size
+    @source.paths.inject(0) do |total, path|
+      next unless File.exists? path
+      total + %x{ du -sb -- #{path} | cut -f1 }.to_i
+    end
+  end #def get_installed_size
 end

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -136,6 +136,11 @@ class FPM::Package
     false
   end # def needs_md5sums
 
+  # nobody needs installed_size by default.
+  def needs_installed_size
+    false
+  end # def needs_installed_size
+
   # TODO [Jay]: make this better...?
   def type
     self.class.name.split(':').last.downcase

--- a/lib/fpm/target/deb.rb
+++ b/lib/fpm/target/deb.rb
@@ -5,6 +5,8 @@ require "fpm/errors"
 require "fpm/util"
 
 class FPM::Target::Deb < FPM::Package
+  # Installed size
+  attr_accessor :installed_size
 
   # Supported Debian control files
   CONTROL_FILES = {
@@ -45,6 +47,11 @@ class FPM::Target::Deb < FPM::Package
             "Add FILEPATH as debconf templates file.") do |templates|
       settings.scripts["debconf-templates"] = File.expand_path(templates)
     end
+
+    opts.on("--installed-size BYTES",
+            "The installed size, in bytes") do |installed_size_s|
+      settings.target[:installed_size] = installed_size_s.to_i
+    end # --installed-size
   end
 
   def needs_md5sums
@@ -55,6 +62,10 @@ class FPM::Target::Deb < FPM::Package
       return true
     end
   end # def needs_md5sums
+
+  def needs_installed_size
+    true
+  end
 
   def architecture
     if @architecture.nil? or @architecture == "native"

--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -23,6 +23,7 @@ Provides: <%= provides.join(", ") %>
 Replaces: <%= properrepl.flatten.join(", ") %>
 <% end -%>
 Standards-Version: 3.9.1
+Installed-Size: <%= installed_size %>
 Section: <%= category or "unknown" %>
 Priority: extra
 Homepage: <%= url or "http://nourlgiven.example.com/" %>


### PR DESCRIPTION
The Ubuntu Software Center complains that there's no Installed-Size field in the control file, that the package is insecure, blah blah.

So, provide the installed size.
