### PR TITLE
Fixed gem ~> version operator translated to rpm require.

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -91,7 +91,7 @@ class FPM::Package::RPM < FPM::Package
         name, op, version = dep.split(/\s+/)
         if op == "~>"
           # ~> x.y means: > x.y and < (x+1).0
-          fixed_deps << "#{name} > #{version}"
+          fixed_deps << "#{name} >= #{version}"
           fixed_deps << "#{name} < #{version.to_i + 1}.0.0"
         else
           fixed_deps << dep


### PR DESCRIPTION
In gem specs ~> is a Pessimistic Version Consrtaint that is inclusive
on the bottom end. E.g., '~> 2.2' means '>= 2.2.0 and < 3.0'.

I changed the translation to RPM spec to be >= and <. It was > and <.

http://docs.rubygems.org/read/chapter/16
http://docs.fedoraproject.org/en-US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/ch-advanced-packaging.html
