### PR TITLE
Make debian control tarball use owner and group arguments.

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -324,6 +324,8 @@ class FPM::Package::Deb < FPM::Package
       tar_flags += [ "--group", attributes[:deb_group] ]
     end
 
+    write_control_tarball(tar_flags)
+
     if attributes[:deb_changelog]
       dest_changelog = File.join(staging_path, "usr/share/doc/#{attributes[:name]}/changelog.Debian")
       FileUtils.mkdir_p(File.dirname(dest_changelog))
@@ -425,7 +427,7 @@ class FPM::Package::Deb < FPM::Package
     end
   end # def control_path
 
-  def write_control_tarball
+  def write_control_tarball(tar_flags=[])
     # Use custom Debian control file when given ...
     write_control # write the control file
     write_shlibs # write optional shlibs file
@@ -437,8 +439,9 @@ class FPM::Package::Deb < FPM::Package
     # Make the control.tar.gz
     with(build_path("control.tar.gz")) do |controltar|
       @logger.info("Creating", :path => controltar, :from => control_path)
-      safesystem(tar_cmd, "--owner=root", "--group=root", "-zcf",
-                 controltar, "-C", control_path, ".")
+
+      args = [ tar_cmd, "-C", control_path, "-z" ] + tar_flags + [ "-cf", controltar, "." ]
+      safesystem(*args)
     end
 
     @logger.debug("Removing no longer needed control dir", :path => control_path)


### PR DESCRIPTION
Hardcoding --group=root in tar command breaks on OSX.

Fixes issue #429.
