### PR TITLE
Allow unsetting epoch and iteration by passing empty strings

### DIFF
--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -1,5 +1,5 @@
 Package: <%= name %>
-Version: <%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>
+Version: <%= "#{epoch}" if epoch and not epoch.empty? %><%= version %><%= "-" + iteration.to_s if iteration and not iteration.empty? %>
 License: <%= license %>
 Vendor: <%= vendor %>
 Architecture: <%= architecture %>


### PR DESCRIPTION
package.rb initializes epoch and iteration to nil, but the default
arguments for both are '1', which means the package version always
ends up with an epoch and an iteration. By changing the template
to take empty strings into account you can customize the version
string by passing --epoch '' and --iteration ''.
