### PR TITLE
Enh: Improved message if a config file is missing

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -349,6 +349,7 @@ class FPM::Package::RPM < FPM::Package
     allconfigs = []
     self.config_files.each do |path|
       cfg_path = File.expand_path(path, staging_path)
+      raise "Config file path #{cfg_path} does not exist" unless File.exist?(cfg_path)
       Find.find(cfg_path) do |p|
         allconfigs << p.gsub("#{staging_path}/", '') if File.file? p
       end


### PR DESCRIPTION
Older fpm versions allowed specifying configuration files with full path (e.g. the path of the file once installed, something like /etc/mypackage.conf ); current version requires a relative path and throws a rather cryptic "No such file or directory" error if the config file does not exist.

This patch provides a better message that will help upgrading users to understand what's happening.
