### PR TITLE
fix rspec deprecation warnings

### DIFF
--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -64,7 +64,7 @@ describe FPM::Package::RPM do
 
   describe "#templating" do
     context "default user and group" do
-      before :all do
+      before :each do
         FileUtils.mkdir_p(subject.staging_path(File.dirname(__FILE__)))
         FileUtils.cp(__FILE__, subject.staging_path(__FILE__))
 
@@ -75,7 +75,7 @@ describe FPM::Package::RPM do
         subject.render_template
       end
 
-      after :all do
+      after :each do
         subject.cleanup
       end
 
@@ -85,7 +85,7 @@ describe FPM::Package::RPM do
     end # context
 
     context "non-default user and group" do
-      before :all do
+      before :each do
         subject.attributes[:rpm_user] = "some_user"
         subject.attributes[:rpm_group] = "some_group"
 
@@ -99,7 +99,7 @@ describe FPM::Package::RPM do
         subject.render_template
       end
 
-      after :all do
+      after :each do
         subject.cleanup
       end
 
@@ -111,7 +111,7 @@ describe FPM::Package::RPM do
 
   describe "#output", :if => program_in_path?("rpmbuild") do
     context "package attributes" do
-      before :all do
+      before :each do
         @target = Tempfile.new("fpm-test-rpm").path
         File.delete(@target)
         subject.name = "name"
@@ -144,12 +144,12 @@ describe FPM::Package::RPM do
         @rpm.header.tags.each do |tag|
           @rpmtags[tag.tag] = tag.value
         end
-      end # before :all
+      end # before :each
 
-      after :all do
+      after :each do
         subject.cleanup
         File.delete(@target)
-      end # after :all
+      end # after :each
 
       it "should have the correct name" do
         insist { @rpmtags[:name] } == subject.name
@@ -241,7 +241,7 @@ describe FPM::Package::RPM do
     end # package attributes
 
     context "package default attributes" do
-      before :all do
+      before :each do
         @target = Tempfile.new("fpm-test-rpm").path
         File.delete(@target)
         subject.name = "name"
@@ -256,12 +256,12 @@ describe FPM::Package::RPM do
         @rpm.header.tags.each do |tag|
           @rpmtags[tag.tag] = tag.value
         end
-      end # before :all
+      end # before :each
 
-      after :all do
+      after :each do
         subject.cleanup
         File.delete(@target)
-      end # after :all
+      end # after :each
 
       it "should have the correct name" do
         insist { @rpmtags[:name] } == subject.name
@@ -383,7 +383,7 @@ describe FPM::Package::RPM do
 
   describe "#output with digest and compression settings", :if => program_in_path?("rpmbuild") do
     context "bzip2/sha1" do
-      before :all do
+      before :each do
         @target = Tempfile.new("fpm-test-rpm").path
         File.delete(@target)
         subject.name = "name"
@@ -406,7 +406,7 @@ describe FPM::Package::RPM do
         end
       end
 
-      after :all do
+      after :each do
         subject.cleanup
         File.delete(@target)
       end # after


### PR DESCRIPTION
RSpec throws a bunch of warnings for not using :all with a specific subject. Swapped out :all for :each, tested, no ill effects as discussed on IRC.
