### PR TITLE
Support --python-pypi when using --python-pip

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -121,7 +121,7 @@ class FPM::Package::Python < FPM::Package
                  "--build-directory", target, want_pkg)
     else
       @logger.debug("using pip", :pip => attributes[:python_pip])
-      safesystem(attributes[:python_pip], "install", "--no-install",
+      safesystem(attributes[:python_pip], "install", "--no-install", "-i", attributes[:python_pypi]
                  "-U", "--build", target, want_pkg)
     end
 


### PR DESCRIPTION
Support already existed in easy_install.  This small change passes the python_pypi option to pip via pip's -i / --index-url option.
