### PR TITLE
EPERM on hardlinking files is not rescued when packaging a dir

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -112,7 +112,7 @@ class FPM::Package::Dir < FPM::Package
       begin
         @logger.debug("Linking", :source => source, :destination => destination)
         File.link(source, destination)
-      rescue Errno::EXDEV
+      rescue Errno::EXDEV, Errno::EPERM
         # Hardlink attempt failed, copy it instead
         @logger.debug("Copying", :source => source, :destination => destination)
         FileUtils.copy_entry(source, destination)


### PR DESCRIPTION
Reproduction steps:

``` bash
mkdir /tmp/fpmlinks
sudo touch /tmp/fpmlinks/sufile
sudo ln -s sufile /tmp/fpmlinks/sulink
fpm -s dir -t deb -n links /tmp/fpmlinks
```

```
(...)/gems/fpm-0.4.14/lib/fpm/package/dir.rb:112:in `link': Operation not permitted - (/tmp/fpmlinks/sufile, /tmp/package-dir-staging20120829-19938-msthu0/tmp/fpmlinks/sufile) (Errno::EPERM)
    from /home/jacek/.rvm/gems/ruby-1.9.3-p194/gems/fpm-0.4.14/lib/fpm/package/dir.rb:112:in `copy'
    from /home/jacek/.rvm/gems/ruby-1.9.3-p194/gems/fpm-0.4.14/lib/fpm/package/dir.rb:79:in `block in clone'
    from /home/jacek/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/find.rb:41:in `block in find'
    from /home/jacek/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/find.rb:40:in `catch'
    from /home/jacek/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/find.rb:40:in `find'
(...)
```
