### PR TITLE
Add package metadata to slug file format

### DIFF
--- a/lib/fpm/package/sh.rb
+++ b/lib/fpm/package/sh.rb
@@ -11,7 +11,7 @@ require "digest"
 #
 # This class only supports output of packages.
 #
-# The sh package is a single sh file with a bzipped tar payload concatenated to the end.
+# The sh package is a single sh file with a tar payload concatenated to the end.
 # The script can unpack the tarball to install it and call optional post install scripts.
 class FPM::Package::Sh < FPM::Package
 

--- a/spec/fpm/package/sh_spec.rb
+++ b/spec/fpm/package/sh_spec.rb
@@ -1,0 +1,40 @@
+require "spec_setup"
+require "fpm" # local
+require "fpm/package/sh" # local
+
+shell_is_bash = (%r{/bash} =~ ENV['SHELL'])
+if !shell_is_bash
+  Cabin::Channel.get("rspec").warn("Skipping SH pkg tests which require a BASH shell.")
+end
+
+describe FPM::Package::Sh do
+  describe "#output", :if => shell_is_bash do
+    before :all do
+      # output a package, use it as the input, set the subject to that input
+      # package. This helps ensure that we can write and read packages
+      # properly.
+      tmpfile = Tempfile.new("fpm-test-sh")
+      @target = tmpfile.path
+      # The target file must not exist.
+      tmpfile.unlink
+
+      @original = FPM::Package::Sh.new
+      @original.output(@target)
+    end
+
+    after :all do
+      @original.cleanup
+    end # after
+
+    context "package contents" do
+      it "should contain a ARCHIVE segment" do
+        insist { File.readlines(@target).any? {|l| l.chomp == '__ARCHIVE__' } } == true
+      end
+
+      it "should contain a METADATA segment" do
+        insist { File.readlines(@target).any? {|l| l.chomp == '__METADATA__' } } == true
+      end
+    end # package attributes
+  end # #output
+end # describe FPM::Package::Sh
+

--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -242,6 +242,12 @@ function clean_out_old_releases(){
     fi
 }
 
+function print_package_metadata(){
+    local metadata_line=$(grep -a -n -m1 '__METADATA__$' $0 | sed 's/:.*//')
+    local archive_line=$(grep -a -n -m1 '__ARCHIVE__$' $0 | sed 's/:.*//')
+    sed -n "$((metadata_line + 1)),$((archive_line - 1)) p" $0
+}
+
 function print_usage(){
     echo "Usage: `basename $0` [options]"
     echo "Install this package"
@@ -275,7 +281,7 @@ function log(){
 }
 
 function parse_args() {
-    args=`getopt i:o:rfuyvh $*`
+    args=`getopt mi:o:rfuyvh $*`
 
     if [ $? != 0 ] ; then
         print_usage
@@ -286,6 +292,10 @@ function parse_args() {
     do
         case "$i"
             in
+            -m)
+                print_package_metadata
+                exit 0
+                shift;;
             -r)
                 USE_FLAT_RELEASE_DIRECTORY=1
                 shift;;
@@ -331,4 +341,6 @@ main
 save_environment $(fpm_metadata_file)
 exit 0
 
+__METADATA__
+<%= package_metadata if respond_to?(:package_metadata) %>
 __ARCHIVE__


### PR DESCRIPTION
We're starting to use the SH package format for a number of different project types. As part of this, we're adding some metadata to the packages so that we can easily determine how to deploy them. For example, a Rails project will want to roll unicorns, but a package of JavaScript assets would be installed differently. For other users, this is a no-op, with the exception of seeing a new `__METADATA__` line in the file, just prior to the `__ARCHIVE__` line.
@jordansissel 