### PR TITLE
Add the version of the gem to the provides

### DIFF
--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -136,7 +136,7 @@ class FPM::Package::Gem < FPM::Package
 
       # By default, we'll usually automatically provide this, but in the case that we are
       # composing multiple packages, it's best to explicitly include it in the provides list.
-      self.provides << "#{self.name}"
+      self.provides << "#{self.name} = #{self.version}"
 
       spec.runtime_dependencies.map do |dep|
         # rubygems 1.3.5 doesn't have 'Gem::Dependency#requirement'


### PR DESCRIPTION
Currently, the only way to depend on specific gem versions is to depend on rubygem-gemname = VERSION while I would prefer depending on rubygem(gemname) = VERSION. 

This way of dependencies should be more compatible with rpm packages that use a different prefix (rubygem-) but still have the correct provides rubygem(gemname).
