### PR TITLE
rpm: Add a option to insert raw Require statements

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -112,6 +112,14 @@ class FPM::Package::RPM < FPM::Package
     next rpmbuild_filter_from_requires
   end
 
+  rpm_tags = []
+  option "--tag", "TAG",
+    "Adds a custom tag in the spec file as is. " \
+    "Example: --rpm-tag 'Requires(post): /usr/sbin/alternatives'" do |add_tag|
+      rpm_tags << add_tag
+    next rpm_tags
+  end
+
   option "--ignore-iteration-in-dependencies", :flag,
             "For '=' (equal) dependencies, allow iterations on the specified " \
             "version. Default is to be specific. This option allows the same " \

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -80,6 +80,9 @@ Packager: <%= maintainer %>
 <% dependencies.each do |req| -%>
 Requires: <%= req %>
 <% end -%>
+<% (attributes[:rpm_tags] or []).each do |tag| -%>
+<%= tag %>
+<% end -%>
 <% end -%>
 <% provides.each do |prov| -%>
 Provides: <%= prov %>


### PR DESCRIPTION
This can be useful to have requirements for different stages.

Examples:

    --rpm-add-require 'Requires(post): /usr/sbin/alternatives'
    --rpm-add-require 'Requires(preun): /usr/sbin/alternatives'