### PR TITLE
python: handle == dependency requirement correctly

### DIFF
--- a/lib/fpm/package/pyfpm/get_metadata.py
+++ b/lib/fpm/package/pyfpm/get_metadata.py
@@ -35,13 +35,8 @@ class get_metadata(Command):
         deps = []
         if dep.specs:
             for operator, version in dep.specs:
-                final_operator = operator
-
-                if operator == "==":
-                    final_operator = "="
-
                 deps.append("%s %s %s" % (dep.project_name,
-                    final_operator, version))
+                        operator, version))
         else:
             deps.append(dep.project_name)
 

--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -200,6 +200,13 @@ class FPM::Package::Python < FPM::Package
           raise FPM::InvalidPackageConfiguration, "Invalid dependency '#{dep}'"
         end
         name, cmp, version = match.captures
+
+        # convert == to =
+        if cmp == "=="
+          @logger.info("Converting == dependency requirement to =", :dependency => dep )
+          cmp = "="
+        end
+
         # dependency name prefixing is optional, if enabled, a name 'foo' will
         # become 'python-foo' (depending on what the python_package_name_prefix
         # is)

--- a/spec/fixtures/python/requirements.txt
+++ b/spec/fixtures/python/requirements.txt
@@ -1,0 +1,2 @@
+rtxt-dep1 > 0.1
+rtxt-dep2 == 0.1

--- a/spec/fpm/package/python_spec.rb
+++ b/spec/fpm/package/python_spec.rb
@@ -69,4 +69,16 @@ describe FPM::Package::Python, :if => python_usable? do
       end
     end
   end
+
+  context "when python_obey_requirements_txt? is true" do
+    before :each do
+      subject.attributes[:python_obey_requirements_txt?] = true
+      subject.attributes[:python_dependencies?] = true
+    end
+
+    it "it should load requirements.txt" do
+      subject.input(example_dir)
+      insist { subject.dependencies.sort } == ["rtxt-dep1 > 0.1", "rtxt-dep2 = 0.1"]
+     end
+  end
 end # describe FPM::Package::Python


### PR DESCRIPTION
Rework of PR #452. Added test for this and moved == to = conversion from pyfpm to package/python.rb.
