### PR TITLE
Updates to support --rpm-use-file-permissions

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -119,11 +119,11 @@ cp <%= source_safe %> <%= target_safe %>
 <% end -%>
 <% subdirs = [] -%>
 <% directories.each do |path| -%>
-%dir <%= File.join(prefix, path) %>
+%dir <%= output_file_line(File.join(prefix, path)) %>
 <%#  We need to include hidden directories, but exclude . and .. -%>
 <%   ::Dir.glob("#{path}/**/*/", File::FNM_DOTMATCH) do |subdir| -%>
 <%     next if File.basename(subdir) =~ /^\.+$/ -%>
-%dir <%= File.join(prefix, subdir) %>
+%dir <%= output_file_line(File.join(prefix, subdir)) %>
 <% subdirs << subdir -%>
 <%   end -%>
 <% end -%>
@@ -146,7 +146,7 @@ cp <%= source_safe %> <%= target_safe %>
     .collect { |f| f.gsub("*", "[*]") } \
     .collect { |f| f.gsub("?", "[?]") } \
     .collect { |f| f.gsub("%", "[%]") } \
-    .join("\n")
+    .map { |f| output_file_line(f) }
     #.collect { |f| File.join(prefix, f) } \
 %>
 


### PR DESCRIPTION
I remember a while back looking at file ownership issues with FPM built RPMs and looking on the issues list I can see this is still a problem...
- https://github.com/jordansissel/fpm/issues/178

I thought I'd have a quick look and see if I could fix it. Attached is a pull-request for ensuring that file modes and owner/groups are preserved when outputing an RPM. It only applies if --rpm-use-file-permissions is specified.

I'm aware this may well be specific to my use case (dir -> rpm) so it might need some additional work for more generic cases.

cheers
