### PR TITLE
Change the gemspec from json =1.6.6 to json >=1.6.6 

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   # For parsing JSON (required for some Python support, etc)
   # http://flori.github.com/json/doc/index.html
-  spec.add_dependency("json", "1.6.6") # license: Ruby License
+  spec.add_dependency("json", ">= 1.6.6") # license: Ruby License
   
   # For logging
   # https://github.com/jordansissel/ruby-cabin


### PR DESCRIPTION
In our project we have another gem that requires json 1.7.6. The hard dependancy in fpm on json 1.6.6 is causing a dependancy conflict
