### PR TITLE
Fix --rpm-use-permissions stat call

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -134,14 +134,15 @@ class FPM::Package::RPM < FPM::Package
   end
 
   def rpm_file_entry(file)
-    file = rpm_fix_name(file)
-    return file unless attributes[:rpm_use_file_permissions?]
+    # We need to keep the original name to stat the file if necessary.
+    fixed_file = rpm_fix_name(file)
+    return fixed_file unless attributes[:rpm_use_file_permissions?]
 
     stat = File.lstat(file.gsub(/\"/, ''))
     user = Etc.getpwuid(stat.uid).name
     group = Etc.getgrgid(stat.gid).name
     mode = stat.mode
-    return sprintf("%%attr(%o, %s, %s) %s\n", mode & 4095 , user, group, file)
+    return sprintf("%%attr(%o, %s, %s) %s\n", mode & 4095 , user, group, fixed_file)
   end
 
 


### PR DESCRIPTION
The stat call in --rpm-use-permissions would remove the leading / from
all files, causing the stat to fail.  Changed the regex to not do that.
Also changed 'stat' to 'lstat', or rpm creation would bomb on broken
symlinks within the directory to package.

There's no rspec included, but I tested the change with lots of rpm
creations.

Also, since directories aren't automatically included, they'll be set to
root:root unless --rpm-auto-add-directories is used.  Perhaps
--rpm-use-permissions should imply that?
