### PR TITLE
Optionally allow gem dependencies to be installed

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |spec|
   # For creating FreeBSD package archives (xz-compressed tars)
   spec.add_dependency("ruby-xz") # license: MIT
 
-  # For sourcing from pleaserun 
+  # For sourcing from pleaserun
   spec.add_dependency("pleaserun", "~> 0.0.24") # license: Apache 2
 
   spec.add_dependency("stud")

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -267,7 +267,7 @@ class FPM::Package::CPAN < FPM::Package
                       :path => path.gsub(staging_path, ""))
         File.unlink(path)
       end
-      
+
       # Remove useless .packlist files and their empty parent folders
       # https://github.com/jordansissel/fpm/issues/1179
       ::Dir.glob(File.join(staging_path, glob_prefix, "**/.packlist")).each do |path|
@@ -323,7 +323,7 @@ class FPM::Package::CPAN < FPM::Package
     else
       self.version = "#{cpan_version}"
     end
-    
+
     # Search metacpan to get download URL for this version of the module
     metacpan_search_url = "https://fastapi.metacpan.org/v1/release/_search"
     metacpan_search_query = '{"fields":["download_url"],"filter":{"term":{"name":"' + "#{distribution}-#{self.version}" + '"}}}'

--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -44,7 +44,7 @@ class FPM::Package::Gem < FPM::Package
   option "--disable-dependency", "gem_name",
     "The gem name to remove from dependency list",
     :multivalued => true, :attribute_name => :gem_disable_dependencies
-  option "--include-dependencies", :flag, "Should the gem dependencies " \
+  option "--embed-dependencies", :flag, "Should the gem dependencies " \
     "be installed?", :default => false
 
   option "--version-bins", :flag, "Append the version to the bins", :default => false
@@ -162,7 +162,7 @@ class FPM::Package::Gem < FPM::Package
     # composing multiple packages, it's best to explicitly include it in the provides list.
     self.provides << "#{self.name} = #{self.version}"
 
-    if !attributes[:no_auto_depends?] && !attributes[:gem_include_dependencies?]
+    if !attributes[:no_auto_depends?] && !attributes[:gem_embed_dependencies?]
       spec.runtime_dependencies.map do |dep|
         # rubygems 1.3.5 doesn't have 'Gem::Dependency#requirement'
         if dep.respond_to?(:requirement)
@@ -201,7 +201,7 @@ class FPM::Package::Gem < FPM::Package
     args = [attributes[:gem_gem], "install", "--quiet", "--no-ri", "--no-rdoc",
        "--no-user-install", "--install-dir", installdir]
 
-    if !attributes[:gem_include_dependencies?]
+    if !attributes[:gem_embed_dependencies?]
       args += ["--ignore-dependencies"]
     end
 


### PR DESCRIPTION
An option should be provided to include all gem dependencies when creating a package.  This is useful when creating a rubygem debian package that is "all inclusive".  You wouldn't have to create separate debian packages for each gem dependency.
