### PR TITLE
a hackish (suggestion) fix to fpm

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -29,7 +29,7 @@ class FPM::Package::RPM < FPM::Package
   } unless defined?(COMPRESSION_MAP)
 
   option "--user", "USER",
-    "Set the user to USER in the %files section.", 
+    "Set the user to USER in the %files section.",
     :default => 'root' do |value|
       value
   end
@@ -42,8 +42,8 @@ class FPM::Package::RPM < FPM::Package
 
   option "--rpmbuild-define", "DEFINITION",
     "Pass a --define argument to rpmbuild." do |define|
-    attributes[:rpm_rpmbuild_define] ||= []
-    attributes[:rpm_rpmbuild_define] << define
+    $rpm_rpmbuild_define ||= []
+    $rpm_rpmbuild_define << define
   end
 
   option "--digest", DIGEST_ALGORITHM_MAP.keys.join("|"),
@@ -174,7 +174,7 @@ class FPM::Package::RPM < FPM::Package
       [name, operator, version].join(" ")
     end
     #input.replaces += replaces
-    
+
     self.config_files += rpm.config_files
     self.directories += rpm.directories
 
@@ -192,7 +192,7 @@ class FPM::Package::RPM < FPM::Package
       "--define", "_sourcedir #{build_path}",
       "--define", "_rpmdir #{build_path}/RPMS"]
 
-    (attributes[:rpm_rpmbuild_define] or []).each do |define|
+    ($rpm_rpmbuild_define or []).each do |define|
       args += ["--define", define]
     end
 


### PR DESCRIPTION
fpm is broken when you pass --rpm-rpmbuild-define to the rpm creator. This patch may or may not be accepted. I hope it, at least, encourages someone that is better at ruby then I to come up with a smarter fix. I really would like this to get into mainstream fpm so I no longer have to roll my own. 
