### PR TITLE
Fix local variable error for --deb-pre-depends

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -25,7 +25,7 @@ class FPM::Package::Deb < FPM::Package
             "version of a package but any iteration is permitted"
 
   option "--pre-depends", "DEPENDENCY",
-    "Add DEPENDENCY as a Pre-Depends" do |val|
+    "Add DEPENDENCY as a Pre-Depends" do |dep|
     @pre_depends ||= []
     @pre_depends << dep
   end


### PR DESCRIPTION
The variable used for the block that parses `--deb-pre-depends` was `val` instead of `dep` causing it to error:

``` ruby
/usr/local/rvm/gems/ruby-1.9.3-p125/gems/fpm-0.4.3/lib/fpm/package/deb.rb:30:in `block in <class:Deb>': undefined local variable or method `dep' for #<FPM::Command:0x000000022ada30> (NameError)
    from /usr/local/rvm/gems/ruby-1.9.3-p125/gems/clamp-0.3.0/lib/clamp/attribute_declaration.rb:32:in `instance_exec'
    from /usr/local/rvm/gems/ruby-1.9.3-p125/gems/clamp-0.3.0/lib/clamp/attribute_declaration.rb:32:in `block in define_writer_for'
    from /usr/local/rvm/gems/ruby-1.9.3-p125/gems/clamp-0.3.0/lib/clamp/option/parsing.rb:27:in `parse_options'
    from /usr/local/rvm/gems/ruby-1.9.3-p125/gems/clamp-0.3.0/lib/clamp/command.rb:49:in `parse'
    from /usr/local/rvm/gems/ruby-1.9.3-p125/gems/clamp-0.3.0/lib/clamp/command.rb:63:in `run'
    from /usr/local/rvm/gems/ruby-1.9.3-p125/gems/clamp-0.3.0/lib/clamp/command.rb:126:in `run'
    from /usr/local/rvm/gems/ruby-1.9.3-p125/gems/fpm-0.4.3/bin/fpm:8:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-1.9.3-p125/bin/fpm:19:in `load'
    from /usr/local/rvm/gems/ruby-1.9.3-p125/bin/fpm:19:in `<main>'
```

This pull request just changes `val` to `dep`.
