### PR TITLE
Relax dependency on Clamp.

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
 
   # For command-line flag support
   # https://github.com/mdub/clamp/blob/master/README.markdown
-  spec.add_dependency("clamp", "0.6.0") # license: MIT
+  spec.add_dependency("clamp", "~> 0.6") # license: MIT
 
   # For starting external processes across various ruby interpreters
   spec.add_dependency("childprocess") # license: ???


### PR DESCRIPTION
When I upgraded fpm, it locked my bundle to clamp-0.6.0. 

This patch relaxes the dependency, so other gems using Clamp can be more easily mixed with fpm.
