### PR TITLE
control case of package name and its dependencies

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -43,6 +43,11 @@ class FPM::Package::Python < FPM::Package
   option "--fix-dependencies", :flag, "Should the package dependencies be " \
     "prefixed?", :default => true
 
+  option "--downcase-name", :flag, "Should the target package name be in " \
+    "lowercase?", :default => true
+  option "--downcase-dependencies", :flag, "Should the package dependencies " \
+    "be in lowercase?", :default => true
+
   option "--install-bin", "BIN_PATH", "The path to where python scripts " \
     "should be installed to.", :default => "/usr/bin"
   option "--install-lib", "LIB_PATH", "The path to where python libs " \
@@ -169,6 +174,9 @@ class FPM::Package::Python < FPM::Package
       self.name = metadata["name"]
     end
 
+    # convert python-Foo to python-foo if flag is set
+    self.name = self.name.downcase if attributes[:python_downcase_name?]
+
     requirements_txt = File.join(setup_dir, "requirements.txt")
     if File.exists?(requirements_txt)
       @logger.info("Found requirements.txt, using it instead of setup.py " \
@@ -199,6 +207,9 @@ class FPM::Package::Python < FPM::Package
       # become 'python-foo' (depending on what the python_package_name_prefix
       # is)
       name = fix_name(name) if attributes[:python_fix_dependencies?]
+
+      # convert dependencies from python-Foo to python-foo
+      name = name.downcase if attributes[:python_downcase_dependencies?]
       "#{name} #{cmp} #{version}"
     end
   end # def load_package_info

--- a/spec/fixtures/python/setup.py
+++ b/spec/fixtures/python/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 
-setup(name="example",
+setup(name="Example",
       version="1.0",
       description="sample description",
       author="sample author",
@@ -8,6 +8,6 @@ setup(name="example",
       url="sample url",
       packages=[],
       package_dir={},
-      requires=["dependency1", "dependency2"],
+      requires=["Dependency1", "dependency2"],
       )
 

--- a/spec/fpm/package/python_spec.rb
+++ b/spec/fpm/package/python_spec.rb
@@ -19,37 +19,54 @@ describe FPM::Package::Python, :if => python_usable? do
   after :each do
     subject.cleanup
   end
-  
-  context "when :python_fix_name? is true" do
+
+  context "when :python_downcase_name? is false" do
     before :each do
-      subject.attributes[:python_fix_name?] = true
+      subject.attributes[:python_downcase_name?] = false
     end
-
-    context "and :python_package_name_prefix is nil/default" do
-      it "should prefix the package with 'python-'" do
-        subject.input(example_dir)
-        insist { subject.name } == "python-example"
-      end
-    end
-
-    context "and :python_package_name_prefix is set" do
-      it "should prefix the package name appropriately" do
-        prefix = "whoa"
-        subject.attributes[:python_package_name_prefix] = prefix
-        subject.input(example_dir)
-        insist { subject.name } == "#{prefix}-example"
-      end
+    
+    it "should leave the package name as is" do
+      subject.input(example_dir)
+      insist { subject.name } == "Example"
     end
   end
 
-  context "when :python_fix_name? is false" do
+  context "when :python_downcase_name? is true" do
     before :each do
-      subject.attributes[:python_fix_name?] = false
+      subject.attributes[:python_downcase_name?] = true
     end
 
-    it "it should not prefix the name at all" do
-      subject.input(example_dir)
-      insist { subject.name } == "example"
+    context "when :python_fix_name? is true" do
+      before :each do
+        subject.attributes[:python_fix_name?] = true
+      end
+
+      context "and :python_package_name_prefix is nil/default" do
+        it "should prefix the package with 'python-'" do
+          subject.input(example_dir)
+          insist { subject.name } == "python-example"
+        end
+      end
+
+      context "and :python_package_name_prefix is set" do
+        it "should prefix the package name appropriately" do
+          prefix = "whoa"
+          subject.attributes[:python_package_name_prefix] = prefix
+          subject.input(example_dir)
+          insist { subject.name } == "#{prefix}-example"
+        end
+      end
+    end
+
+    context "when :python_fix_name? is false" do
+      before :each do
+        subject.attributes[:python_fix_name?] = false
+      end
+
+      it "it should not prefix the name at all" do
+        subject.input(example_dir)
+        insist { subject.name } == "example"
+      end
     end
   end
 end # describe FPM::Package::Python


### PR DESCRIPTION
Added the following two flags:
  --[no-]python-downcase-name
  (python only) Should the target package name be in lowercase? (default: true)
  --[no-]python-downcase-dependencies
  (python only) Should the package dependencies be in lowercase? (default: true)

fixes #326
