### PR TITLE
Add -f/--force flag to allow overwriting existing package output path

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -55,6 +55,8 @@ class FPM::Command < Clamp::Command
     "be necessary for all input packages. For example, the 'gem' type will" \
     "prefix with your gem directory automatically."
   option ["-p", "--package"], "OUTPUT", "The package file path to output."
+  option ["-f", "--force"], :flag, "Force output even if it will overwrite an " \
+    "existing file", :default => false
   option ["-n", "--name"], "NAME", "The name to give to the package"
   option "--verbose", :flag, "Enable verbose output"
   option "--debug", :flag, "Enable debug output"

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -487,6 +487,13 @@ class FPM::Package
     if !File.directory?(File.dirname(output_path))
       raise ParentDirectoryMissing.new(output_path)
     end
+    if File.exists?(output_path)
+      if attributes[:force?]
+        @logger.warn("--force flag given, overwriting package at #{output_path}")
+      else
+        raise FileAlreadyExists.new(output_path)
+      end
+    end
   end # def output_path
 
   def provides=(value)

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -267,7 +267,6 @@ class FPM::Package::Deb < FPM::Package
   def output(output_path)
     output_check(output_path)
     # Abort if the target path already exists.
-    raise FileAlreadyExists.new(output_path) if File.exists?(output_path)
 
     # create 'debian-binary' file, required to make a valid debian package
     File.write(build_path("debian-binary"), "2.0\n")

--- a/lib/fpm/package/osxpkg.rb
+++ b/lib/fpm/package/osxpkg.rb
@@ -130,7 +130,6 @@ class FPM::Package::OSXpkg < FPM::Package
   # Output a pkgbuild pkg.
   def output(output_path)
     output_check(output_path)
-    raise FileAlreadyExists.new(output_path) if File.exists?(output_path)
 
     temp_info = pkginfo_template_path
 

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -231,7 +231,6 @@ class FPM::Package::RPM < FPM::Package
 
   def output(output_path)
     output_check(output_path)
-    raise FileAlreadyExists.new(output_path) if File.exists?(output_path)
     %w(BUILD RPMS SRPMS SOURCES SPECS).each { |d| FileUtils.mkdir_p(build_path(d)) }
     args = ["rpmbuild", "-bb"]
 

--- a/lib/fpm/package/tar.rb
+++ b/lib/fpm/package/tar.rb
@@ -48,7 +48,6 @@ class FPM::Package::Tar < FPM::Package
   # the compression type.
   def output(output_path)
     output_check(output_path)
-    raise FileAlreadyExists.new(output_path) if File.exists?(output_path)
     # Unpack the tarball to the staging path
     args = ["-cf", output_path, "-C", staging_path, "."]
     with(tar_compression_flag(output_path)) do |flag|


### PR DESCRIPTION
- fixes #354
- consolidated FileAlreadyExists error into Package class's output_check rather than duplicate it within each package type
