### PR TITLE
Fix debian dependency name mangling.

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -349,13 +349,13 @@ class FPM::Package::Deb < FPM::Package
     if name =~ /[A-Z]/
       @logger.warn("Downcasing dependency '#{name}' because deb packages " \
                    " don't work so good with uppercase names")
-      dep.gsub!(name_re) { |n| n.downcase }
+      dep=dep.gsub(name_re) { |n| n.downcase }
     end
 
     if dep.include?("_")
       @logger.warn("Replacing underscores with dashes in '#{dep}' because " \
                    "debs don't like underscores")
-      dep.gsub!("_", "-")
+      dep=dep.gsub("_", "-")
     end
 
     # Convert gem ~> X.Y.Z to '>= X.Y.Z' and << X.Y+1.0


### PR DESCRIPTION
Tries to modify frozen string.

```
$ bundle exec fpm -s dir -t deb -n foo -v 1.0 -d 'Aafasf-asf_sf' --inputs foo
/home/cpk/src/ruby/fpm/lib/fpm/version.rb:2: warning: already initialized constant VERSION
Downcasing dependency 'Aafasf-asf_sf' because deb packages  don't work so good with uppercase names {:level=>:warn}
/home/cpk/src/ruby/fpm/lib/fpm/package/deb.rb:352:in `gsub!': string frozen (RuntimeError)
    from /home/cpk/src/ruby/fpm/lib/fpm/package/deb.rb:352:in `fix_dependency'
    from /home/cpk/src/ruby/fpm/lib/fpm/package/deb.rb:323:in `converted_from'
    from /home/cpk/src/ruby/fpm/lib/fpm/package/deb.rb:322:in `collect'
    from /home/cpk/src/ruby/fpm/lib/fpm/package/deb.rb:322:in `converted_from'
    from /home/cpk/src/ruby/fpm/lib/fpm/package.rb:208:in `convert'
    from /home/cpk/src/ruby/fpm/lib/fpm/command.rb:396:in `execute'
    from /home/cpk/.rvm/gems/ruby-1.8.7-p249/gems/clamp-0.3.1/lib/clamp/command.rb:64:in `run'
    from /home/cpk/.rvm/gems/ruby-1.8.7-p249/gems/clamp-0.3.1/lib/clamp/command.rb:126:in `run'
    from /home/cpk/src/ruby/fpm/bin/fpm:8
    from /home/cpk/.rvm/gems/ruby-1.8.7-p249/bin/fpm:19:in `load'
    from /home/cpk/.rvm/gems/ruby-1.8.7-p249/bin/fpm:19
    from /home/cpk/.rvm/gems/ruby-1.8.7-p249/bin/ruby_noexec_wrapper:14

$ bundle exec fpm -s dir -t deb -n foo -v 1.0 -d 'afasf-asf_sf' --inputs foo
/home/cpk/src/ruby/fpm/lib/fpm/version.rb:2: warning: already initialized constant VERSION
Replacing underscores with dashes in 'afasf-asf_sf' because debs don't like underscores {:level=>:warn}
/home/cpk/src/ruby/fpm/lib/fpm/package/deb.rb:358:in `gsub!': can't modify frozen string (TypeError)
    from /home/cpk/src/ruby/fpm/lib/fpm/package/deb.rb:358:in `fix_dependency'
    from /home/cpk/src/ruby/fpm/lib/fpm/package/deb.rb:323:in `converted_from'
    from /home/cpk/src/ruby/fpm/lib/fpm/package/deb.rb:322:in `collect'
    from /home/cpk/src/ruby/fpm/lib/fpm/package/deb.rb:322:in `converted_from'
    from /home/cpk/src/ruby/fpm/lib/fpm/package.rb:208:in `convert'
    from /home/cpk/src/ruby/fpm/lib/fpm/command.rb:396:in `execute'
    from /home/cpk/.rvm/gems/ruby-1.8.7-p249/gems/clamp-0.3.1/lib/clamp/command.rb:64:in `run'
    from /home/cpk/.rvm/gems/ruby-1.8.7-p249/gems/clamp-0.3.1/lib/clamp/command.rb:126:in `run'
    from /home/cpk/src/ruby/fpm/bin/fpm:8
    from /home/cpk/.rvm/gems/ruby-1.8.7-p249/bin/fpm:19:in `load'
    from /home/cpk/.rvm/gems/ruby-1.8.7-p249/bin/fpm:19
    from /home/cpk/.rvm/gems/ruby-1.8.7-p249/bin/ruby_noexec_wrapper:14
```
