### PR TITLE
General Perl fixes

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -259,7 +259,10 @@ class FPM::Package::CPAN < FPM::Package
   end # def metadata
 
   def fix_name(name)
-    return [attributes[:cpan_package_name_prefix], name].join("-").gsub("::", "-")
+    case name
+      when "perl"; return "perl"
+      else; return [attributes[:cpan_package_name_prefix], name].join("-").gsub("::", "-")
+    end
   end # def fix_name
 
   def httpfetch(url)


### PR DESCRIPTION
Unbreak the proxy being used outside the scope of its declaration, resolves #488 and fixes bug introduced by #491.
Fix the case where Perl as a dependency is listed as perl-perl, or potentially in Debian as libperl-perl depending on what happens with prefix stuff. Resolves unrelated question brought up in #510.
