### PR TITLE
We should also use rubygem(name) for the dependencies

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -121,6 +121,15 @@ class FPM::Package::RPM < FPM::Package
           provides
         end
       end
+      self.dependencies = self.dependencies.collect do |dependency|
+        first, remainder = dependency.split("-", 2)
+        if first == "rubygem"
+          name, remainder = remainder.split(" ", 2)
+          "rubygem(#{name})#{remainder ? " #{remainder}" : ""}"
+        else
+          dependency
+        end
+      end
       #self.provides << "rubygem(#{self.name})"
     end
   end # def converted


### PR DESCRIPTION
We are currently having an issue with the dependencies. 

RPM seems to add some magic 

```
rubygem(fpm) = 0.4.20
rubygem-fpm = 1:0.4.20-1
```

Normally, I would expect the second provide string to be rubygem-fpm = 0.4.20-1 but it seems something changed. I have not tracked down what yet.

Anyhow, even besides that, this still is a good idea IMHO. We should depend on something we know our packages provide, not on rpm magic.
