### PR TITLE
Adds a plain rpm-prefix option, which doesn't prefix all files.

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -113,6 +113,9 @@ class FPM::Package::RPM < FPM::Package
             "version. Default is to be specific. This option allows the same " \
             "version of a package but any iteration is permitted"
 
+  option "--prefix", "FILEPATH",
+	"In some cases you may only want to mark part of an rpm as relocatable."
+
   private
 
   # Fix path name
@@ -394,7 +397,7 @@ class FPM::Package::RPM < FPM::Package
   end # def output
 
   def prefix
-    return (attributes[:prefix] or "/")
+    return (attributes[:prefix] or attributes[:rpm_prefix] or "/")
   end # def prefix
 
   def build_sub_dir


### PR DESCRIPTION
Sometimes, we like to make partially relocatable RPM packages, where usually some files in `/etc` are not prefixed. i.e.:

```
/etc/init.d/myapp
/etc/sysconfig/myapp
/etc/myapp/config
/work/myapp/bin
/work/myapp/lib
/work/myapp/var
...
```

If I package this (not using fpm) with `Prefix: /work/myapp` that part is relocatable, but everything in `/etc` stays put.

I was initially going to look at modifying `FPM::Package::Dir` since the other package types utilize its chdir/prefix implementation, but I wasn't sure how that would effect anything else.
