### PR TITLE
swap key/value when doing the replacement of deprecated conditional operators

### DIFF
--- a/lib/fpm/package/pyfpm/get_metadata.py
+++ b/lib/fpm/package/pyfpm/get_metadata.py
@@ -100,6 +100,6 @@ class get_metadata(Command):
 
   def _replace_deprecated(self, sign):
     """Replace deprecated operators"""
-    return {'<': '<<', '>': '>>'}.get(sign, sign)
+    return {'<<': '<', '>>': '>'}.get(sign, sign)
 
 # class list_dependencies


### PR DESCRIPTION
the current replacement replaces > and < with >> and << respectively.

> bin/fpm -s python -t rpm RhodeCode
> results in the following error:
>   error: line 38: Dependency tokens must begin with alpha-numeric, '_' or '/': Requires: python-whoosh << 2.4

swapping the keys/values allows me to package RhodeCode as an rpm.

I'm not sure what other package types this may break but it seems to work for rpms/rpmbuild on Centos6.0
