### PR TITLE
Support RPM dist tag

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -54,6 +54,12 @@ class FPM::Package
   # to handle any default value that should be instead.
   attr_accessor :iteration
 
+  # The target distribution of this package. Used to scope the validity of a
+  # package to a specific distribution like el5 (RHEL 5) or el6 (RHEL 6).
+  # More information:
+  #   http://fedoraproject.org/wiki/Packaging:DistTag
+  attr_accessor :dist
+
   # Who maintains this package? This could be the upstream author
   # or the package maintainer. You pick.
   attr_accessor :maintainer
@@ -147,6 +153,7 @@ class FPM::Package
     @version = nil
     @epoch = nil
     @iteration = nil
+    @dist = nil
     @url = nil
     @category = "default"
     @license = "unknown"
@@ -196,7 +203,7 @@ class FPM::Package
     # copy other bits
     ivars = [
       :@architecture, :@category, :@config_files, :@conflicts,
-      :@dependencies, :@description, :@epoch, :@iteration, :@license, :@maintainer,
+      :@dependencies, :@description, :@epoch, :@iteration, :@dist, :@license, :@maintainer,
       :@name, :@provides, :@replaces, :@scripts, :@url, :@vendor, :@version,
       :@directories, :@staging_path
     ]
@@ -339,6 +346,7 @@ class FPM::Package
       .gsub("FULLVERSION", fullversion) \
       .gsub("VERSION", version.to_s) \
       .gsub("ITERATION", iteration.to_s) \
+      .gsub("DIST", dist.to_s) \
       .gsub("EPOCH", epoch.to_s) \
       .gsub("TYPE", type.to_s)
   end # def to_s

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -54,12 +54,6 @@ class FPM::Package
   # to handle any default value that should be instead.
   attr_accessor :iteration
 
-  # The target distribution of this package. Used to scope the validity of a
-  # package to a specific distribution like el5 (RHEL 5) or el6 (RHEL 6).
-  # More information:
-  #   http://fedoraproject.org/wiki/Packaging:DistTag
-  attr_accessor :dist
-
   # Who maintains this package? This could be the upstream author
   # or the package maintainer. You pick.
   attr_accessor :maintainer
@@ -153,7 +147,6 @@ class FPM::Package
     @version = nil
     @epoch = nil
     @iteration = nil
-    @dist = nil
     @url = nil
     @category = "default"
     @license = "unknown"
@@ -203,7 +196,7 @@ class FPM::Package
     # copy other bits
     ivars = [
       :@architecture, :@category, :@config_files, :@conflicts,
-      :@dependencies, :@description, :@epoch, :@iteration, :@dist, :@license, :@maintainer,
+      :@dependencies, :@description, :@epoch, :@iteration, :@license, :@maintainer,
       :@name, :@provides, :@replaces, :@scripts, :@url, :@vendor, :@version,
       :@directories, :@staging_path
     ]
@@ -346,7 +339,6 @@ class FPM::Package
       .gsub("FULLVERSION", fullversion) \
       .gsub("VERSION", version.to_s) \
       .gsub("ITERATION", iteration.to_s) \
-      .gsub("DIST", dist.to_s) \
       .gsub("EPOCH", epoch.to_s) \
       .gsub("TYPE", type.to_s)
   end # def to_s

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -55,6 +55,8 @@ class FPM::Package::RPM < FPM::Package
     next rpmbuild_define
   end
 
+  option "--dist", "DIST-TAG", "Set the rpm distribution, like el5, el6, or fc20."
+
   option "--digest", DIGEST_ALGORITHM_MAP.keys.join("|"),
     "Select a digest algorithm. md5 works on the most platforms.",
     :default => "md5" do |value|
@@ -170,6 +172,10 @@ class FPM::Package::RPM < FPM::Package
   def iteration
     return @iteration ? @iteration : 1
   end # def iteration
+
+  def dist
+    @dist || attributes[:rpm_dist]
+  end
 
   # See FPM::Package#converted_from
   def converted_from(origin)
@@ -318,6 +324,9 @@ class FPM::Package::RPM < FPM::Package
       args += ["--target", rpm_target]
     end
 
