### PR TITLE
Fix blank line being added to deb control file, which is causing errors. 

### DIFF
--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -17,7 +17,7 @@ Conflicts: <%= conflicts.join(", ") %>
 <%# end -%>
 <% if !provides.empty? -%>
 <%# Turn each provides from 'foo = 123' to simply 'foo' because Debian :\ -%>
-<%#  http://www.debian.org/doc/debian-policy/ch-relationships.html %>
+<%#  http://www.debian.org/doc/debian-policy/ch-relationships.html -%>
 Provides: <%= provides.first.split(" ").first %>
 <% end -%>
 <% if !replaces.empty? -%>


### PR DESCRIPTION
Hi, 

Updated our install of fpm today and caught this bug.
Here's a minor change to fix a typo on the comments in the templates/deb.erb file. 

> template file. (added '-' to the end tag).
> 
> Without the edit, the template was inserting an extra blank line into the
> config file. When dpkg/reprepro try to read the file the blank line is
> interpreted as the end of the configuration, and the additional lines
> below it cause an error.
> 
> With the edit, no additional blank line is inserted. The comment is
> correctly escaped.
> 
> Signed-off-by: Andrew Bunday andrew.bunday@gmail.com

Thanks,

A,.
