### PR TITLE
Don't fart if an internal API user doesn't specify a compression type for Debian packages.

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -230,7 +230,7 @@ class FPM::Package::Deb < FPM::Package
 
     # Tar up the staging_path into data.tar.{compression type}
     case self.attributes[:deb_compression]
-      when "gzip"
+      when "gzip", nil
         datatar = build_path("data.tar.gz")
         compression = "-z"
       when "bzip2" 


### PR DESCRIPTION
Yep.
