### PR TITLE
python: customize the --install-data option for setup.py

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -47,6 +47,8 @@ class FPM::Package::Python < FPM::Package
     "Want to what your target platform is using? Run this: " \
     "python -c 'from distutils.sysconfig import get_python_lib; " \
     "print get_python_lib()'"
+  option "--install-data", "DATA_PATH", "The path to where data should be " \
+    "installed to."
 
   private
 
@@ -188,13 +190,16 @@ class FPM::Package::Python < FPM::Package
       @logger.info("Setting default :python_install_lib attribute",
                    :value => attributes[:python_install_lib])
     end
+    if attributes[:python_install_data].nil?
+      attributes[:python_install_data] = attributes[:python_install_lib]
+    end
     # Some setup.py's assume $PWD == current directory of setup.py, so let's
     # chdir first.
     ::Dir.chdir(project_dir) do
       safesystem(attributes[:python_bin], "setup.py", "install",
                  "--root", staging_path, 
                  "--install-lib", File.join(prefix, attributes[:python_install_lib]),
-                 "--install-data", File.join(prefix, attributes[:python_install_lib]),
+                 "--install-data", File.join(prefix, attributes[:python_install_data]),
                  "--install-scripts", File.join(prefix, attributes[:python_install_bin]))
     end
   end # def install_to_staging


### PR DESCRIPTION
Give the possibility to specify from command line where to install the
data. Data were installed in the 'lib' directory, which is still the
default setting if not explicitely changed, for backward compatibility.
A more "normal" data directory would be /usr or /usr/share, also
depending on the target OS.
