### PR TITLE
Stat the link itself instead of file it refers to

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -167,7 +167,7 @@ class FPM::Package::RPM < FPM::Package
 
     # Stat the original filename in the relative staging path
     ::Dir.chdir(staging_path) do
-      stat = File.stat(original_file.gsub(/\"/, '').sub(/^\//,''))
+      stat = File.lstat(original_file.gsub(/\"/, '').sub(/^\//,''))
 
       # rpm_user and rpm_group attribute should override file ownership
       # otherwise use the current file user/group by name.


### PR DESCRIPTION
If path is a symbolic link and target doesn't exist, we may incorrectly throw
file not found exception. This changes fixes the issue by using File.lstat to
stat the path.
