### PR TITLE
Don't throw an error when --deb-compression=gz is passed.

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -328,7 +328,7 @@ class FPM::Package::Deb < FPM::Package
 
     # Tar up the staging_path into data.tar.{compression type}
     case self.attributes[:deb_compression]
-      when "gzip", nil
+      when "gz", nil
         datatar = build_path("data.tar.gz")
         compression = "-z"
       when "bzip2" 


### PR DESCRIPTION
Previously, when passing `--deb-compression=gz`, you'd get

```
Invalid package configuration: Unknown compression type 'gz' {:level=>:error}
```

And when passing `--deb-compression=gzip`, you'd get

```
ERROR: option '--deb-compression': deb compression value of 'gzip' is invalid. Must be one of gz, bzip2, xz
```

This makes `--deb-compression=gz` work happily.
