### PR TITLE
Fix get_metadata to handle unicode strings

### DIFF
--- a/lib/fpm/package/pyfpm/get_metadata.py
+++ b/lib/fpm/package/pyfpm/get_metadata.py
@@ -1,12 +1,22 @@
-from __future__ import unicode_literals
-
 from distutils.core import Command
 import os
+import sys
 import pkg_resources
 try:
     import json
 except ImportError:
     import simplejson as json
+
+PY3 = sys.version_info[0] == 3
+
+if PY3:
+    def u(s):
+        return s
+else:
+    def u(s):
+        if isinstance(u, unicode):
+            return u
+        return s.decode('utf-8')
 
 
 # Note, the last time I coded python daily was at Google, so it's entirely
@@ -50,9 +60,9 @@ class get_metadata(Command):
         data = {
             "name": self.distribution.get_name(),
             "version": self.distribution.get_version(),
-            "author": "%s <%s>" % (
-                self.distribution.get_author(),
-                self.distribution.get_author_email(),
+            "author": u("%s <%s>") % (
+                u(self.distribution.get_author()),
+                u(self.distribution.get_author_email()),
             ),
             "description": self.distribution.get_description(),
             "license": self.distribution.get_license(),


### PR DESCRIPTION
get_metadata was failing with non-ascii `author` fields on Python 2. This
brings Python 3's unicode behaviour: all strings are unicode without having to
prefix them with `u''`s.

This works with every python version >= 2.6.

To reproduce the issue, run with the current version of fpm (and python 2.X as the default python):

`fpm -s python -t deb django-push`

The `get_metadata` task fails with a `UnicodeDecodeError`. My patch fixes it.
