### PR TITLE
When running in debug mode, do not remove temp files created

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -260,8 +260,8 @@ class FPM::Package
 
   # Clean up any temporary storage used by this class.
   def cleanup
-    cleanup_staging
-    cleanup_build
+    cleanup_staging unless @logger.level == :debug
+    cleanup_build unless @logger.level == :debug
   end # def cleanup
 
   def cleanup_staging


### PR DESCRIPTION
This should help during debugging. I find myself trying to ctrl+c at the right moment now which can be troublesome.
