### PR TITLE
Ensure the post-pre install deb script functions aren't empty.

### DIFF
--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -1,12 +1,16 @@
 after_upgrade() {
 <% if script?(:after_upgrade) -%>
-<%=  script(:after_upgrade) %>
+<%= script(:after_upgrade) %>
+<% else -%>
+true
 <% end -%>
 }
 
 after_install() {
 <% if script?(:after_install) -%>
-<%=  script(:after_install) %>
+<%= script(:after_install) %>
+<% else -%>
+true
 <% end -%>
 }
 

--- a/templates/deb/postrm_upgrade.sh.erb
+++ b/templates/deb/postrm_upgrade.sh.erb
@@ -1,10 +1,13 @@
 after_remove() {
 <% if script?(:after_remove) -%>
-<%=  script(:after_remove) %>
+<%= script(:after_remove) %>
+<% else -%>
+true
 <% end -%>
 }
 
 dummy() {
+true
 }
 
 

--- a/templates/deb/preinst_upgrade.sh.erb
+++ b/templates/deb/preinst_upgrade.sh.erb
@@ -1,12 +1,16 @@
 before_upgrade() {
 <% if script?(:before_upgrade) -%>
-<%=  script(:before_upgrade) %>
+<%= script(:before_upgrade) %>
+<% else -%>
+true
 <% end -%>
 }
 
 before_install() {
 <% if script?(:before_install) -%>
-<%=  script(:before_install) %>
+<%= script(:before_install) %>
+<% else -%>
+true
 <% end -%>
 }
 

--- a/templates/deb/prerm_upgrade.sh.erb
+++ b/templates/deb/prerm_upgrade.sh.erb
@@ -1,10 +1,13 @@
 before_remove() {
 <% if script?(:before_remove) -%>
-<%=  script(:before_remove) %>
+<%= script(:before_remove) %>
+<% else -%>
+true
 <% end -%>
 }
 
 dummy() {
+true
 }
 
 if [ "${1}" = "remove" -a -z "${2}" ]


### PR DESCRIPTION
I was getting errors locally because these functions were empty when a script hadn't been defined. Apparently there needs to be something inside them for these files to be valid bash?