### PR TITLE
CPAN test and sandboxing fixes

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -109,6 +109,7 @@ class FPM::Package::CPAN < FPM::Package
       cpanm_flags = ["-l", build_path("cpan"), moduledir]
     end
 
+    cpanm_flags += ["-n"] if !attributes[:cpan_test?]
     cpanm_flags += ["--mirror", "#{attributes[:cpan_mirror]}"] if !attributes[:cpan_mirror].nil?
     cpanm_flags += ["--mirror-only"] if attributes[:cpan_mirror_only?] && !attributes[:cpan_mirror].nil?
 

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -27,6 +27,9 @@ class FPM::Package::CPAN < FPM::Package
   option "--perl-lib-path", "PERL_LIB_PATH",
     "Path of target Perl Libraries"
 
+  option "--sandbox-non-core", :flag,
+    "Sandbox all non-core modules, even if they're already installed", :default => true
+
   private
   def input(package)
     #if RUBY_VERSION =~ /^1\.8/
@@ -100,8 +103,12 @@ class FPM::Package::CPAN < FPM::Package
     # We'll install to a temporary directory.
     @logger.info("Installing any build or configure dependencies")
 
-    cpanm_flags = ["-L", build_path("cpan"), moduledir]
-    cpanm_flags += ["-n"] if attributes[:cpan_test?]
+    if attributes[:cpan_sandbox_non_core?]
+      cpanm_flags = ["-L", build_path("cpan"), moduledir]
+    else
+      cpanm_flags = ["-l", build_path("cpan"), moduledir]
+    end
+
     cpanm_flags += ["--mirror", "#{attributes[:cpan_mirror]}"] if !attributes[:cpan_mirror].nil?
     cpanm_flags += ["--mirror-only"] if attributes[:cpan_mirror_only?] && !attributes[:cpan_mirror].nil?
 


### PR DESCRIPTION
As discussed in #515 and #748, make sandboxing optional for packaging with system dependencies. This doesn't fix the core issue with RHEL and derivatives, but it does allow users to not install every dependency if they want a build to use system installed modules.

Up til now, `--cpan-test` would skip tests when told to test and then run them when told not to. That was bad logic on my part I think, so this reverses the behavior and makes it do what a user would expect.