### PR TITLE
Fix CPAN download URL problems - correct path and use a mirror if specified

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -273,8 +273,12 @@ class FPM::Package::CPAN < FPM::Package
 
     # should probably be basepathed from the url 
     tarball = File.basename(archive)
+
+    url_base = "http://www.cpan.org/"
+    url_base = "#{attributes[:cpan_mirror]}" if !attributes[:cpan_mirror].nil?
+
     #url = "http://www.cpan.org/CPAN/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{tarball}"
-    url = "http://www.cpan.org/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{archive}"
+    url = "#{url_base}/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{archive}"
     @logger.debug("Fetching perl module", :url => url)
     
     begin


### PR DESCRIPTION
LockFile::Simple wasn't able to be built because it's download URL wasn't compatible with the hard coded format previously used in cpan.rb - it returned a 404. 

I've updated the download function to use another metacpan API call to find the 'archive' string which includes a subdirectory if required. 

I've also updated the URL to use the specified mirror if one is specified. This wasn't done previously. The mirror was previously only used when cpanm pulls dependencies. 

With the patch I've successfully created packages of IO::Event and DBI which were mentioned in the commit where the URL was changed last time (in addition to LockFile::Simple). 
