### PR TITLE
Fix md5sums generation for deb packages

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -718,7 +718,7 @@ class FPM::Package::Deb < FPM::Package
     if not md5_sums.empty?
       File.open(control_path("md5sums"), "w") do |out|
         md5_sums.each do |path, md5|
-          out.puts "#{md5} #{path}"
+          out.puts "#{md5}  #{path}"
         end
       end
       File.chmod(0644, control_path("md5sums"))


### PR DESCRIPTION
Since version 1.17.2, dpkg includes a `--verify` operation mode which is roughly comparable to what `rpm --verify` does. Among the checks, it verifies MD5 sums of installed files using `/var/lib/dpkg/info/<package>.md5sums` like debsums used to do.

Unfortunately, `dpkg --verify` _insists_ on having the md5sums control file formatted exactly as it would be produced by a run of md5sum (hash, two spaces, file path), if a single md5sums file is badly formatted it will die with a "missing value separator" error.

This PR addresses this (debatable) behavior by adding the missing space. It should be noted that this is probably a dpkg issue (md5sum, debsums and lintian itself are more forgiving), but the aforementioned version is already shipping on recent Ubuntu versions and it would be troublesome to get it fixed.
