### PR TITLE
CPAN: Fix stripping of perllocal.pod if cpan_perl_lib_path is set

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -207,7 +207,8 @@ class FPM::Package::CPAN < FPM::Package
       # across packages.
       # https://github.com/jordansissel/fpm/issues/443
       # https://github.com/jordansissel/fpm/issues/510
-      ::Dir.glob(File.join(staging_path, prefix, "**/perllocal.pod")).each do |path|
+      glob_prefix = attributes[:cpan_perl_lib_path] || prefix
+      ::Dir.glob(File.join(staging_path, glob_prefix, "**/perllocal.pod")).each do |path|
         @logger.debug("Removing useless file.",
                       :path => path.gsub(staging_path, ""))
         File.unlink(path)


### PR DESCRIPTION
For example, if cpan_perl_lib_path is set to "/usr/share/perl5", all packages created with fpm will contain this file:

```
/usr/share/perl5/x86_64-linux-gnu-thread-multi/perllocal.pod
```

The current code only works if cpan_perl_lib_path is undefined.

Also see #443 and #510.
