### PR TITLE
fix issues when packaging links in dir package and rpm template

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -91,16 +91,17 @@ class FPM::Package::Dir < FPM::Package
     end
 
     # Create a directory if this path is a directory
-    if File.directory?(source)
+    if File.directory?(source) and !File.symlink?(source)
       @logger.debug("Creating", :directory => destination)
       FileUtils.mkdir(destination)
     else
       # Otherwise try copying the file.
-      @logger.debug("Copying", :source => source, :destination => destination)
       begin
+        @logger.debug("Linking", :source => source, :destination => destination)
         File.link(source, destination)
       rescue Errno::EXDEV
         # Hardlink attempt failed, copy it instead
+        @logger.debug("Copying", :source => source, :destination => destination)
         FileUtils.copy(source, destination)
       end
     end

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -56,8 +56,8 @@ Obsoletes: <%= repl %>
 <%   target = File.join(build_path, "BUILD", path) -%>
 <%   dir = File.dirname(target) %>
 mkdir -p "<%= dir %>"
-if [ -f "<%= source %>" ] ; then
-  cp "<%= source %>" "<%= target %>"
+if [ -f "<%= source %>" ] || [ -h "<%= source %>" ] ; then
+  cp -d "<%= source %>" "<%= target %>"
 elif [ -d "<%= source %>" ] ; then
   mkdir "<%= target %>"
 fi
@@ -96,7 +96,7 @@ fi
 <%= 
   # Reject directories or config files already listed, then prefix files with
   # "/", then make sure paths with spaces are quoted. I hate rpm so much.
-  files.reject { |f| File.directory?(File.join(staging_path, f)) } \
+  files.reject { |f| x = File.join(staging_path, f); File.directory?(x) && !File.symlink?(x) } \
     .collect { |f| "/#{f}" } \
     .reject { |f| config_files.include?(f) } \
     .collect { |f| f[/\s/] and "\"#{f}\"" or f } \


### PR DESCRIPTION
- lib/fpm/package/dir.rb: File.directory? returns true if source is a
  link to a directory. This is not the desired behavior, a link should
  be kept as a link, whether it is a link for a file or a directory.
- templates/rpm.erb: check whether we are copying a link, if so, only
  copy the link not a new file. For the same reason as lib/fpm/package/dir.rb,
  links to directories were rejected. So, do not reject links to directories.
