### PR TITLE
make channel-discover optional for custom channels

### DIFF
--- a/lib/fpm/package/pear.rb
+++ b/lib/fpm/package/pear.rb
@@ -56,10 +56,22 @@ class FPM::Package::PEAR < FPM::Package
     @logger.info("Setting php_bin", :php_bin => php_bin)
     safesystem("pear", "-c", config, "config-set", "php_bin", php_bin)
 
-    # try channel-discover
+    # do channel-discover if required
     if !attributes[:pear_channel].nil?
       @logger.info("Custom channel specified", :channel => attributes[:pear_channel])
-      safesystem("pear", "-c", config, "channel-discover", attributes[:pear_channel])
+      pear_lc_cmd = "pear -c #{config} list-channels"
+      pear_lc_fd = IO.popen(pear_lc_cmd)
+      pear_lc_out = pear_lc_fd.read()
+      pid, status = Process.waitpid2(pear_lc_fd.pid)
+      if !status.success?
+        raise FPM::Util::ProcessFailed.new("#{pear_ls_cmd.first} failed (exit " \
+                                         "code #{status.exitstatus}). " \
+                                         "Full command was: #{pear_ls_cmd.inspect}")
+      end
+      if !pear_lc_out =~ /#{Regexp.quote(attributes[:pear_channel])}/
+        @logger.info("Discovering new channel", :channel => attributes[:pear_channel])
+        safesystem("pear", "-c", config, "channel-discover", attributes[:pear_channel])
+      end
       input_package = "#{attributes[:pear_channel]}/#{input_package}"
       @logger.info("Prefixing package name with channel", :package => input_package)
     end


### PR DESCRIPTION
Should fix #437 but I feel it's a bit dirty and lacks any unit tests (along with the rest of the PEAR stuff really.) I based the change on the way the NPM packager works although I handled popen differently as I need it to work in Ruby 1.8.7 for various reasons. Should still be solid and testing hasn't shown any problems.
