### PR TITLE
Standards-Version is not a valid control field for binary Debian package...

### DIFF
--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -22,7 +22,6 @@ Provides: <%= provides.join(", ") %>
 <%   properrepl = replaces.collect { |d| fix_dependency(d) }.flatten -%>
 Replaces: <%= properrepl.flatten.join(", ") %>
 <% end -%>
-Standards-Version: 3.9.1
 Installed-Size: <%= installed_size %>
 Section: <%= category or "unknown" %>
 Priority: extra


### PR DESCRIPTION
See http://www.debian.org/doc/debian-policy/ch-controlfields.html
