### PR TITLE
Add support for setting build-depends on debian targets

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -28,6 +28,12 @@ class FPM::Package::Deb < FPM::Package
             "version. Default is to be specific. This option allows the same " \
             "version of a package but any iteration is permitted"
 
+  option "--build-depends", "DEPENDENCY",
+    "Add DEPENDENCY as a Build-Depends" do |dep|
+    @build_depends ||= []
+    @build_depends << dep
+  end
+
   option "--pre-depends", "DEPENDENCY",
     "Add DEPENDENCY as a Pre-Depends" do |dep|
     @pre_depends ||= []

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -125,6 +125,11 @@ describe FPM::Package::Deb do
       @original.conflicts = ["foo < 123"]
       @original.attributes[:deb_breaks] = ["baz < 123"]
 
+      @original.attributes[:deb_build_depends_given?] = true
+      @original.attributes[:deb_build_depends] ||= []
+      @original.attributes[:deb_build_depends] << 'something-else > 0.0.0'
+      @original.attributes[:deb_build_depends] << 'something-else < 1.0.0'
+
       @original.attributes[:deb_priority] = "fizzle"
       @original.attributes[:deb_field_given?] = true
       @original.attributes[:deb_field] = { "foo" => "bar" }
@@ -189,6 +194,10 @@ describe FPM::Package::Deb do
       it "should have the correct dependency list" do
         # 'something > 10' should convert to 'something (>> 10)', etc.
         insist { dpkg_field("Depends") } == "something (>> 10), hello (>= 20)"
+      end
+
+      it "should have the correct build dependency list" do
+        insist { dpkg_field("Build-Depends") } == "something-else (>> 0.0.0), something-else (<< 1.0.0)"
       end
 
       it "should have a custom field 'foo: bar'" do

--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -17,6 +17,9 @@ Breaks: <%= attributes[:deb_breaks].collect { |d| fix_dependency(d) }.flatten.jo
 <% if attributes[:deb_pre_depends_given?] -%>
 Pre-Depends: <%= attributes[:deb_pre_depends].collect { |d| fix_dependency(d) }.flatten.join(", ") %>
 <% end -%>
+<% if attributes[:deb_build_depends_given?] -%>
+Build-Depends: <%= attributes[:deb_build_depends].collect { |d| fix_dependency(d) }.flatten.join(", ") %>
+<% end -%>
 <% if !provides.empty? -%>
 <%# Turn each provides from 'foo = 123' to simply 'foo' because Debian :\ -%>
 <%#  http://www.debian.org/doc/debian-policy/ch-relationships.html -%>


### PR DESCRIPTION
While at first this may seem like a silly flag for FPM to have, I'd like to propose a use-case:

For a company that does a lot of automated packaging via FPM through something like Jenkins, this parameter can be used to guide the bulid server re: what packages are needed to be able to generate the specified package.
