### PR TITLE
Debian changelog chmod fails

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -301,8 +301,8 @@ class FPM::Package::Deb < FPM::Package
       dest_changelog = File.join(staging_path, "usr/share/doc/#{attributes[:name]}/changelog.Debian")
       FileUtils.mkdir_p(File.dirname(dest_changelog))
       FileUtils.cp attributes[:deb_changelog], dest_changelog
-      safesystem("gzip", dest_changelog)
       File.chmod(0644, dest_changelog)
+      safesystem("gzip", dest_changelog)
     end
 
     args = [ tar_cmd, "-C", staging_path, compression ] + tar_flags + [ "-cf", datatar, "." ]


### PR DESCRIPTION
system("gzip") renames the file, so save that command for last.
