### PR TITLE
Add an option for no compression in RPMs.

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -23,6 +23,7 @@ class FPM::Package::RPM < FPM::Package
   } unless defined?(DIGEST_ALGORITHM_MAP)
 
   COMPRESSION_MAP = {
+    "none" => "w0.gzdio",
     "xz" => "w2.xzdio",
     "gzip" => "w9.gzdio",
     "bzip2" => "w9.bzdio"


### PR DESCRIPTION
I've found this useful for big packages.
Speed over size.
