### PR TITLE
adding --prefix support for RPM

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -204,6 +204,15 @@ class FPM::Package::RPM < FPM::Package
     @logger.log("Created rpm", :path => output_path)
   end # def output
 
+  def prefix
+    return attributes[:prefix]
+  end # def prefix
+
+  def build_sub_dir
+    return "BUILD" + prefix
+  end # def prefix
+
+
   def to_s(format=nil)
     return super("NAME-VERSION-ITERATION.ARCH.TYPE") if format.nil?
     return super(format)
@@ -218,5 +227,5 @@ class FPM::Package::RPM < FPM::Package
   end # def digest_algorithm
 
   public(:input, :output, :converted_from, :architecture, :to_s, :iteration,
-         :payload_compression, :digest_algorithm)
+         :payload_compression, :digest_algorithm, :prefix, :build_sub_dir)
 end # class FPM::Package::RPM

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -27,6 +27,9 @@ AutoReqProv: no
 # Seems specifying BuildRoot is required on older rpmbuild (like on CentOS 5)
 # fpm passes '--define buildroot ...' on the commandline, so just reuse that.
 BuildRoot: %buildroot
+<% if !prefix.empty? %>
+Prefix: <%= prefix %>
+<% end -%>
 
 Group: <%= category %>
 License: <%= license %>
@@ -62,7 +65,7 @@ Obsoletes: <%= repl %>
 <% files.each do |path| -%>
 <%   source = Shellwords.shellescape(File.join(staging_path, path)) -%>
 <%   # Copy to the build_path/BUILD/ to make rpmbuild happy -%>
-<%   target = Shellwords.shellescape(File.join(build_path, "BUILD", path)) -%>
+<%   target = Shellwords.shellescape(File.join(build_path, build_sub_dir, path)) -%>
 <%   dir = File.dirname(target) %>
 mkdir -p <%= dir %>
 if [ -f <%= source %> ] || [ -h <%= source %> ] ; then
@@ -99,7 +102,7 @@ fi
 %defattr(-,<%= attributes[:rpm_user] %>,<%= attributes[:rpm_group] %>,-)
 <%# Output config files and then regular files. -%>
 <% config_files.each do |path| -%>
-%config(noreplace) <%= path %>
+%config(noreplace) <%= path.gsub(/^/,prefix) %>
 <% end -%>
 <%# list only files, not directories? -%>
 <%= 
@@ -115,7 +118,8 @@ fi
     .collect { |f| f[/\s/] and "\"#{f}\"" or f } \
     .collect { |f| f.gsub("[", "[\\[]") } \
     .collect { |f| f.gsub("*", "[*]") } \
-    .join("\n") 
+    .collect { |f| f.gsub(/^/, prefix ) } \
+    .join("\n")
 %>
 
 %changelog


### PR DESCRIPTION
I exposed prefix and build_sub_dir so the ERB can read these bits and manipulate the SPEC according to http://www.rpm.org/max-rpm/s1-rpm-reloc-prefix-tag.html.  It's a pretty simple change, and I've used it to generate RPMs with and without the --prefix argument.  Let me know if there's anything else you need! 
