### PR TITLE
Warn about strange debian dependencies, but don't auto-fix (downcase) them

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -445,9 +445,10 @@ class FPM::Package::Deb < FPM::Package
     name_re = /^[^ \(]+/
     name = dep[name_re]
     if name =~ /[A-Z]/
-      @logger.warn("Downcasing dependency '#{name}' because deb packages " \
+      # We used to downcase strange dependency by default but now just emit a warning:
+      # some valid dependencies like 'libMagick++5' really like their special casing!
+      @logger.warn("Consider downcasing dependency '#{name}' because deb packages " \
                    " don't work so good with uppercase names")
-      dep = dep.gsub(name_re) { |n| n.downcase }
     end
 
     if dep.include?("_")


### PR DESCRIPTION
I tried to create a .deb for a custom application that depends on the strangely-named `libMagic++5` package.
As of fpm 1.2.0, the dependency name will be force-downcased (and a warning emitted), which results in a package that I cannot install (since there is no package named `libmagic++5` in the debian archive).

This modest PR keeps the warning but will not mangle the package name in the depend string anymore.
