### PR TITLE
Adding guntar installation note for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ which you must map to your distribution's package names.
 You can install fpm with gem:
 
     gem install fpm
+    
+(On OS X, you may also need gnutar: `brew install gnu-tar`.)
 
 Building a package named "awesome" might look something like this:
 


### PR DESCRIPTION
I think this one's fairly self-explanatory, but it should save mac users a few minutes of googling around.