### PR TITLE
Missing space in help

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -85,7 +85,7 @@ class FPM::Command < Clamp::Command
   option "--no-depends", :flag, "Do not list any dependencies in this package",
     :default => false
 
-  option "--no-auto-depends", :flag, "Do not list any dependencies in this" \
+  option "--no-auto-depends", :flag, "Do not list any dependencies in this " \
     "package automatically", :default => false
 
   option "--provides", "PROVIDES",


### PR DESCRIPTION
```
    --no-depends                  Do not list any dependencies in this package (default: false)
    --no-auto-depends             Do not list any dependencies in thispackage automatically (default: false)
```
