### PR TITLE
Pear enhancements

### DIFF
--- a/lib/fpm/package/pear.rb
+++ b/lib/fpm/package/pear.rb
@@ -85,11 +85,17 @@ class FPM::Package::PEAR < FPM::Package
     self.description  = %x{#{pear_cmd} | sed -ne '/^Summary\s*/s/^Summary\s*//p'}.chomp
     @logger.debug("Package info", :name => self.name, :version => self.version,
                   :description => self.description)
- 
+
     # Remove the stuff we don't want
     delete_these = [".depdb", ".depdblock", ".filemap", ".lock", ".channel", "cache", "temp", "download", ".channels", ".registry"]
     Find.find(staging_path) do |path|
+      if File.file?(path) && File.executable?(path)
+        @logger.info("replacing pear_dir in binary", :binary => path)
+        content = File.read(path).gsub(/#{staging_path}/, "")
+        File.open(path, "w") { |file| file.puts content }
+      end
       FileUtils.rm_r(path) if delete_these.include?(File.basename(path))
     end
+
   end # def input
 end # class FPM::Package::PEAR


### PR DESCRIPTION
I've ran into some issues creating packages for the default debian php setup, so I've added options for these customizations.

Some junk was left in some pear packages, I've added those directories to the list to be deleted from staging.

Then there's the case of task:replace in pear installer, which is used to replace tokens in php files with pear config values. This is used to insert the pear directory in the executable files, I've added a workaround for this issue too. (See [PHPUnit](https://github.com/sebastianbergmann/phpunit/blob/master/package.xml#L209) for example)
