### PR TITLE
dpkg vs rubygem version dependency

### DIFF
--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -112,7 +112,13 @@ class FPM::Package::Gem < FPM::Package
 
       #self.name = [attributes[:gem_package_name_prefix], spec.name].join("-")
       self.license = (spec.license or "no license listed in #{File.basename(file)}")
-      self.version = spec.version.to_s
+
+      # expand spec's version to match RationalVersioningPolicy to prevent cases
+      # where missing 'build' number prevents correct dependency resolution by target
+      # package manager. Ie. for dpkg 1.1 != 1.1.0
+      m = spec.version.to_s.match /^(\d)?.?(\d+)?.?(\d+)?/
+      self.version = m.captures.map {|m| m ? m : 0}.join('.')
+
       self.vendor = spec.author
       self.url = spec.homepage
       self.category = "Languages/Development/Ruby"


### PR DESCRIPTION
Hi,

I would like to verify what's causing the following issue between gem -> deb dependencies. Using FPM to convert all necessary Chef gems into Debian packages. Chef gem itself depends on net-ssh-multi ~> 1.1.0, but net-ssh-multi gem turns as debian package version 1.1. 

This causes issue where dpkg >= 1.1.0 dependency can't be satisfied by rubygem-net-ssh-multi-1.1 package.

Is this dpkg issue or is the better way to enforce Rubygems version to always include build number, i.e 1.1 -> 1.1.0 (so far using this fix as temporary workaround).

Thanks 

Radim
