### PR TITLE
Specify %attr directive on a per-file basis

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -346,6 +346,16 @@ class FPM::Command < Clamp::Command
     input.replaces += replaces
     input.config_files += config_files
     input.directories += directories
+
+    h = {}
+    attrs.each do | e |
+
+      s = e.split(':', 2)
+      h[s.last] = s.first
+    end
+
+    input.attrs = h
+
     
     script_errors = []
     setscript = proc do |scriptname|

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -111,6 +111,8 @@ class FPM::Package
   # This is where you'd put rpm, deb, or other specific attributes.
   attr_accessor :attributes
 
+  attr_accessor :attrs
+
   private
 
   def initialize
@@ -172,6 +174,7 @@ class FPM::Package
     @scripts = {}
     @config_files = []
     @directories = []
+    @attrs = {}
 
     staging_path
     build_path
@@ -198,7 +201,7 @@ class FPM::Package
       :@architecture, :@category, :@config_files, :@conflicts,
       :@dependencies, :@description, :@epoch, :@iteration, :@license, :@maintainer,
       :@name, :@provides, :@replaces, :@scripts, :@url, :@vendor, :@version,
-      :@directories, :@staging_path
+      :@directories, :@staging_path, :@attrs
     ]
     ivars.each do |ivar|
       #@logger.debug("Copying ivar", :ivar => ivar, :value => instance_variable_get(ivar),

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -95,6 +95,10 @@ class FPM::Package::RPM < FPM::Package
   option "--autoreq", :flag, "Enable RPM's AutoReq option"
   option "--autoprov", :flag, "Enable RPM's AutoProv option"
 
+  option "--attr", "ATTRFILE",
+    "Set the attribute for a file (%attr).",
+    :multivalued => true, :attribute_name => :attrs
+
   rpmbuild_filter_from_provides = []
   option "--filter-from-provides", "REGEX",
     "Set %filter_from_provides to the supplied REGEX." do |filter_from_provides|
@@ -131,7 +135,17 @@ class FPM::Package::RPM < FPM::Package
   def rpm_file_entry(file)
     original_file = file
     file = rpm_fix_name(file)
-    return file unless attributes[:rpm_use_file_permissions?]
+
+    if !attributes[:rpm_use_file_permissions?]
+
+      if attrs[file].nil?
+        return file
+      else
+        return sprintf("%%attr(%s) %s\n", attrs[file], file)
+      end
+    end
+
+    return sprintf("%%attr(%s) %s\n", attrs[file], file) unless attrs[file].nil?
 
     # Stat the original filename in the relative staging path
     ::Dir.chdir(staging_path) do


### PR DESCRIPTION
Please consider this pull request as a naive proof of concept for a new proposed command line argument `--rpm-attr`.

We really like fpm and are using it for building rpm packages but have hit a problem where we'd like to be able to specify file specific attributes on a per-file basis.

We note that the rpm `%defattr(<filemode>, <user>, <group>, <dirmode>)` directive is managed in fpm via the `--rpm-user user`, `--rpm-group group`, `--rpm-defattrfile mode` and `--rpm-defattrdir mode` command line arguments.

So we'd like to also be able to specify the `%attr(<mode>, <user>, <group>) file` directive overriding `%defattr` on a per-file basis but cannot find fpm command line arguments to handle this.

One use case for this is where the majority of files and directories within an rpm are owned by an application user but the init.d script in `/etc/rc.d/init.d/appname` should be owned by root and not by the application user.

We note that this could be done with the fpm command line argument `--rpm-use-file-permissions` but we are not keen on this approach as it would require our build system to run as root in order to call chown/chgrp before invoking fpm.

We are currently working around this by calling `chown` and `chmod` from the `--after-install` script but we consider this a hack given rpm should manage this itself.
## Proposed feature request

Add support for new command line argument which can be called multiple times, e.g.

`--rpm-attr '0755,root,root:/etc/rc.d/init.d/appname`
