### PR TITLE
* Fix #263 Convert != dependency as Conflict =, as rpm doesn't understand it

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -182,13 +182,14 @@ class FPM::Package::Python < FPM::Package
       # requirements.txt can have dependencies, flags, and comments.
       # We only want the comments, so remove comment and flag lines.
       metadata["dependencies"] = File.read(requirements_txt).split("\n") \
+        .reject { |l| l =~ /^\s*$/ } \
         .reject { |l| l =~ /^\s*#/ } \
         .reject { |l| l =~ /^-/ } \
         .map(&:strip)
     end
 
     self.dependencies += metadata["dependencies"].collect do |dep|
-      dep_re = /^([^<>= ]+)\s*(?:([<>=]{1,2})\s*(.*))?$/
+      dep_re = /^([^<>!= ]+)\s*(?:([<>!=]{1,2})\s*(.*))?$/
       match = dep_re.match(dep)
       if match.nil?
         @logger.error("Unable to parse dependency", :dependency => dep)

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -141,6 +141,19 @@ class FPM::Package::RPM < FPM::Package
       end
       #self.provides << "rubygem(#{self.name})"
     end
+
+    # Convert != dependency as Conflict =, as rpm doesn't understand !=
+    if origin == FPM::Package::Python
+      self.dependencies = self.dependencies.select do |dep|
+        name, op, version = dep.split(/\s+/)
+        dep_ok = true
+        if op == '!='
+          self.conflicts << "#{name} = #{version}"
+          dep_ok = false
+        end
+        dep_ok
+      end
+    end
   end # def converted
 
   def input(path)


### PR DESCRIPTION
- Fix #263 Convert != dependency as Conflict =, as rpm doesn't understand it
- Skip empty lines in requirements.txt
