### PR TITLE
Fixes jordansissel/fpm#707

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -309,12 +309,16 @@ class FPM::Package::RPM < FPM::Package
     args = ["rpmbuild", "-bb"]
 
     if %x{uname -m}.chomp != self.architecture
-      args += [ '--target', self.architecture ]
+      rpm_target = self.architecture
     end
 
     # issue #309
     if !attributes[:rpm_os].nil?
       rpm_target = "#{architecture}-unknown-#{attributes[:rpm_os]}"
+    end
+
+    # issue #707
+    if !rpm_target.nil?
       args += ["--target", rpm_target]
     end
 


### PR DESCRIPTION
With rpms, if `--architecture` and `--rpm-os` are specified and different than the host, `--target` would be passed to `rpmbuild` twice, causing an error.

Example: an OS X host (`uname -s` = "Darwin") with x86_64 (`uname -m`) architecture building for `--rpm-os linux` and `--architecture noarch`.

This change only adds `--target` to the `rpmbuild` args once, fixing this specific error.
