### PR TITLE
remove trailing slash added by --prefix

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -366,7 +366,7 @@ class FPM::Package
     end
 
     Find.find(installdir) do |path|
-      match_path = path.sub("#{installdir}/", '')
+      match_path = path.sub("#{installdir.chomp('/')}/", '')
 
       attributes[:excludes].each do |wildcard|
         @logger.debug("Checking path against wildcard", :path => match_path, :wildcard => wildcard)


### PR DESCRIPTION
Fixes a case where --prefix with a trailing slash (e.g. --prefix /) causes --excludes to not get picked up, for example:

```
Checking path against wildcard {:path=>"/tmp/package-dir-staging20131001-14679-1as4b6o/usr/lib/python2.4/site-packages/freeswitch.py", :wildcard=>"mnt/services/freeswitch/bin/scripts", :installdir=>"/tmp/package-dir-staging20131001-14679-1as4b6o/", :level=>:debug, :file=>"fpm/package.rb", :line=>"372"}
```

Wouldn't exclude the directory that had to be exluded
