### PR TITLE
Do no generate empty prefix

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -29,7 +29,7 @@ AutoReqProv: no
 BuildRoot: %buildroot
 # Add prefix, must not end with /
 <% if !prefix.nil? and !prefix.empty? %>
-Prefix: <%= prefix.gsub(/\/$/, '') %>
+Prefix: <%= prefix.gsub(/([^\/]+)(\/$)/, '') %>
 <% end -%>
 
 Group: <%= category %>


### PR DESCRIPTION
Introduced by #414, generates empty prefix if prefix is `/`.
