### PR TITLE
Only convert the dashes in version if it exists.

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -175,7 +175,7 @@ class FPM::Package::RPM < FPM::Package
     # Convert any dashes in version strings to underscores.
     self.dependencies = self.dependencies.collect do |dep|
       name, op, version = dep.split(/\s+/)
-      if version.include?("-")
+      if !version.nil? and version.include?("-")
         @logger.warn("Dependency package '#{name}' version '#{version}' " \
                      "includes dashes, converting to underscores")
         version = version.gsub(/-/, "_")


### PR DESCRIPTION
Fixes an issue when defining a dependency, without a version.

```
/usr/share/ruby/find.rb:38:in `block in find': No such file or directory (Errno::ENOENT)
    from /usr/share/ruby/find.rb:38:in `collect!'
    from /usr/share/ruby/find.rb:38:in `find'
    from /usr/local/share/gems/gems/fpm-0.4.31/lib/fpm/package/dir.rb:79:in `clone'
    from /usr/local/share/gems/gems/fpm-0.4.31/lib/fpm/package/dir.rb:34:in `block in input'
    from /usr/local/share/gems/gems/fpm-0.4.31/lib/fpm/package/dir.rb:32:in `chdir'
    from /usr/local/share/gems/gems/fpm-0.4.31/lib/fpm/package/dir.rb:32:in `input'
    from /usr/local/share/gems/gems/fpm-0.4.31/lib/fpm/command.rb:321:in `block in execute'
    from /usr/local/share/gems/gems/fpm-0.4.31/lib/fpm/command.rb:320:in `each'
    from /usr/local/share/gems/gems/fpm-0.4.31/lib/fpm/command.rb:320:in `execute'
    from /usr/local/share/gems/gems/clamp-0.3.1/lib/clamp/command.rb:64:in `run'
    from /usr/local/share/gems/gems/clamp-0.3.1/lib/clamp/command.rb:126:in `run'
    from /usr/local/share/gems/gems/fpm-0.4.31/bin/fpm:8:in `<top (required)>'
    from /usr/local/bin/fpm:23:in `load'
    from /usr/local/bin/fpm:23:in `<main>'
```
