### PR TITLE
Correct permissions for `md5sums`.

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -626,6 +626,7 @@ class FPM::Package::Deb < FPM::Package
           out.puts "#{md5} #{path}"
         end
       end
+      File.chmod(0644, control_path("md5sums"))
     end
   end # def write_md5sums
 


### PR DESCRIPTION
According to `lintian` the file `md5sums` should have the permissions 0644. Without this patch the following is returned from a `lintian` run:

``` sh
E: PACKAGE_NAME: control-file-has-bad-permissions md5sums 0664 != 0644
```

More details can be found [here](http://lintian.debian.org/tags/control-file-has-bad-permissions.html) and [here](http://www.debian.org/doc/debian-policy/ch-files.html#s-permissions-owners).
