### PR TITLE
Always expand the path for the setup.py file

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -65,6 +65,7 @@ class FPM::Package::Python < FPM::Package
     else
       setup_py = path_to_package
     end
+    setup_py = File.expand_path(setup_py)
 
     if !File.exists?(setup_py)
       @logger.error("Could not find 'setup.py'", :path => setup_py)


### PR DESCRIPTION
As we chdir in the setup.py base directory, we need to be sure to have
an absolute path. If we have a relative path, after chdir in the base
dir, the command to get metadata will fail. And if we remove the chdir,
some setup.py file open "local" file (i.e README files). So, to be sure
that the command will run, after chdir, we need to use the absolute
path.

The bug can be reproduced when building a python package from a directory.
Download a package tarball from PyPI, extract the source, and in the same
directory, build using fpm:
wget http://...../celery-2.5.0.tar.gz
tar zxvf celery-2.5.0.tar.gz
fpm -s python -t deb celery-2.5.0

This was making fpm resolve the setup.py to "celery-2.5.0/setup.py", and then, chdir into celery-2.5.0 directory and running the command, which was looking for celery-2.5.0/setup.py, which fails.

If you have any comment ! :)
