### PR TITLE
Remove dirs empty due to --exclude.  Issue 205.

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -351,6 +351,8 @@ class FPM::Package
             if (::Dir.entries(d) - %w[ . .. ]).empty?
               ::Dir.rmdir(d)
               @logger.info("Deleting empty directory left by removing exluded file", :path => d)
+            else
+              break
             end
           end
         end


### PR DESCRIPTION
Could be improved by breaking the ascend once a non-empty directory is found, but this code works for me in the case of packaging directories and excluding `**/.git/*`
