### PR TITLE
Add --debug-workspace

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -60,6 +60,9 @@ class FPM::Command < Clamp::Command
   option ["-n", "--name"], "NAME", "The name to give to the package"
   option "--verbose", :flag, "Enable verbose output"
   option "--debug", :flag, "Enable debug output"
+  option "--debug-workspace", :flag, "Keep any file workspaces around for " \
+    "debugging. This will disable automatic cleanup of package staging and " \
+    "build paths. It will also print which directories are available."
   option ["-v", "--version"], "VERSION", "The version to give to the package",
     :default => 1.0
   option "--iteration", "ITERATION",
@@ -426,8 +429,18 @@ class FPM::Command < Clamp::Command
     @logger.error("Process failed: #{e}")
     return 1
   ensure
-    input.cleanup unless input.nil?
-    output.cleanup unless output.nil?
+    if debug_workspace?
+      # only emit them if they have files
+      [input, output].each do |plugin|
+        [:staging_path, :build_path].each do |pathtype|
+          path = plugin.send(pathtype)
+          puts "#{plugin.type} #{pathtype}: #{path}" if Dir.open(path).to_a.size > 2
+        end
+      end
+    else
+      input.cleanup unless input.nil?
+      output.cleanup unless output.nil?
+    end
   end # def execute
 
   def run(*args)

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -519,5 +519,5 @@ class FPM::Package
 
   # Package internal public api
   public(:cleanup_staging, :cleanup_build, :staging_path, :converted_from,
-         :edit_file)
+         :edit_file, :build_path)
 end # class FPM::Package


### PR DESCRIPTION
Avoids Package#cleanup calls and also prints the paths, if not empty, of
any build or staging directories used for input or output.

Fixes #720