+    # set the rpm dist tag
+    args += ["--define", "dist .#{dist}"] if dist
+
     args += [
       "--define", "buildroot #{build_path}/BUILD",
       "--define", "_topdir #{build_path}",
@@ -425,7 +434,10 @@ class FPM::Package::RPM < FPM::Package
   end # def epoch
 
   def to_s(format=nil)
-    return super("NAME-VERSION-ITERATION.ARCH.TYPE") if format.nil?
+    if format.nil?
+      return super("NAME-VERSION-ITERATION.DIST.ARCH.TYPE") if dist
+      return super("NAME-VERSION-ITERATION.ARCH.TYPE")
+    end
     return super(format)
   end # def to_s
 
@@ -438,6 +450,6 @@ class FPM::Package::RPM < FPM::Package
   end # def digest_algorithm
 
   public(:input, :output, :converted_from, :architecture, :to_s, :iteration,
-         :payload_compression, :digest_algorithm, :prefix, :build_sub_dir,
+         :dist, :payload_compression, :digest_algorithm, :prefix, :build_sub_dir,
          :epoch, :version, :prefixed_path)
 end # class FPM::Package::RPM

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -55,7 +55,7 @@ class FPM::Package::RPM < FPM::Package
     next rpmbuild_define
   end
 
-  option "--dist", "DIST-TAG", "Set the rpm distribution, like el5, el6, or fc20."
+  option "--dist", "DIST-TAG", "Set the rpm distribution."
 
   option "--digest", DIGEST_ALGORITHM_MAP.keys.join("|"),
     "Select a digest algorithm. md5 works on the most platforms.",
@@ -172,10 +172,6 @@ class FPM::Package::RPM < FPM::Package
   def iteration
     return @iteration ? @iteration : 1
   end # def iteration
-
-  def dist
-    @dist || attributes[:rpm_dist]
-  end
 
   # See FPM::Package#converted_from
   def converted_from(origin)
@@ -325,7 +321,7 @@ class FPM::Package::RPM < FPM::Package
     end
 
     # set the rpm dist tag
-    args += ["--define", "dist .#{dist}"] if dist
+    args += ["--define", "dist .#{attributes[:rpm_dist]}"] if attributes[:rpm_dist]
 
     args += [
       "--define", "buildroot #{build_path}/BUILD",
@@ -435,7 +431,7 @@ class FPM::Package::RPM < FPM::Package
 
   def to_s(format=nil)
     if format.nil?
-      return super("NAME-VERSION-ITERATION.DIST.ARCH.TYPE") if dist
+      return super("NAME-VERSION-ITERATION.DIST.ARCH.TYPE").gsub('DIST', attributes[:rpm_dist]) if attributes[:rpm_dist]
       return super("NAME-VERSION-ITERATION.ARCH.TYPE")
     end
     return super(format)
@@ -450,6 +446,6 @@ class FPM::Package::RPM < FPM::Package
   end # def digest_algorithm
 
   public(:input, :output, :converted_from, :architecture, :to_s, :iteration,
-         :dist, :payload_compression, :digest_algorithm, :prefix, :build_sub_dir,
+         :payload_compression, :digest_algorithm, :prefix, :build_sub_dir,
          :epoch, :version, :prefixed_path)
 end # class FPM::Package::RPM

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -66,9 +66,10 @@ describe FPM::Package::RPM do
       subject.version = "123"
       subject.architecture = "all"
       subject.iteration = "100"
-      subject.dist = "el6"
       subject.epoch = "5"
 
+      insist { subject.to_s } == "name-123-100.noarch.rpm"
+      subject.attributes[:rpm_dist] = "el6"
       insist { subject.to_s } == "name-123-100.el6.noarch.rpm"
     end
   end
@@ -351,6 +352,21 @@ describe FPM::Package::RPM do
 
         @rpm = ::RPM::File.new(@target)
         insist { @rpm.tags[:release] } == "#{subject.iteration}.el6"
+
+        File.unlink(@target)
+      end
+
+      it "should accept the dist in the iteration" do
+        subject.name = "example"
+        subject.iteration = "1.el6"
+        subject.version = "1.0"
+        @target = Stud::Temporary.pathname
+
+        # Write RPM
+        subject.output(@target)
+
+        @rpm = ::RPM::File.new(@target)
+        insist { @rpm.tags[:release] } == "#{subject.iteration}"
 
         File.unlink(@target)
       end

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -60,6 +60,17 @@ describe FPM::Package::RPM do
       # This is the default filename I see commonly output by rpmbuild
       insist { subject.to_s } == "name-123-100.noarch.rpm"
     end
+
+    it "should include the dist when specified" do
+      subject.name = "name"
+      subject.version = "123"
+      subject.architecture = "all"
+      subject.iteration = "100"
+      subject.dist = "el6"
+      subject.epoch = "5"
+
+      insist { subject.to_s } == "name-123-100.el6.noarch.rpm"
+    end
   end
 
 
@@ -327,6 +338,23 @@ describe FPM::Package::RPM do
         end
       end
     end # package attributes
+
+    context "dist" do
+      it "should have the dist in the release" do
+        subject.name = "example"
+        subject.attributes[:rpm_dist] = "el6"
+        subject.version = "1.0"
+        @target = Stud::Temporary.pathname
+
+        # Write RPM
+        subject.output(@target)
+
+        @rpm = ::RPM::File.new(@target)
+        insist { @rpm.tags[:release] } == "#{subject.iteration}.el6"
+
+        File.unlink(@target)
+      end
+    end # dist
   end # #output
 
   describe "regressions should not occur", :if => program_exists?("rpmbuild") do

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -38,7 +38,7 @@ Version: <%= version %>
 <% if epoch -%>
 Epoch: <%= epoch %>
 <% end -%>
-Release: <%= iteration or 1 %>
+Release: <%= iteration or 1 %><%= "%{?dist}" if attributes[:rpm_dist] %>
 <%# use the first line of the description as the summary -%>
 Summary: <%= description.split("\n").first.empty? ? "_" :  description.split("\n").first %>
 <% if !attributes[:rpm_autoreqprov?] -%>


### PR DESCRIPTION
When --rpm-dist is specified, pass the dist tag to rpmbuild and
correctly name the file to ensure packages can be built with a
specific distribution in mind.