### PR TITLE
added lib/fpm/package/pecl.rb - can use pecl.php.net as source for packages

### DIFF
--- a/lib/fpm/package/pecl.rb
+++ b/lib/fpm/package/pecl.rb
@@ -69,8 +69,7 @@ class FPM::Package::PECL < FPM::Package
         # Default directorys for extensions and configs
         ext_dir = safesystemout('php-config', '--extension-dir').chomp
         config_dir = '/tmp/php.d'
-        safesystemout('php-config', '--configure-options')
-        .split(/\s+/).each do |line|
+        safesystemout('php-config', '--configure-options').split(/\s+/).each do |line|
           if line.start_with?('--with-config-file-scan-dir')
             config_dir = line.sub('--with-config-file-scan-dir=', '')
             break


### PR DESCRIPTION
Hi, 

I had added few lines of code - to install PECL extensions from pecl.php.net. Have tested on CentOS6 so far - have managed to create packages for proctitle for example. The code isn't greatest but let me know what do you thing and if this could land into future version of fpm. 

Thanks, Marius.
