### PR TITLE
Fixing some data issues with npm

### DIFF
--- a/lib/fpm/package/npm.rb
+++ b/lib/fpm/package/npm.rb
@@ -56,7 +56,7 @@ class FPM::Package::NPM < FPM::Package
     # Query details about our now-installed package.
     # We do this by using 'npm ls' with json + long enabled to query details
     # about the installed package.
-    npm_ls_out = safesystemout(attributes[:npm_bin], "ls", "--json", "--long", package, *npm_flags)
+    npm_ls_out = safesystemout(attributes[:npm_bin], "ls", "--json", "--long", *npm_flags)
     npm_ls = JSON.parse(npm_ls_out)
     name, info = npm_ls["dependencies"].first
 


### PR DESCRIPTION
Fixes #457 (I think)

npm allows authors to remain partially anonymous and not use email addresses so I'm checking for that case and using a default of unknown@unknown.unknown in that event.

Bug #457 seems to point to an issue with version not being set, this is a problem I can only imagine happening if you were trying to build rpm's for something locally packaged (maybe slightly incorrectly).
