### PR TITLE
Fixed default value for --deb-compression.

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -41,7 +41,7 @@ class FPM::Package::Deb < FPM::Package
   end
 
   option "--compression", "COMPRESSION", "The compression type to use, must " \
-    "be one of #{COMPRESSION_TYPES.join(", ")}.", :default => "gzip" do |value|
+    "be one of #{COMPRESSION_TYPES.join(", ")}.", :default => "gz" do |value|
     if !COMPRESSION_TYPES.include?(value)
       raise ArgumentError, "deb compression value of '#{value}' is invalid. " \
         "Must be one of #{COMPRESSION_TYPES.join(", ")}"


### PR DESCRIPTION
Related to #616.  The default value was incorrect which was failing if --deb-compression wasn't provided.
