### PR TITLE
Bandaid fix for Issue #316

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -187,7 +187,11 @@ class FPM::Package::RPM < FPM::Package
     #input.replaces += replaces
     
     self.config_files += rpm.config_files
-    self.directories += rpm.directories
+    begin
+        self.directories += rpm.directories
+    rescue NoMethodError
+        # Do nothing
+    end
 
     # Extract to the staging directory
     rpm.extract(staging_path)


### PR DESCRIPTION
Bandaid fix for Issue #316

/usr/lib64/ruby/gems/1.9.1/gems/fpm-0.4.25/lib/fpm/package/rpm.rb:190:in `input': undefined method`directories' for #RPM::File:0x00000000b05068 (NoMethodError)

Added an exception block to catch NoMethodError

Perhaps the rescue statement should actually do something here?
