### PR TITLE
Remove errant space in debian postinst_upgrade.sh

### DIFF
--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -10,7 +10,7 @@ after_install() {
 <% end -%>
 }
 
-if [ "${1}" = "configure " -a -z "${2}" ]
+if [ "${1}" = "configure" -a -z "${2}" ]
 then
     # "after install" here
     after_install


### PR DESCRIPTION
This space was preventing postinst scripts to run on initial install of the .deb package
