### PR TITLE
Adding the noreplace option to config files in the rpm spec template. 

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -99,7 +99,7 @@ fi
 %defattr(-,root,root,-)
 <%# Output config files and then regular files. -%>
 <% config_files.each do |path| -%>
-%config <%= path %>
+%config(noreplace) <%= path %>
 <% end -%>
 <%# list only files, not directories? -%>
 <%= 


### PR DESCRIPTION
This prevents the rpm install/update from overwriting local modifications to config files.

Some background info:
http://www-uxsup.csx.cam.ac.uk/~jw35/docs/rpm_config.html
