### PR TITLE
Added rpm-provides option

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -121,6 +121,13 @@ class FPM::Package::RPM < FPM::Package
             "version. Default is to be specific. This option allows the same " \
             "version of a package but any iteration is permitted"
 
+  rpm_provides = []
+  option "--provides", "PROVIDES",
+    "Add an additional value to the %Provides section" do |provides|
+    rpm_provides << provides
+    next rpm_provides
+  end
+
   private
 
   # Fix path name
@@ -368,6 +375,10 @@ class FPM::Package::RPM < FPM::Package
 
     (attributes[:rpm_rpmbuild_define] or []).each do |define|
       args += ["--define", define]
+    end
+
+    (attributes[:rpm_provides] or []).each do |additional_provide|
+      self.provides << additional_provide
     end
 
     # copy all files from staging to BUILD dir


### PR DESCRIPTION
This adds the ability to specify additional provides elements. For example, I might want to say "This RPM also provides 'mail_reader'" so that another RPM can require 'mail_reader' and be satisfied.

I didn't see if any other packaging system allows for additional provides elements like RPM does. If so, please modify as needed.