### PR TITLE
Don't chmod/chown symlinks.

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -112,6 +112,10 @@ class FPM::Package::Dir < FPM::Package
   end # def copy
 
   def copy_metadata(source, destination)
+    # chmod/chown on symlinks will alter the linked file's permissions, which
+    # isn't desirable.
+    return if File.symlink?(source)
+
     source_stat = File::lstat(source)
     dest_stat = File::lstat(destination)
 


### PR DESCRIPTION
File.chown and File.chmod will follow symlinks and change the ownership
and permissions of the symlink's destination file. Bail out early on
symlinks.

Fixes #224 (I think)
