### PR TITLE
Add reference to README.md about Mac OS X packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Targets:
 * solaris
 * tar
 * directories
+* Mac OS X `.pkg` files (`osxpkg`)
 
 ## Need Help or Want to Contribute?
 


### PR DESCRIPTION
Seems silly to have such a useful feature and not advertise it!

A fix to the docs is attached.
