### PR TITLE
python and debian disagree on the equality operator

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -200,6 +200,7 @@ class FPM::Package::Python < FPM::Package
           raise FPM::InvalidPackageConfiguration, "Invalid dependency '#{dep}'"
         end
         name, cmp, version = match.captures
+        cmp = '=' if cmp == '=='
         # dependency name prefixing is optional, if enabled, a name 'foo' will
         # become 'python-foo' (depending on what the python_package_name_prefix
         # is)


### PR DESCRIPTION
The way the initial regexp would catch the equality operator in requirements.txt would keep cmd at `==` and forward that in the dependency declaration in the output debian package which would generate broken packages.

Attached is a one-liner to unbreak that behavior.

Cheers !
