### PR TITLE
Use the proper gemdir setting when --gem-gem is specified

### DIFF
--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -163,7 +163,7 @@ class FPM::Package::Gem < FPM::Package
     if attributes.include?(:prefix) && ! attributes[:prefix].nil?
       installdir = "#{staging_path}/#{attributes[:prefix]}"
     else
-      gemdir = safesystemout("#{attributes[:gem_gem]} env gemdir").chomp
+      gemdir = safesystemout(*[attributes[:gem_gem], 'env', 'gemdir']).chomp
       installdir = File.join(staging_path, gemdir)
     end
 
@@ -176,10 +176,13 @@ class FPM::Package::Gem < FPM::Package
     end
     if attributes[:gem_bin_path]
       bin_path = File.join(staging_path, attributes[:gem_bin_path])
-      args += ["--bindir", bin_path]
-      ::FileUtils.mkdir_p(bin_path)
+    else
+      gem_env  = safesystemout(*[attributes[:gem_gem], 'env']).split("\n")
+      bin_path = gem_env.select{ |line| line =~ /EXECUTABLE DIRECTORY/ }.first.split(': ').last
     end
 
+    args += ["--bindir", bin_path]
+    ::FileUtils.mkdir_p(bin_path)
     args << gem_path
     safesystem(*args)
   end # def install_to_staging


### PR DESCRIPTION
This allows an FPM installed under one ruby to package things for a different ruby. I'm in the middle of upgrading our build infrastructure to ruby 2, and this would greatly alleviate some chicken and egg problems we're having.
