### PR TITLE
Closes #396 Convert all != dependencies to Conflicts

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -161,16 +161,14 @@ class FPM::Package::RPM < FPM::Package
     end
 
     # Convert != dependency as Conflict =, as rpm doesn't understand !=
-    if origin == FPM::Package::Python
-      self.dependencies = self.dependencies.select do |dep|
-        name, op, version = dep.split(/\s+/)
-        dep_ok = true
-        if op == '!='
-          self.conflicts << "#{name} = #{version}"
-          dep_ok = false
-        end
-        dep_ok
+    self.dependencies = self.dependencies.select do |dep|
+      name, op, version = dep.split(/\s+/)
+      dep_ok = true
+      if op == '!='
+        self.conflicts << "#{name} = #{version}"
+        dep_ok = false
       end
+      dep_ok
     end
 
     # Convert any dashes in version strings to underscores.


### PR DESCRIPTION
Convert all != dependencies to Conflicts for rpm packages.
