### PR TITLE
Bugfix: filenames w/ special characters and permissions

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -134,14 +134,18 @@ class FPM::Package::RPM < FPM::Package
   end
 
   def rpm_file_entry(file)
+    original_file = file
     file = rpm_fix_name(file)
     return file unless attributes[:rpm_use_file_permissions?]
 
-    stat = File.stat(file.gsub(/\"/, '').sub(/^\//,''))
-    user = Etc.getpwuid(stat.uid).name
-    group = Etc.getgrgid(stat.gid).name
-    mode = stat.mode
-    return sprintf("%%attr(%o, %s, %s) %s\n", mode & 4095 , user, group, file)
+    # Stat the original filename in the relative staging path
+    ::Dir.chdir(staging_path) do
+      stat = File.stat(original_file.gsub(/\"/, '').sub(/^\//,''))
+      user = Etc.getpwuid(stat.uid).name
+      group = Etc.getgrgid(stat.gid).name
+      mode = stat.mode
+      return sprintf("%%attr(%o, %s, %s) %s\n", mode & 4095 , user, group, file)
+    end
   end
 
 

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -335,6 +335,18 @@ describe FPM::Package::RPM do
       insist { rpm.files } == [ "/example/%name%" ]
     end
 
+    it "should escape '%' characters in filenames while preserving permissions" do
+      Dir.mkdir(subject.staging_path("/example"))
+      File.write(subject.staging_path("/example/%name%"), "Hello")
+      File.chmod(01777,subject.staging_path("/example/%name%"))
+      subject.attributes[:rpm_use_file_permissions?] = true
+      subject.output(@target)
+
+      rpm = ::RPM::File.new(@target)
+      insist { rpm.files } == [ "/example/%name%" ]
+      insist { `rpm -qlv -p #{@target}`.chomp.split.first } == "-rwxrwxrwt"
+    end
+
     it "should permit spaces in filenames (issue #164)" do
       File.write(subject.staging_path("file with space"), "Hello")
 


### PR DESCRIPTION
Filenames containing special characters like '%' won't stat correctly because they've already been sanitized and the current working directory could potentially be off.

I've added a test case for this but it's kind of gross. I didn't see a way to get at file permissions from the RPM object, but maybe I'm just missing something. Feedback on making it cleaner would be appreciated :-)
