### PR TITLE
Fix gem command conflict with specific_install

### DIFF
--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -89,7 +89,7 @@ class FPM::Package::Gem < FPM::Package
 
   def load_package_info(gem_path)
 
-    spec = YAML.load(%x{#{attributes[:gem_gem]} spec #{gem_path} --yaml})
+    spec = YAML.load(%x{#{attributes[:gem_gem]} specification #{gem_path} --yaml})
 
     if !attributes[:gem_package_prefix].nil?
       attributes[:gem_package_name_prefix] = attributes[:gem_package_prefix]


### PR DESCRIPTION
When specific_install is installed, calling "gem spec" is ambiguous and
fails.  Call it with the full name "gem specification" instead to avoid
that.
