### PR TITLE
Adding install info to readme for Mac OS 10.9 Users

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ If you think your changes are ready to be merged back to the main fpm repo, you
 can generate a pull request on the github website for your repo and send it in
 for review.
 
+
+##Problems running bundle install?
+
+If you are installing on Mac OS 10.9 (Mavericks) you will need to make sure that 
+you have the standalone command line tools seperate from Xcode:
+
+    $ xcode-select --install
+
+Finally, click the install button on the prompt that appears.
+
+
+
 ## More Documentation
 
 [See the wiki for more docs](https://github.com/jordansissel/fpm/wiki)


### PR DESCRIPTION
I ran into some issues while installing fpm, It turns out the issue was down to new command line tools being created when Mac OS made the jump to 10.9, i've added a way to fix this issue for future Mavericks users to the readme
