### PR TITLE
Ignore unset CPAN metadata fields

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -72,7 +72,7 @@ class FPM::Package::CPAN < FPM::Package
       else; metadata["license"]
     end
 
-    if metadata.include?("distribution")
+    unless metadata["distribution"].nil?
       @logger.info("Setting package name from 'distribution'",
                    :distribution => metadata["distribution"])
       self.name = fix_name(metadata["distribution"])
@@ -83,7 +83,7 @@ class FPM::Package::CPAN < FPM::Package
     end
 
     # Not all things have 'author' listed.
-    self.vendor = metadata["author"].join(", ") if metadata.include?("author")
+    self.vendor = metadata["author"].join(", ") unless metadata["author"].nil?
     self.url = metadata["resources"]["homepage"] rescue "unknown"
 
     # TODO(sissel): figure out if this perl module compiles anything
@@ -102,7 +102,7 @@ class FPM::Package::CPAN < FPM::Package
     safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
 
     if !attributes[:no_auto_depends?] 
-      if metadata.include?("requires") && !metadata["requires"].nil?
+      unless metadata["requires"].nil?
         metadata["requires"].each do |dep_name, version|
           # Special case for representing perl core as a version.
           if dep_name == "perl"


### PR DESCRIPTION
Otherwise this can happen:

```
$ fpm -t deb -s cpan --verbose 'Lingua::JA::Romanize::Japanese'
Asking metacpan about a module {:module=>"Lingua::JA::Romanize::Japanese", :level=>:info}
Downloading perl module {:distribution=>"Lingua-JA-Romanize-Japanese", :version=>nil, :level=>:info}
Setting package name from 'name' {:name=>"Lingua-JA-Romanize-Japanese", :level=>:info}
/usr/lib/ruby/gems/1.9.1/gems/fpm-1.1.0/lib/fpm/package/cpan.rb:86:in `input': undefined method `join' for nil:NilClass (NoMethodError)
    from /usr/lib/ruby/gems/1.9.1/gems/fpm-1.1.0/lib/fpm/command.rb:299:in `block in execute'
    from /usr/lib/ruby/gems/1.9.1/gems/fpm-1.1.0/lib/fpm/command.rb:298:in `each'
    from /usr/lib/ruby/gems/1.9.1/gems/fpm-1.1.0/lib/fpm/command.rb:298:in `execute'
    from /usr/lib/ruby/gems/1.9.1/gems/clamp-0.6.3/lib/clamp/command.rb:67:in `run'
    from /usr/lib/ruby/gems/1.9.1/gems/fpm-1.1.0/lib/fpm/command.rb:449:in `run'
    from /usr/lib/ruby/gems/1.9.1/gems/clamp-0.6.3/lib/clamp/command.rb:125:in `run'
    from /usr/lib/ruby/gems/1.9.1/gems/fpm-1.1.0/bin/fpm:8:in `<top (required)>'
    from /usr/bin/fpm:23:in `load'
    from /usr/bin/fpm:23:in `<main>'
```
