### PR TITLE
Introduced a dependency mapping for != dependency

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -262,12 +262,9 @@ class FPM::Package::Deb < FPM::Package
       nextversion = nextversion.join(".")
       return ["#{name} (>= #{version})", "#{name} (<< #{nextversion})"]
     elsif (m = dep.match(/(\S+)\s+\(!= (.+)\)/))
-      # Convert 'foo (!= x)' to 'foo (>= x+1)'
-      name, version = m[1..2]
-      nextversion = version.split('.').collect { |v| v.to_i }
-      nextversion[-1] += 1
-      nextversion = nextversion.join(".")
-      return ["#{name} (>= #{nextversion})"]
+      # Append this to conflicts
+      self.conflicts += [dep.gsub(/!=/,"=")]
+      return []
     elsif (m = dep.match(/(\S+)\s+\(= (.+)\)/)) and
         self.attributes[:deb_ignore_iteration_in_dependencies?]
       # Convert 'foo (= x)' to 'foo (>= x)' and 'foo (<< x+1)'


### PR DESCRIPTION
There exist gems in the wild that have a dependency !=
Example is sprocket gem (at least version 2.1.3). Use a mapping
that prevents dpkg to choke on != and appended it to the conflicts.
