### PR TITLE
Set install-data flag in python setup.py

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -194,6 +194,7 @@ class FPM::Package::Python < FPM::Package
       safesystem(attributes[:python_bin], "setup.py", "install",
                  "--root", staging_path, 
                  "--install-lib", File.join(prefix, attributes[:python_install_lib]),
+                 "--install-data", File.join(prefix, attributes[:python_install_lib]),
                  "--install-scripts", File.join(prefix, attributes[:python_install_bin]))
     end
   end # def install_to_staging


### PR DESCRIPTION
Ran into this problem with installing Django, where the install_data would place the files in /usr/local/lib vs /usr/lib

The test I was running was:

fpm -s python -t deb -p django-lib.deb --verbose --debug django

And the output deb should be entirely locatable under /usr/lib/
