### PR TITLE
#258 Make root/root as owner of control files

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -432,7 +432,7 @@ class FPM::Package::Deb < FPM::Package
     # Make the control.tar.gz
     with(build_path("control.tar.gz")) do |controltar|
       @logger.info("Creating", :path => controltar, :from => control_path)
-      safesystem(tar_cmd, "--numeric-owner", "--owner=0", "--group=0", "-zcf",
+      safesystem(tar_cmd, "--owner=root", "--group=root", "-zcf",
                  controltar, "-C", control_path, ".")
     end
 


### PR DESCRIPTION
Resolve the following lintian errors

```
control-file-has-bad-owner md5sums 0/0 != root/root
control-file-has-bad-owner postinst 0/0 != root/root
control-file-has-bad-owner prerm 0/0 != root/root
```

http://lintian.debian.org/tags/control-file-has-bad-owner.html
