### PR TITLE
allow unsetting of epoch for rpm target packages

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -270,7 +270,9 @@ class FPM::Package::RPM < FPM::Package
   # The default epoch value must be 1 (backward compatibility for rpms built
   # with fpm 0.4.3 and older)
   def epoch
-    return @epoch || "1"
+    return 1 if @epoch.nil?
+    return nil if @epoch.empty?
+    return @epoch
   end # def epoch
 
   def to_s(format=nil)


### PR DESCRIPTION
commit 3b5853e allowed target packages other than rpm to unset epoch
when --epoch was an empty string.  That didn't work with the rpm target
package because of commit d8f2ac which set epoch to 1 for rpm packages
even when epoch is an empty string.

This commit makes a distinction between nil and an empty string: when a
user passes an empty string for epoch (--epoch "") no epoch is set.
When --epoch is ommitted completly, it defaults to 1.
