### PR TITLE
Allow forcing ownership even when using --rpm-use-file-permissions

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -127,7 +127,7 @@ Obsoletes: <%= repl %>
 <% end -%>
 
 %files
-%defattr(<%= attributes[:rpm_defattrfile] %>,<%= attributes[:rpm_user] %>,<%= attributes[:rpm_group] %>,<%= attributes[:rpm_defattrdir] %>)
+%defattr(<%= attributes[:rpm_defattrfile] %>,<%= attributes[:rpm_user] || "root" %>,<%= attributes[:rpm_group] || "root" %>,<%= attributes[:rpm_defattrdir] %>)
 <%# Output config files and then regular files. -%>
 <% config_files.each do |path| -%>
 %config(noreplace) <%= rpm_file_entry(path) %>


### PR DESCRIPTION
The rpm-use-file-permissions setting asks each file who owns it and what
the mode is. Sometimes you only want the mode, or sometimes the user is
not correct for deployment. Now, specifying --rpm-user will force the
owner to be the given user but still respect the file modes gathered
by --rpm-use-file-permissions.

The intent of this change is:
- --rpm-use-file-permissions still works the same, when alone
- --rpm-user forces the 'user' owner regardless of the above
- --rpm-group forces the 'group' owner regardless of the above

This was identified by https://logstash.jira.com/browse/LOGSTASH-2012
