### PR TITLE
Now raises an FPM error for missing source dir

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -408,6 +408,9 @@ class FPM::Command < Clamp::Command
   rescue FPM::Util::ProcessFailed => e
     @logger.error("Process failed: #{e}")
     return 1
+  rescue FPM::Package::SourceDirectoryMissing => e
+    @logger.fatal(e.message)
+    return 1
   ensure
     input.cleanup unless input.nil?
     output.cleanup unless output.nil?

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -34,6 +34,14 @@ class FPM::Package
     end # def to_s
   end # class ParentDirectoryMissing
 
+  # This class is raised when you try to clone from a directory
+  # that does not exist
+  class SourceDirectoryMissing < StandardError
+    def to_s
+      return "Source directory does not exist: #{super}"
+    end # def to_s
+  end # class SourceDirectoryMissing
+
   # The name of this package
   attr_accessor :name
 
@@ -499,6 +507,12 @@ class FPM::Package
       end
     end
   end # def output_path
+
+  def clone_check(source_path)
+    if !File.directory?(source_path)
+      raise SourceDirectoryMissing.new(source_path)
+    end
+  end # def input_check
 
   def provides=(value)
     if !value.is_a?(Array)

--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -106,6 +106,9 @@ class FPM::Package::Dir < FPM::Package
   # The above will copy, recursively, /tmp/hello/world into
   # /tmp/example/hello/world
   def clone(source, destination)
+    @logger.debug("Checking Source Exists", :source => source)
+    clone_check(source)
+
     @logger.debug("Cloning path", :source => source, :destination => destination)
     # For single file copies, permit file destinations
     if File.file?(source) && !File.directory?(destination) 


### PR DESCRIPTION
Current behaviour:

``` bash
$ fpm -s dir -t deb -n foo -a all -v 0.1 --prefix /opt /fakesourcedir
/opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/find.rb:38:in `block in find': No such file or directory (Errno::ENOENT)
    from /opt/boxen/rbenv/versions/1.9.3-p448/lib/ruby/1.9.1/find.rb:38:in `collect!'
#etc. etc.
```

New behaviour:

``` bash
$ fpm -s dir -t deb -n foo -a all -v 0.1 --prefix /opt /fakesourcedir
Source directory does not exist: /fakesourcedir {:level=>:fatal}
```

However, I'm having difficulty with the specs, I'm not sure how to fix the ones I've broken and how to add one for this specific case? Help on that would be appreciated! 

@jordansissel any thoughts? :+1: 
