### PR TITLE
use maximum compression level for RPMs compressed with XZ

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -24,7 +24,7 @@ class FPM::Package::RPM < FPM::Package
 
   COMPRESSION_MAP = {
     "none" => "w0.gzdio",
-    "xz" => "w2.xzdio",
+    "xz" => "w9.xzdio",
     "gzip" => "w9.gzdio",
     "bzip2" => "w9.bzdio"
   } unless defined?(COMPRESSION_MAP)


### PR DESCRIPTION
This can reduce the package size considerably.

For wkhtmltopdf, the RPM for CentOS 7 reduced from 35MiB to around 14.5MiB.
