### PR TITLE
Add RakeTask

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -43,6 +43,7 @@ Gem::Specification.new do |spec|
   # For calling functions in dynamic libraries
   spec.add_dependency("ffi") # license: GPL3/LGPL3
 
+  spec.add_development_dependency("rake", "~> 10") # license: MIT
   spec.add_development_dependency("rspec", "~> 3.0.0") # license: MIT (according to wikipedia)
   spec.add_development_dependency("insist", "~> 0.0.5") # license: ???
   spec.add_development_dependency("pry")

--- a/lib/fpm/rake_task.rb
+++ b/lib/fpm/rake_task.rb
@@ -1,0 +1,60 @@
+require "ostruct"
+require "rake"
+require "rake/tasklib"
+
+class FPM::RakeTask < Rake::TaskLib
+  attr_reader :options
+
+  def initialize(*args, source:, target:, directory: ".", &block)
+    @options = OpenStruct.new
+    @source = source.to_s
+    @target = target.to_s
+    @directory = File.expand_path(directory)
+
+    abort("Must specify source and output") if @source.empty? || @target.empty?
+    options.name = args.shift.to_s || abort("Must specify a package name")
+
+    desc "Package #{@name}" unless ::Rake.application.last_comment
+
+    task(options.name, *args) do |_, task_args|
+      block.call(*[options, task_args].first(block.arity)) if block
+      abort("Must specify args") unless (@args = options.delete_field(:args))
+
+      run_cli
+    end
+  end
+
+  private
+
+  def parsed_options
+    options.to_h.map do |option, value|
+      opt = option.to_s.tr("_", "-")
+
+      case
+      when value.is_a?(String), value.is_a?(Symbol)
+        %W(--#{opt} #{value})
+      when value.is_a?(Array)
+        value.map { |v| %W(--#{opt} #{v}) }
+      when value.is_a?(TrueClass)
+        "--#{opt}"
+      when value.is_a?(FalseClass)
+        "--no-#{opt}"
+      else
+        fail TypeError, "Unexpected type: #{value.class}"
+      end
+    end
+  end
+
+  def run_cli
+    require "fpm"
+    require "fpm/command"
+
+    args = %W(-t #{@target} -s #{@source} -C #{@directory})
+    args << parsed_options
+    args << @args
+
+    args.flatten!.compact!
+
+    exit(FPM::Command.new("fpm").run(args) || 0)
+  end
+end

--- a/spec/fpm/rake_task_spec.rb
+++ b/spec/fpm/rake_task_spec.rb
@@ -1,0 +1,63 @@
+require "rspec" # Avoid setup_spec due to overrides
+require "fpm/command"
+require "fpm/rake_task"
+require "tmpdir"
+
+describe FPM::RakeTask do
+  around do |example|
+    old_stderr = $stderr.dup
+    $stderr.reopen("/dev/null")
+
+    example.run
+
+    $stderr = old_stderr
+    Rake::Task.clear
+  end
+
+  describe "#new" do
+    it "requires a package name" do
+      expect { described_class.new(nil, :source => :dir, :target => :tar) }.
+        to raise_error(SystemExit, "Must specify package name, source and output")
+    end
+
+    it "requires a source" do
+      expect { described_class.new(:awesome, :source => nil, :target => :tar) }.
+        to raise_error(SystemExit, "Must specify package name, source and output")
+    end
+
+    it "requires a target" do
+      expect { described_class.new(:awesome, :source => :dir, :target => nil) }.
+        to raise_error(SystemExit, "Must specify package name, source and output")
+    end
+
+    it "requires package args" do
+      described_class.new(:awesome, :source => :dir, :target => :tar)
+      expect { Rake::Task["awesome"].execute }.
+        to raise_error(SystemExit, "Must specify args")
+    end
+
+    it "executes FPM::Command with the appropriate arguments" do
+      command = instance_double(FPM::Command)
+      expected = %W(-t tar -s dir -C #{Dir.tmpdir} --cpan-mirror-only
+                    --no-cpan-test --config-files foo --config-files bar
+                    --name awesome --cpan-mirror-only --url http://example.com
+                    bin/)
+
+      allow(FPM::Command).to receive(:new).and_return(command)
+      expect(command).to receive(:run).with(array_including(*expected))
+
+      args = [:awesome,
+              { :source => :dir, :target => :tar, :directory => Dir.tmpdir }]
+
+      described_class.new(*args) do |pkg|
+        pkg.args = %w(bin/)
+        pkg.cpan_mirror_only = true
+        pkg.cpan_test = false
+        pkg.url = "http://example.com"
+        pkg.config_files = %w(foo bar)
+      end
+
+      expect { Rake::Task["awesome"].execute }.to raise_error(SystemExit, nil)
+    end
+  end
+end


### PR DESCRIPTION
This allows you to easily use `fpm` in a Rakefile without a bunch of backticks or other non-Ruby ugliness. For example, given a Rakefile:

```ruby
require "fpm/rake_task"

FPM::RakeTask.new(:awesome_pkg, :source => :dir, :target => :tar) do |pkg|
  pkg.args = %w(bin/)
  pkg.verbose = true
  pkg.config_files = %w(foo bar)
end
```

Run `rake awesome_pkg`:

```
Created package {:path=>"awesome_pkg.tar"}
```