### PR TITLE
Include subdirs of --directories option as %dir directives in SPEC files

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -109,8 +109,15 @@ fi
 <% config_files.each do |path| -%>
 %config(noreplace) <%= File.join(prefix, path) %>
 <% end -%>
+<% subdirs = [] -%>
 <% directories.each do |path| -%>
 %dir <%= File.join(prefix, path) %>
+<%#  We need to include hidden directories, but exclude . and .. -%>
+<%   ::Dir.glob("#{path}/**/*/", FNM_DOTMATCH) do |subdir| -%>
+<%     next if File.basename(subdir) =~ /^\.+$/ -%>
+%dir <%= File.join(prefix, subdir) %>
+<% subdirs << subdir -%>
+<%   end -%>
 <% end -%>
 <%# list only files, not directories? -%>
 <%= 
@@ -125,6 +132,7 @@ fi
   # Replace % with [%] to make rpm not expand macros
   files.collect { |f| "/#{f}" } \
     .reject { |f| config_files.include?(f) } \
+    .reject { |f| subdirs.include?("#{f}/") } \
     .collect { |f| f[/\s/] and "\"#{f}\"" or f } \
     .collect { |f| f.gsub("[", "[\\[]") } \
     .collect { |f| f.gsub("*", "[*]") } \


### PR DESCRIPTION
This is an extension of the support introduced in pull #260 and resolves the remaining issues in #245 and #199.

I am not a ruby coder, so I'm sure this could be cleaner, but it seems to work in all situations that I could throw at it.  I'm more than willing to take some tips on how to make it better.
