### PR TITLE
Fix #365 producing huge packages because of hard links

### DIFF
--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -155,7 +155,19 @@ module FPM::Util
     when 'directory'
       FileUtils.mkdir(dst) unless File.exists? dst
     else
-      FileUtils.copy_entry(src, dst)
+      # if the file with the same dev and inode has been copied already -
+      # hard link it's copy to `dst`, otherwise make an actual copy
+      st = File.stat(src)
+      if copied_entry = copied_entries[[st.dev, st.ino]]
+        FileUtils.ln(copied_entry, dst)
+      else
+        FileUtils.copy_entry(src, dst)
+        copied_entries.store([st.dev, st.ino], dst)
+      end
     end
+  end
+
+  def copied_entries
+    @copied_entries ||= {}
   end
 end # module FPM::Util


### PR DESCRIPTION
Following the discussion in #365, here is the implementation of tracking source device and inode numbers to preserve hard links. I was finally able to build git package with fpm :metal:.
