### PR TITLE
Provide support for LIB and --install_path

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -109,27 +109,26 @@ class FPM::Package::CPAN < FPM::Package
       # Try Makefile.PL, Build.PL
       #
       if File.exists?("Makefile.PL")
-	if attributes[:cpan_perl_lib_path]	
-	  perl_lib_path = attributes[:cpan_perl_lib_path]
+        if attributes[:cpan_perl_lib_path]	
+	        perl_lib_path = attributes[:cpan_perl_lib_path]
           safesystem(attributes[:cpan_perl_bin],
                      "-Mlocal::lib=#{build_path("cpan")}",
                      "Makefile.PL",
                      "PREFIX=#{prefix}",
-		     "LIB=#{perl_lib_path}",
+		                 "LIB=#{perl_lib_path}",
                      # Empty install_base to avoid local::lib being used.
                      "INSTALL_BASE=")
-	else 
-	  safesystem(attributes[:cpan_perl_bin],
-	    "-Mlocal::lib=#{build_path("cpan")}",
-	    "Makefile.PL",
-	    "PREFIX=#{prefix}",
-	    # Empty install_base to avoid local::lib being used.
-	    "INSTALL_BASE=")
-	end
+	      else 
+	        safesystem(attributes[:cpan_perl_bin],
+	                   "-Mlocal::lib=#{build_path("cpan")}",
+	                   "Makefile.PL",
+	                   "PREFIX=#{prefix}",
+	                   # Empty install_base to avoid local::lib being used.
+	                   "INSTALL_BASE=")
+	      end
         make = [ "make" ]
         safesystem(*make)
         safesystem(*(make + ["test"])) if attributes[:cpan_test?]
-	safesystem(*(make + ["DESTDIR=#{staging_path}", "install"]))
         safesystem(*(make + ["DESTDIR=#{staging_path}", "install"]))
       elsif File.exists?("Build.PL")
         # Module::Build is in use here; different actions required.
@@ -141,11 +140,11 @@ class FPM::Package::CPAN < FPM::Package
         if attributes[:cpan_test?]
           safesystem("./Build", "test")
         end
-	if attributes[:cpan_perl_lib_path]
-	  perl_lib_path = attributes[:cpan_perl_lib_path]
-	  safesystem("./Build install --install_path lib=#{perl_lib_path} \
-		     --destdir #{staging_path} --prefix #{prefix} --destdir #{staging_path}")
-	else
+	      if attributes[:cpan_perl_lib_path]
+	        perl_lib_path = attributes[:cpan_perl_lib_path]
+	        safesystem("./Build install --install_path lib=#{perl_lib_path} \
+		                 --destdir #{staging_path} --prefix #{prefix} --destdir #{staging_path}")
+	      else
        	  safesystem("./Build", "install",
                      "--prefix", prefix, "--destdir", staging_path,
                      # Empty install_base to avoid local::lib being used.


### PR DESCRIPTION
MakeMaker and Module::Build can use LIB and --install_path to specify installation targets. This patch provides support for allowing general library paths (/usr/share/perl5/ for example), instead of the build machines perl lib path.
