### PR TITLE
Replace % with [%] to make rpm not expand macros in file names

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -69,9 +69,9 @@ Obsoletes: <%= repl %>
 
 %install
 <% files.each do |path| -%>
-<%   source = Shellwords.shellescape(File.join(staging_path, path)) -%>
+<%   source = Shellwords.shellescape(File.join(staging_path, path)).gsub("%", "%%") -%>
 <%   # Copy to the build_path/BUILD/ to make rpmbuild happy -%>
-<%   target = Shellwords.shellescape(File.join(build_path, build_sub_dir, path)) -%>
+<%   target = Shellwords.shellescape(File.join(build_path, build_sub_dir, path)).gsub("%", "%%") -%>
 <%   dir = File.dirname(target) %>
 mkdir -p <%= dir %>
 if [ -f <%= source %> ] || [ -h <%= source %> ] ; then


### PR DESCRIPTION
File names can have percents in them and rpm is... rpm, so stop the macro replacement madness.

Macro replacement is usually not an issue unless your file name contains something like "%name%" or another defined macro. (I'm looking at you, rails.)
