### PR TITLE
Issue #234: Do not check utime on a copied symlink

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -125,7 +125,8 @@ class FPM::Package::Dir < FPM::Package
     dest_stat = File::lstat(destination)
 
     # If this is a hard-link, there's no metadata to copy.
-    return if source_stat.ino == dest_stat.ino
+    # If this is a symlink, what it points to hasn't been copied yet.
+    return if source_stat.ino == dest_stat.ino || File.symlink?(destination)
 
     File.utime(source_stat.atime, source_stat.mtime, destination)
     begin


### PR DESCRIPTION
/usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/package/dir.rb:121:in `utime': No such file or directory - /tmp/package-dir-staging2
0120710-20351-f4vjw7/usr/lib/libQt3Support.so (Errno::ENOENT)
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/package/dir.rb:121:in`copy_metadata'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/package/dir.rb:111:in `copy'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/package/dir.rb:79:in`block in clone'
    from /usr/local/rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/find.rb:41:in `block in find'
    from /usr/local/rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/find.rb:40:in`catch'
    from /usr/local/rvm/rubies/ruby-1.9.3-p0/lib/ruby/1.9.1/find.rb:40:in `find'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/package/dir.rb:77:in`clone'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/package/dir.rb:36:in `block in input'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/package/dir.rb:32:in`chdir'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/package/dir.rb:32:in `input'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/command.rb:248:in`block in execute'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/command.rb:247:in `each'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/lib/fpm/command.rb:247:in`execute'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/clamp-0.3.1/lib/clamp/command.rb:64:in `run'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/clamp-0.3.1/lib/clamp/command.rb:126:in`run'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/gems/fpm-0.4.10/bin/fpm:8:in `<top (required)>'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/bin/fpm:19:in`load'
    from /usr/local/rvm/gems/ruby-1.9.3-p0/bin/fpm:19:in `<main>'
