### PR TITLE
add --rpm-init option

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -142,14 +142,6 @@ class FPM::Package::RPM < FPM::Package
   end # --posttrans
   private
     
-  attributes.fetch(:rpm_init_list, []).each do |init|
-    name = File.basename(init, ".init")
-    dest_init = File.join(staging_path, "etc/init.d/#{name}")
-    FileUtils.mkdir_p(File.dirname(dest_init))
-    FileUtils.cp init, dest_init
-    File.chmod(0755, dest_init)
-  end
-
   # Fix path name
   # Replace [ with [\[] to make rpm not use globs
   # Replace * with [*] to make rpm not use globs
@@ -427,6 +419,15 @@ class FPM::Package::RPM < FPM::Package
     allconfigs.sort!.uniq!
 
     self.config_files = allconfigs.map { |x| File.join("/", x) }
+
+    # add init script if present
+    (attributes[:rpm_init_list] or []).each do |init|
+      name = File.basename(init, ".init")
+      dest_init = File.join(staging_path, "etc/init.d/#{name}")
+      FileUtils.mkdir_p(File.dirname(dest_init))
+      FileUtils.cp init, dest_init
+      File.chmod(0755, dest_init)
+    end
 
     (attributes[:rpm_rpmbuild_define] or []).each do |define|
       args += ["--define", define]


### PR DESCRIPTION
We currently use the same command across several platforms to start services:

```
sudo /etc/init.d/myservice start
```

This makes fpm's `--deb-init` option extremely useful (Thanks!)

Added the `--rpm-init` option which mimics its deb counterpart.
