### PR TITLE
The npm tries to read from a variable that never really gets sent

### DIFF
--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -80,6 +80,8 @@ module FPM::Util
 
     process.start
     stdout_w.close; stderr_w.close
+    stdout_r_str = stdout_r.read
+    stdout_r.close; stderr_r.close
     @logger.debug("Process is running", :pid => process.pid)
 
     process.wait
@@ -90,7 +92,7 @@ module FPM::Util
                               ". Full command was:#{args.inspect}")
     end
 
-    return :stdout_r
+    return stdout_r_str
   end # def safesystemout
 
   # Get the recommended 'tar' command for this platform.


### PR DESCRIPTION
This patch makes the safesystemout function return the output instead of a symbol which didnt resolve to anything.
