### PR TITLE
Add --gem-disable-dependencies flag to allow for excluding one or more dependencies

### DIFF
--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -38,6 +38,9 @@ class FPM::Package::Gem < FPM::Package
     "shebang rewritten to use env?", :default => true
 
   option "--prerelease", :flag, "Allow prerelease versions of a gem", :default => false
+  option "--disable-dependencies", "gem_name",
+    "The gem name to remove from dependency list",
+    :multivalued => true, :attribute_name => :gem_disable_dependencies
 
   def input(gem)
     # 'arg'  is the name of the rubygem we should unpack.
@@ -147,6 +150,10 @@ class FPM::Package::Gem < FPM::Package
 
         # Some reqs can be ">= a, < b" versions, let's handle that.
         reqs.to_s.split(/, */).each do |req|
+          if attributes[:gem_disable_dependencies]
+            next if attributes[:gem_disable_dependencies].include?(dep.name)
+          end
+
           if attributes[:gem_fix_dependencies?]
             name = fix_name(dep.name)
           else


### PR DESCRIPTION
I've run into situations where i'm building rpm's of gem's to install into an embedded ruby instance (for example sensu).   The embedded ruby may already include one or more gem's that are dependencies of the gem i'm installing.    So in this situation I would like to be able to pass in '--gem-disable-dependencies <gem_name>' and have the specified gem removed from the auto dependency list.
