### PR TITLE
Allow JSON 1.8 to be used with FPM

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   # For parsing JSON (required for some Python support, etc)
   # http://flori.github.com/json/doc/index.html
-  spec.add_dependency("json", "~> 1.7.7") # license: Ruby License
+  spec.add_dependency("json", ">= 1.7.7") # license: Ruby License
   
   # For logging
   # https://github.com/jordansissel/ruby-cabin


### PR DESCRIPTION
We have JSON 1.8 on some of our build servers (installed via a Debian package generated with fpm, of course!) - it'd be great if these could run fpm without a secondary JSON version installed. I know long-term support for this is an omnibus package, but it sure would be nice if I could stop deploying this patch manually :)
