### PR TITLE
pyfpm: Fall back to __str__ when encoding package metadata as JSON

### DIFF
--- a/lib/fpm/package/pyfpm/get_metadata.py
+++ b/lib/fpm/package/pyfpm/get_metadata.py
@@ -90,7 +90,15 @@ class get_metadata(Command):
 
         output = open(self.output, "w")
         if hasattr(json, 'dumps'):
-            output.write(json.dumps(data, indent=2))
+            def default_to_str(obj):
+                """ Fall back to using __str__ if possible """
+                # This checks if the class of obj defines __str__ itself,
+                # so we don't fall back to an inherited __str__ method.
+                if "__str__" in type(obj).__dict__:
+                    return str(obj)
+                return json.JSONEncoder.default(self, obj)
+
+            output.write(json.dumps(data, indent=2, default=default_to_str))
         else:
             # For Python 2.5 and Debian's python-json
             output.write(json.write(data))


### PR DESCRIPTION
This is a fix for unittest2, as it's [setup.py](https://hg.python.org/unittest2/file/bfdcdc6bdb89/setup.py#l13) passes a non-string parameter for `version` into `setup()`. Trying to package it with fpm results in this nastiness:

`fpm -s python -t rpm --debug  unittest2`
```
...
running get_metadata {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
Traceback (most recent call last): {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "setup.py", line 87, in <module> {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    setup(**params) {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib64/python2.6/distutils/core.py", line 152, in setup {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    dist.run_commands() {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib64/python2.6/distutils/dist.py", line 975, in run_commands {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    self.run_command(cmd) {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib64/python2.6/distutils/dist.py", line 995, in run_command {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    cmd_obj.run() {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib/ruby/gems/1.8/gems/fpm-1.3.2/lib/fpm/package/pyfpm/get_metadata.py", line 93, in run {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    output.write(json.dumps(data, indent=2)) {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib64/python2.6/json/__init__.py", line 237, in dumps {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    **kw).encode(obj) {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib64/python2.6/json/encoder.py", line 367, in encode {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    chunks = list(self.iterencode(o)) {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib64/python2.6/json/encoder.py", line 309, in _iterencode {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    for chunk in self._iterencode_dict(o, markers): {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib64/python2.6/json/encoder.py", line 275, in _iterencode_dict {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    for chunk in self._iterencode(value, markers): {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib64/python2.6/json/encoder.py", line 317, in _iterencode {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    for chunk in self._iterencode_default(o, markers): {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib64/python2.6/json/encoder.py", line 323, in _iterencode_default {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    newobj = self.default(o) {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
  File "/usr/lib64/python2.6/json/encoder.py", line 344, in default {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
    raise TypeError(repr(o) + " is not JSON serializable") {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
TypeError: <__main__.late_version instance at 0x7eff3205b518> is not JSON serializable {:line=>"46", :file=>"cabin/mixins/pipe.rb", :level=>:info}
Process failed: /bin/bash failed (exit code 1). Full command was:["/bin/bash", "-c", "env PYTHONPATH=/usr/lib/ruby/gems/1.8/gems/fpm-1.3.2/lib/fpm/package python setup.py --command-packages=pyfpm get_metadata --output=/tmp/package-python-build20141120-2513-uj2xh/metadata.json"] {:line=>"468", :file=>"fpm/command.rb", :level=>:error}
```

This PR passes a default method to the JSONEncoder that tries to fall back to calling str() on an object, but only if that object's class has a __str__ method defined (not inherited).

Alternatively, we could just wrap the call to `self.distribution.get_version()` on line 62 in `str()` - this would work too (though I noticed this after already fixing it with the default method).