### PR TITLE
Make the namespacing used for --deb-changelog consistent with other fields

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -356,7 +356,7 @@ class FPM::Package::Deb < FPM::Package
     end
 
     if attributes[:deb_changelog]
-      dest_changelog = File.join(staging_path, "usr/share/doc/#{attributes[:name]}/changelog.Debian")
+      dest_changelog = File.join(staging_path, "usr/share/doc/#{name}/changelog.Debian")
       FileUtils.mkdir_p(File.dirname(dest_changelog))
       FileUtils.cp attributes[:deb_changelog], dest_changelog
       File.chmod(0644, dest_changelog)


### PR DESCRIPTION
Fixes #543
