### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Targets:
 * directories
 * Mac OS X `.pkg` files (`osxpkg`)
 
-## Need Help or Want to Contribute?
+## Need Help or Want to Contribute? [![Inline docs](http://inch-ci.org/github/jordansissel/fpm.svg?branch=master)](http://inch-ci.org/github/jordansissel/fpm)
 
 All contributions are welcome: ideas, patches, documentation, bug reports,
 complaints, and even something you drew up on a napkin.


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to potential contributors: [![Inline docs](http://inch-ci.org/github/jordansissel/fpm.svg)](http://inch-ci.org/github/jordansissel/fpm)

The badge links to [Inch CI](http://inch-ci.org), a project that tries to raise the visibility of inline-docs to encourage aspiring Rubyists to document their code. Your status page is http://inch-ci.org/github/jordansissel/fpm/

Inch CI is still in its infancy (3 months), but already used by projects like [Bundler](https://github.com/bundler/bundler), [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [ROM](https://github.com/rom-rb/rom).

What do you think?
