### PR TITLE
Fixed the path_prefix to prefix to allow overriding the gem path

### DIFF
--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -159,8 +159,8 @@ class FPM::Package::Gem < FPM::Package
   end # def load_package_info
 
   def install_to_staging(gem_path)
-    if attributes.include?(:path_prefix)
-      installdir = "#{staging_path}/#{attributes[:path_prefix]}"
+    if attributes.include?(:prefix) && ! attributes[:prefix].nil?
+      installdir = "#{staging_path}/#{attributes[:prefix]}"
     else
       installdir = File.join(staging_path, ::Gem::dir)
     end


### PR DESCRIPTION
Current situation:

```
$ fpm -s gem -t rpm fpm
$ rpm -qlp rubygem-fpm-0.4.8-1.noarch.rpm
/home/jan/.gem/ruby/1.8/bin/fpm
/home/jan/.gem/ruby/1.8/bin/fpm-npm
/home/jan/.gem/ruby/1.8/cache/fpm-0.4.8.gem
...
```

Without the patch, its impossible to use 

```
$ fpm --prefix /usr/lib/ruby/gems/1.8 ...
```

There is some code in there that references path_prefix but I couldn't find that anywhere in the rest of the code so I changed path_prefix to prefix and added a sanity check (if prefix is nil, dont use it)

After patch:

```
$ fpm -s gem -t rpm --prefix /usr/lib/ruby/gems/1.8 --gem-bin-path /usr/bin fpm
$ rpm -qlp rubygem-fpm-0.4.8-1.noarch.rpm
/usr/bin/fpm
/usr/bin/fpm-npm
/usr/lib/ruby/gems/1.8/cache/fpm-0.4.8.gem
...
```
