### PR TITLE
Pear: custom data dir

### DIFF
--- a/lib/fpm/package/pear.rb
+++ b/lib/fpm/package/pear.rb
@@ -103,8 +103,12 @@ class FPM::Package::PEAR < FPM::Package
     Find.find(staging_path) do |path|
       if File.file?(path)
         @logger.info("replacing staging_path in file", :replace_in => path, :staging_path => staging_path)
-        content = File.read(path).gsub(/#{Regexp.escape(staging_path)}/, "")
-        File.write(path, content)
+        begin
+          content = File.read(path).gsub(/#{Regexp.escape(staging_path)}/, "")
+          File.write(path, content)
+        rescue ArgumentError
+          @logger.warn("error replacing staging_path in file", :replace_in => path)
+        end
       end
       FileUtils.rm_r(path) if delete_these.include?(File.basename(path))
     end


### PR DESCRIPTION
Debian has the data dir set php/data instead of just data, you can handle it with this option. I've also fixed a bug in the custom channel discovery, and made the staging path replacement broader, because some packages rely on it like PHP_PMD.
