### PR TITLE
rpm: Don't add prefix to absolute paths + don't add prefix to config files

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -301,6 +301,10 @@ class FPM::Package::RPM < FPM::Package
     rpm.extract(staging_path)
   end # def input
 
+  def prefixed_path(path)
+    Pathname.new(path).absolute?() ? path : File.join(self.prefix, path)
+  end # def prefixed_path
+
   def output(output_path)
     output_check(output_path)
     %w(BUILD RPMS SRPMS SOURCES SPECS).each { |d| FileUtils.mkdir_p(build_path(d)) }
@@ -333,7 +337,7 @@ class FPM::Package::RPM < FPM::Package
         end
       end
     else
-      self.directories = self.directories.map { |x| File.join(self.prefix, x) }
+      self.directories = self.directories.map { |x| self.prefixed_path(x) }
       alldirs = []
       self.directories.each do |path|
         Find.find(File.join(staging_path, path)) do |subpath|
@@ -348,14 +352,14 @@ class FPM::Package::RPM < FPM::Package
     # scan all conf file paths for files and add them
     allconfigs = []
     self.config_files.each do |path|
-      cfg_path = File.expand_path(path, staging_path)
+      cfg_path = File.join(staging_path, path)
       Find.find(cfg_path) do |p|
         allconfigs << p.gsub("#{staging_path}/", '') if File.file? p
       end
     end
     allconfigs.sort!.uniq!
 
-    self.config_files = allconfigs.map { |x| File.join(self.prefix, x) }
+    self.config_files = allconfigs.map { |x| File.join("/", x) }
 
     (attributes[:rpm_rpmbuild_define] or []).each do |define|
       args += ["--define", define]
@@ -431,5 +435,5 @@ class FPM::Package::RPM < FPM::Package
 
   public(:input, :output, :converted_from, :architecture, :to_s, :iteration,
          :payload_compression, :digest_algorithm, :prefix, :build_sub_dir,
-         :epoch, :version)
+         :epoch, :version, :prefixed_path)
 end # class FPM::Package::RPM


### PR DESCRIPTION
Now if paths in `--directories' are absolute they treated as absolute,
otherwise they are treated as relative to current prefix.

Config files paths treated always as absolute.  Looks like it was a bug
that they treated as relative to prefix directory.

This should fix issue #632.
