### PR TITLE
Adds RPM input spec test

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -303,7 +303,6 @@ class FPM::Package::RPM < FPM::Package
   end # def converted
 
   def rpm_get_trigger_type(flag)
-    puts "#{flag.to_s(2)}"
     if (flag & (1 << 25)) == (1 << 25)
        :rpm_trigger_before_install
     elsif (flag & (1 << 16)) == (1 << 16)


### PR DESCRIPTION
To make sure #802, doesn't happen again, here are some tests for the rpm input method.

While doing these tests, I uncovered a bug in arr-pm. Pull Request #5 in jordansissel/ruby-arr-pm will fix it. Until that pull request is merged, the tests will fail.

Also, removes some debugging output that got forgotten when using rpm triggers.