### PR TITLE
Respect rubygem(package) form with custom gem package name prefix

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -193,6 +193,8 @@ class FPM::Package::RPM < FPM::Package
       # Convert 'rubygem-foo' provides values to 'rubygem(foo)'
       # since that's what most rpm packagers seem to do.
       self.provides = self.provides.collect do |provides|
+        # Tries to match rubygem_prefix [1], gem_name [2] and version [3] if present
+        # and return it in rubygem_prefix(gem_name) form
         if name=/^(#{attributes[:gem_package_name_prefix]})-([^\s]+)\s*(.*)$/.match(provides)
           "#{name[1]}(#{name[2]})#{name[3] ? " #{name[3]}" : ""}"
         else
@@ -200,6 +202,8 @@ class FPM::Package::RPM < FPM::Package
         end
       end
       self.dependencies = self.dependencies.collect do |dependency|
+        # Tries to match rubygem_prefix [1], gem_name [2] and version [3] if present
+        # and return it in rubygem_prefix(gem_name) form
         if name=/^(#{attributes[:gem_package_name_prefix]})-([^\s]+)\s*(.*)$/.match(dependency)
           "#{name[1]}(#{name[2]})#{name[3] ? " #{name[3]}" : ""}"
         else


### PR DESCRIPTION
Hi Jordan,
I'm using fpm (great tool btw!) for packaging **GEMs -> RPMs** with Red Hat Software Collections. The problem is that fpm does not respect the standard format **rubygem(packagename)** for requires/provides, if any other prefix than standard "rubygem" is used for gems naming. This should fix it and keep the bracketed form even when different prefix is used for naming, like `--gem-package-name-prefix ruby193-rubygem` for Red Hat SCLs.

Cheers .st
