### PR TITLE
Closes #381 rpm, epoch should not be set by default.

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -281,12 +281,15 @@ class FPM::Package::RPM < FPM::Package
     #return File.join("BUILD", prefix)
   end # def prefix
 
-  # The default epoch value must be 1 (backward compatibility for rpms built
-  # with fpm 0.4.3 and older)
+  # The default epoch value must be nil, see #381
   def epoch
-    return 1 if @epoch.nil?
     return @epoch if @epoch.is_a?(Numeric)
-    return nil if @epoch.empty?
+
+    if @epoch.nil? or @epoch.empty?
+      @logger.warn("no value for epoch is set, defaulting to nil")
+      return nil
+    end
+
     return @epoch
   end # def epoch
 

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -39,8 +39,8 @@ describe FPM::Package::RPM do
   end
 
   describe "#epoch" do
-    it "should default to 1" do
-      insist { subject.epoch.to_s } == "1"
+    it "should default to empty" do
+      insist { subject.epoch.to_s } == ""
     end
     it "should cope with it being zero" do
       subject.epoch = 0
@@ -357,9 +357,9 @@ describe FPM::Package::RPM do
         rpmtags[tag.tag] = tag.value
       end
 
-      # Default epoch must be '1'
+      # Default epoch must be empty, see #381
       # For some reason, epoch is an array of numbers in rpm?
-      insist { rpmtags[:epoch] } == [1]
+      insist { rpmtags[:epoch] } == nil
 
       # Default release must be '1'
       insist { rpmtags[:release] } == "1"


### PR DESCRIPTION
- Closes #381 rpm, epoch should not be set by default.
- Warn user its being set to nil by default.
