### PR TITLE
Add init-y configuration options for Debian packages

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -112,6 +112,14 @@ class FPM::Package::Deb < FPM::Package
     File.expand_path(file)
   end
 
+  option "--default", "FILEPATH", "Add FILEPATH as /etc/default configuration" do |file|
+    File.expand_path(file)
+  end
+
+  option "--upstart", "FILEPATH", "Add FILEPATH as an upstart script" do |file|
+    File.expand_path(file)
+  end
+
   def initialize(*args)
     super(*args)
     attributes[:deb_priority] = "extra"
@@ -352,6 +360,20 @@ class FPM::Package::Deb < FPM::Package
       FileUtils.mkdir_p(File.dirname(dest_init))
       FileUtils.cp attributes[:deb_init], dest_init
       File.chmod(0755, dest_init)
+    end
+
+    if attributes[:deb_default]
+      dest_default = File.join(staging_path, "etc/default/#{attributes[:name]}")
+      FileUtils.mkdir_p(File.dirname(dest_default))
+      FileUtils.cp attributes[:deb_default], dest_default
+      File.chmod(0644, dest_default)
+    end
+
+    if attributes[:deb_upstart]
+      dest_upstart = File.join(staging_path, "etc/init/#{attributes[:name]}.conf")
+      FileUtils.mkdir_p(File.dirname(dest_upstart))
+      FileUtils.cp attributes[:deb_upstart], dest_upstart
+      File.chmod(0644, dest_upstart)
     end
 
     args = [ tar_cmd, "-C", staging_path, compression ] + tar_flags + [ "-cf", datatar, "." ]


### PR DESCRIPTION
`--deb-init FILEPATH` will put that file into `/etc/init.d/$name`; similarly for `--deb-default` and `/etc/default/$name`, and, for Ubuntu users, `--deb-upstart` and `/etc/init/$name.conf`
