### PR TITLE
Fixed an error showed by puppet if the EMPTY file is very large

### DIFF
--- a/test/vagrant.pp
+++ b/test/vagrant.pp
@@ -18,7 +18,7 @@ exec {
 
 file {
   # Sometimes veewee leaves behind this...
-  "/EMPTY": ensure => absent;
+  "/EMPTY": ensure => absent, backup => false;
 }
 
 package {


### PR DESCRIPTION
Got this error in the debian6 machine after running 'vagrant up':
Error: /Stage[main]//File[/EMPTY]: Could not evaluate: Puppet::Util::Log requires a message

When the EMPTY file is very large, puppet uses a lot of memory deleting the file, and if the file is too large it crashes.

The size of the EMPTY file in the debian6 box:
$ du -sh /EMPTY
7.8G    /EMPTY

Added the backup=>false option.
