### PR TITLE
Make exclusion work in a more obvious manner.

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -365,14 +365,14 @@ class FPM::Package
       installdir = staging_path
     end
 
-    Find.find(staging_path) do |path|
-      match_path = path.sub("#{staging_path}/", '')
+    Find.find(installdir) do |path|
+      match_path = path.sub("#{installdir}/", '')
 
       attributes[:excludes].each do |wildcard|
-        @logger.debug("Checking path against wildcard", :path => path, :wildcard => wildcard)
+        @logger.debug("Checking path against wildcard", :path => match_path, :wildcard => wildcard)
 
         if File.fnmatch(wildcard, match_path)
-          @logger.info("Removing excluded path", :path => path, :matches => wildcard)
+          @logger.info("Removing excluded path", :path => match_path, :matches => wildcard)
           FileUtils.remove_entry_secure(path)
           Find.prune
           break


### PR DESCRIPTION
By comparing against installdir instead of staging_path we can write
exclusions as working against the top level of the source directory,
without requiring reproducing the prefix.

Also log the actual matched path rather than the full path, for
clarity.

(I tried to run make test but it failed with a 'cannot find test/all.rb' - is there a better option?)

Sample output before and after:

Before

```
Checking path against wildcard {:path=>"/tmp/package-dir-staging20130718-22367-11sjvsh", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Checking path against wildcard {:path=>"/tmp/package-dir-staging20130718-22367-11sjvsh/opt", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Checking path against wildcard {:path=>"/tmp/package-dir-staging20130718-22367-11sjvsh/opt/footballradar", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Checking path against wildcard {:path=>"/tmp/package-dir-staging20130718-22367-11sjvsh/opt/footballradar/xxx", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Checking path against wildcard {:path=>"/tmp/package-dir-staging20130718-22367-11sjvsh/opt/footballradar/xxx/.git", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Checking path against wildcard {:path=>"/tmp/package-dir-staging20130718-22367-11sjvsh/opt/footballradar/xxx/.git/COMMIT_EDITMSG", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
...
Cleaning up staging path {:path=>"/tmp/package-deb-staging20130718-22367-1pih3m", :level=>:debug, :file=>"fpm/package.rb", :line=>"273"}
```

After

```
Checking path against wildcard {:path=>"/tmp/package-dir-staging20130718-21891-1ibltbo/opt/footballradar/xxx", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Checking path against wildcard {:path=>".git", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Removing excluded path {:path=>".git", :matches=>".git", :level=>:info, :file=>"fpm/package.rb", :line=>"375"}
Checking path against wildcard {:path=>"README.md", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Checking path against wildcard {:path=>"libinit", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Checking path against wildcard {:path=>"scripts", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Checking path against wildcard {:path=>"scripts/package", :wildcard=>".git", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
Cleaning up staging path {:path=>"/tmp/package-deb-staging20130718-21891-g7ygb5", :level=>:debug, :file=>"fpm/package.rb", :line=>"273"}
```

As you can see, there is no 'Removing excluded path' line in the current (0.4.41) version.
