### PR TITLE
rpm: add fifo support

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -116,6 +116,8 @@ Obsoletes: <%= repl %>
 ln -s <%= File.readlink(source) %> <%= target_safe %>
 <%   elsif st.directory? -%>
 mkdir <%= target_safe %>
+<%   elsif File.ftype(source) == 'fifo' -%>
+mkfifo <%= target_safe %>
 <%   else -%>
 cp <%= source_safe %> <%= target_safe %>
 <%   end -%>


### PR DESCRIPTION
https://github.com/jordansissel/fpm/pull/511 added FIFO support to fpm, but not the RPM template. 

This allows RPMs to contain named pipes.
