### PR TITLE
issue 245 (RPM's with non-root owners doesn't set ownership of directori...

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -88,6 +88,12 @@ class FPM::Command < Clamp::Command
     @config_files ||= []
     @config_files << val
   end # --config-files
+  option "--directories", "DIRECTORIES",
+    "Mark a directory as being owned by the package" \
+    do |val|
+    @directories ||= []
+    @directories << val
+  end # directories
   option ["-a", "--architecture"], "ARCHITECTURE",
     "The architecture name. Usually matches 'uname -m'. For automatic values," \
     " you can use '-a all' or '-a native'. These two strings will be " \
@@ -198,6 +204,7 @@ class FPM::Command < Clamp::Command
     @provides = []
     @dependencies = []
     @config_files = []
+    @directories = []
     @excludes = []
   end # def initialize
 
@@ -323,6 +330,7 @@ class FPM::Command < Clamp::Command
     input.provides += provides
     input.replaces += replaces
     input.config_files += config_files
+    input.directories += directories
     
     setscript = proc do |scriptname|
       # 'self.send(scriptname) == self.before_install == --before-install

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -104,6 +104,8 @@ class FPM::Package
   # Array of configuration files
   attr_accessor :config_files
 
+  attr_accessor :directories
+
   # Any other attributes specific to this package.
   # This is where you'd put rpm, deb, or other specific attributes.
   attr_accessor :attributes
@@ -168,6 +170,7 @@ class FPM::Package
     @dependencies = []
     @scripts = {}
     @config_files = []
+    @directories = []
 
     staging_path
     build_path
@@ -194,7 +197,7 @@ class FPM::Package
       :@architecture, :@attributes, :@category, :@config_files, :@conflicts,
       :@dependencies, :@description, :@epoch, :@iteration, :@license, :@maintainer,
       :@name, :@provides, :@replaces, :@scripts, :@url, :@vendor, :@version,
-      :@config_files, :@staging_path
+      :@directories, :@staging_path
     ]
     ivars.each do |ivar|
       #@logger.debug("Copying ivar", :ivar => ivar, :value => instance_variable_get(ivar),

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -167,6 +167,7 @@ class FPM::Package::RPM < FPM::Package
     #input.replaces += replaces
     
     self.config_files += rpm.config_files
+    self.directories += rpm.directories
 
     # Extract to the staging directory
     rpm.extract(staging_path)

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -107,6 +107,9 @@ fi
 <% config_files.each do |path| -%>
 %config(noreplace) <%= File.join(prefix, path) %>
 <% end -%>
+<% directories.each do |path| -%>
+%dir <%= File.join(prefix, path) %>
+<% end -%>
 <%# list only files, not directories? -%>
 <%= 
   # Reject config files already listed or parent directories, then prefix files


### PR DESCRIPTION
Hi,

I've added a --directories argument to FPM which causes the values to be added as %dir entries under the file list, so they take the --rpm-user and --rpm-group as owners and get removed when the RPM gets removed. As you can see, it works just like --config-files.

What do you think?

Thanks and Regards,
