### PR TITLE
Fixed python3 incopabilities.

### DIFF
--- a/lib/fpm/package/pyfpm/get_metadata.py
+++ b/lib/fpm/package/pyfpm/get_metadata.py
@@ -65,9 +65,9 @@ class get_metadata(Command):
 
     #print json.dumps(data, indent=2)
     try:
-      print json.dumps(data, indent=2)
-    except AttributeError, e:
+      print(json.dumps(data, indent=2))
+    except AttributeError as e:
       # For Python 2.5 and Debian's python-json
-      print json.write(data)
+      print(json.write(data))
   # def run
 # class list_dependencies

--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -183,7 +183,7 @@ class FPM::Package::Python < FPM::Package
       # Ask python where libraries are installed to.
       # This line is unusually long because I don't have a shorter way to express it.
       attributes[:python_install_lib] = %x{
-        #{attributes[:python_bin]} -c 'from distutils.sysconfig import get_python_lib; print get_python_lib()'
+        #{attributes[:python_bin]} -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib())'
       }.chomp
       @logger.info("Setting default :python_install_lib attribute",
                    :value => attributes[:python_install_lib])


### PR DESCRIPTION
modified:   lib/fpm/package/python.rb

Added python3 support. Useful for packaging python3 projects. For example:
fpm -s python -t deb --python-bin /usr/bin/python3 myproject/setup.py
