### PR TITLE
Enable loading configuration from YAML document

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -6,6 +6,7 @@ require "clamp"
 require "ostruct"
 require "fpm"
 require "tmpdir" # for Dir.tmpdir
+require "yaml"
 
 if $DEBUG
   Cabin::Channel.get(Kernel).subscribe($stdout)
@@ -198,6 +199,9 @@ class FPM::Command < Clamp::Command
     "copying, downloading, etc. Roughly any scratch space fpm needs to build " \
     "your package.", :default => Dir.tmpdir
 
+  option "--settings", "FILE",
+    "Load configuration from a YAML document."
+
   parameter "[ARGS] ...",
     "Inputs to the source package type. For the 'dir' type, this is the files" \
     " and directories you want to include in the package. For others, like " \
@@ -225,6 +229,18 @@ class FPM::Command < Clamp::Command
     if ARGV == [ "--version" ]
       puts FPM::VERSION
       return 0
+    end
+
+    # Parse options from YAML document.
+    if settings
+      @logger.debug("Loading configuration from YAML document: #{settings}")
+      yaml_loader = YAMLLoader.new(self)
+      begin
+        yaml_config = yaml_loader.load(settings)
+      rescue Errno::ENOENT
+        @logger.warn("Cannot find YAML document: #{settings}. Using default settings.")
+      end
+      @logger.info("Loaded configuration from YAML document: #{settings}")
     end
 
     @logger.level = :warn
@@ -270,6 +286,18 @@ class FPM::Command < Clamp::Command
     # They are stored in 'settings' as :gem_foo_bar.
     input.attributes ||= {}
 
+    # Before merging command-line options into FPM::Package attributes,
+    # override package defaults with values from the YAML configuration.
+    #
+    # Setting the instance variables directly ensures the values are passed to
+    # the output properly (FPM::Package#convert).
+    if yaml_config
+      # Merge general package instance variables.
+      yaml_config.each do |k, v|
+        input.instance_variable_set("@#{k}", v) if input.respond_to?(k)
+      end
+    end
+
     # Iterate over all the options and set their values in the package's
     # attribute hash.
     #
@@ -277,6 +305,14 @@ class FPM::Command < Clamp::Command
     self.class.declared_options.each do |option|
       with(option.attribute_name) do |attr|
         next if attr == "help"
+
+        # Override package-specific defaults from the YAML configuration, if
+        # applicable. These are in turn overridden by command-line options.
+        if yaml_config.key?(attr.to_sym)
+          option.instance_variable_set("@default_value",
+                                       yaml_config[attr.to_sym])
+        end
+
         # clamp makes option attributes available as accessor methods
         # --foo-bar is available as 'foo_bar'. Put these in the package
         # attributes hash. (See FPM::Package#attributes)
@@ -564,4 +600,38 @@ class FPM::Command < Clamp::Command
 
     public(:initialize, :ok?, :messages)
   end # class Validator
+
+  # Load configuration options from a YAML document.
+  #
+  # Let Validator handle validation.
+  class YAMLLoader
+
+    def initialize(command)
+      @command = command
+    end # def initialize
+
+    # Load the configuration. Will raise Errno:ENOENT if the file does not
+    # exist.
+    def load(filename)
+      config = YAML.load_file(filename)
+      # Hash#unnest is defined in lib/fpm/util.rb.
+      config = config.unnest
+      unless @command.instance_variable_defined?("@input_type")
+        @command.input_type = config.delete(:source)
+      end
+      unless @command.instance_variable_defined?("@output_type")
+        @command.output_type = config.delete(:target)
+      end
+      unless @command.instance_variable_defined?("@args")
+        inputs = config.delete(:input)
+        if inputs
+          inputs = [inputs] if inputs.is_a?(String)
+          @command.args = inputs
+        end
+      end
+      return config
+    end # def load
+
+  end # class YAMLLoader
+
 end # class FPM::Program

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -224,3 +224,27 @@ module FPM::Util
     end
   end #def expand_pesimistic_constraints
 end # module FPM::Util
+
+class Hash
+  # Convert a nested hash into a flat hash.
+  #
+  # See <http://stackoverflow.com/q/12064648/>.
+  #
+  # @param [String] string separator to join keys with
+  # @return [Hash] the flattened hash
+  def unnest(separator = '_')
+    # Prefix all keys in the hash.
+    def prefix_keys(prefix)
+      Hash[map { |k, v| ["#{prefix}#{k}".to_sym, v] }].unnest
+    end
+    new_hash = {}
+    each do |k, v|
+      if v.is_a?(Hash)
+        new_hash.merge!(v.prefix_keys("#{k}#{separator}"))
+      else
+        new_hash[k.to_sym] = v
+      end
+    end
+    new_hash
+  end # def unnest
+end # class Hash

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -227,22 +227,14 @@ end # module FPM::Util
 
 class Hash
   # Convert a nested hash into a flat hash.
-  #
-  # See <http://stackoverflow.com/q/12064648/>.
-  #
-  # @param [String] string separator to join keys with
-  # @return [Hash] the flattened hash
-  def unnest(separator = '_')
-    # Prefix all keys in the hash.
-    def prefix_keys(prefix)
-      Hash[map { |k, v| ["#{prefix}#{k}".to_sym, v] }].unnest
-    end
+  def unnest(prefix = nil, separator = '_')
     new_hash = {}
     each do |k, v|
+      new_key = prefix ? "#{prefix}#{separator}#{k}" : k
       if v.is_a?(Hash)
-        new_hash.merge!(v.prefix_keys("#{k}#{separator}"))
+        new_hash.merge!(v.unnest(new_key, separator))
       else
-        new_hash[k.to_sym] = v
+        new_hash[new_key.to_sym] = v
       end
     end
     new_hash


### PR DESCRIPTION
This commit adds a `--settings` option that allows users to load
configuration options from a YAML document.

This is a much more flexible implementation than the current support for
`.fpm` rc files.

Example
-------

Here is an example settings file for FPM:

    ---
    source: gem
    target: deb
    maintainer: Jordan Sissel <jls@semicomplete.com>
    input:
      - fpm

Apply the settings by calling FPM like so:

    $ fpm --settings settings.yaml

Package options
---------------

Use nested block mappings to group package-specific options. This
settings file:

    ---
    python:
      install_bin: /usr/bin
      install_lib: /usr/local/lib/python2.7/site-packages

is equivalent to:

    ---
    python_install_bin: /usr/bin
    python_install_lib: /usr/local/lib/python2.7/site-packages

If there is a conflict between settings defined at the top level of the
document and in a nested block mapping, the latter definition wins.

That is, using this settings file:

    ---
    python:
      install_bin: /usr/bin
    python_install_bin: /usr/local/bin

the package will install Python executables to `/usr/local/bin`.

Command-line overrides
----------------------

Command-line options override all settings defined in the YAML document.

For example, if the settings file contained:

    ---
    source: gem
    target: deb
    gem:
      bin_path: /usr/local/bin

one could produce an RPM instead by running:

    $ fpm -t rpm --settings settings.yaml fpm

If the mandatory options (`source`, `target`, and `input`) are not
specified, FPM will prompt the user to supply `-s`, `-t`, and the input
arguments.