### PR TITLE
Closes #339 Add minitest to spec, fix rspec test breakage.

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency("rspec") # license: MIT (according to wikipedia)
   spec.add_development_dependency("insist", "~> 0.0.5") # license: ???
+  spec.add_development_dependency("minitest")
 
   spec.files = files
   spec.require_paths << "lib"

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -487,7 +487,7 @@ class FPM::Package
     if !File.directory?(File.dirname(output_path))
       raise ParentDirectoryMissing.new(output_path)
     end
-    if File.exists?(output_path)
+    if File.file?(output_path)
       if attributes[:force?]
         @logger.warn("--force flag given, overwriting package at #{output_path}")
       else


### PR DESCRIPTION
- Closes #339, Add minitest to spec.
- Fix rspec (dir_spec, package_spec) breakage introduced by f541cf9 via #385.
