### PR TITLE
Fix up debian maintenance script templates

### DIFF
--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -8,6 +8,8 @@ after_upgrade() {
 after_install() {
 <% if script?(:after_install) -%>
 <%=  script(:after_install) %>
+<% else -%>
+  :
 <% end -%>
 }
 

--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -1,3 +1,4 @@
+#!/bin/sh
 after_upgrade() {
 <% if script?(:after_upgrade) -%>
 <%=  script(:after_upgrade) %>

--- a/templates/deb/postrm_upgrade.sh.erb
+++ b/templates/deb/postrm_upgrade.sh.erb
@@ -1,3 +1,4 @@
+#!/bin/sh
 after_remove() {
 <% if script?(:after_remove) -%>
 <%=  script(:after_remove) %>

--- a/templates/deb/postrm_upgrade.sh.erb
+++ b/templates/deb/postrm_upgrade.sh.erb
@@ -6,6 +6,7 @@ after_remove() {
 }
 
 dummy() {
+    :
 }
 
 

--- a/templates/deb/preinst_upgrade.sh.erb
+++ b/templates/deb/preinst_upgrade.sh.erb
@@ -8,6 +8,8 @@ before_upgrade() {
 before_install() {
 <% if script?(:before_install) -%>
 <%=  script(:before_install) %>
+<% else -%>
+  :
 <% end -%>
 }
 

--- a/templates/deb/preinst_upgrade.sh.erb
+++ b/templates/deb/preinst_upgrade.sh.erb
@@ -1,3 +1,4 @@
+#!/bin/sh
 before_upgrade() {
 <% if script?(:before_upgrade) -%>
 <%=  script(:before_upgrade) %>

--- a/templates/deb/prerm_upgrade.sh.erb
+++ b/templates/deb/prerm_upgrade.sh.erb
@@ -1,3 +1,4 @@
+#!/bin/sh
 before_remove() {
 <% if script?(:before_remove) -%>
 <%=  script(:before_remove) %>

--- a/templates/deb/prerm_upgrade.sh.erb
+++ b/templates/deb/prerm_upgrade.sh.erb
@@ -6,6 +6,7 @@ before_remove() {
 }
 
 dummy() {
+    :
 }
 
 if [ "${1}" = "remove" -a -z "${2}" ]


### PR DESCRIPTION
These templates are only used when --before-upgrade and --after-upgrade are used.