### PR TITLE
Fix error return code on Ruby 1.8. (#338)

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -373,7 +373,7 @@ class FPM::Command < Clamp::Command
 
       if !File.exists?(path)
         @logger.error("No such file (for #{scriptname.to_s}): #{path.inspect}")
-        return 1
+        exit 1
       end
 
       # Load the script into memory.


### PR DESCRIPTION
--before-install (and its brethren) were not causing fpm to exit on a
non-existant file error when using Ruby 1.8.

The root of the problem appears to be that that particular error-checking is
done inside a proc (lib/fpm/command.rb#L374); in Ruby 1.9, the return value of
the proc is used to determine whether `#call` was successful, while 1.8
gleefully ignores it.

```
[$]> cat test.rb
test = proc do
    return 1
end

test.call

[$]> ruby-1.8.7-p334 test.rb; echo $?
0

[$]> ruby-1.9.3-p125 test.rb; echo $?
test.rb:2:in `block in <main>': unexpected return (LocalJumpError)
    from test.rb:5:in `call'
    from test.rb:5:in `<main>'
1
```

In this instance, we can use `exit` instead of `return`, and that'll be fine.
