### PR TITLE
Fix for file stat when using -rpm-use-file-permissions

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -132,7 +132,7 @@ class FPM::Package::RPM < FPM::Package
     file = rpm_fix_name(file)
     return file unless attributes[:rpm_use_file_permissions?]
 
-    stat = File.stat( file.gsub(/\"/, '') )
+    stat = File.stat(file.gsub(/\"/, '').sub(/^\//,''))
     user = Etc.getpwuid(stat.uid).name
     group = Etc.getgrgid(stat.gid).name
     mode = stat.mode


### PR DESCRIPTION
Strip leading slash from file pathname before call to stat.
Otherwise the correct file permissions will not be calculated.
