### PR TITLE
allow for links to nonexistent files in build environment to be added to package

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -112,7 +112,7 @@ class FPM::Package::Dir < FPM::Package
       begin
         @logger.debug("Linking", :source => source, :destination => destination)
         File.link(source, destination)
-      rescue Errno::EXDEV, Errno::EPERM
+      rescue Errno::ENOENT, Errno::EXDEV, Errno::EPERM
         # Hardlink attempt failed, copy it instead
         @logger.debug("Copying", :source => source, :destination => destination)
         FileUtils.copy_entry(source, destination)


### PR DESCRIPTION
(eval):3:in `link_without_potential_path_argument': No such file or directory - usr/local/bin/kt or /var/folders/9n/zpntlhcs6ls0qf_29ngjrhcr0000gn/T/package-dir-staging20130114-70813-gja6ry/usr/local/bin/kt (Errno::ENOENT)
