### PR TITLE
Add --python-disable-dependency option to disable specific python dependencies

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -71,7 +71,7 @@ class FPM::Package::Python < FPM::Package
     "to 'setup.py install' command."
   option "--disable-dependency", "python_package_name",
     "The python package name to remove from dependency list",
-    :multivalued => true, :attribute_name => :python_disable_dependencies,
+    :multivalued => true, :attribute_name => :python_disable_dependency,
     :default => []
 
   private
@@ -232,7 +232,7 @@ class FPM::Package::Python < FPM::Package
         end
         name, cmp, version = match.captures
 
-        next if attributes[:python_disable_dependencies].include?(name)
+        next if attributes[:python_disable_dependency].include?(name)
 
         # convert == to =
         if cmp == "=="

--- a/spec/fixtures/python/setup.py
+++ b/spec/fixtures/python/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(name="Example",
       version="1.0",
@@ -8,6 +8,6 @@ setup(name="Example",
       url="sample url",
       packages=[],
       package_dir={},
-      requires=["Dependency1", "dependency2"],
+      install_requires=["Dependency1", "dependency2"],
       )
 

--- a/spec/fpm/package/python_spec.rb
+++ b/spec/fpm/package/python_spec.rb
@@ -99,6 +99,28 @@ describe FPM::Package::Python, :if => python_usable? do
     end
   end
 
+  context "when :python_dependencies is set" do
+    before :each do
+      subject.attributes[:python_dependencies] = true
+    end
+
+    it "it should include the dependencies from setup.py" do
+      subject.input(example_dir)
+      insist { subject.dependencies.sort } == ["python-dependency1  ","python-dependency2  "]
+    end
+
+    context "and :python_disable_dependency is set" do
+      before :each do
+        subject.attributes[:python_disable_dependency] = "Dependency1"
+      end
+
+      it "it should exclude the dependency" do
+        subject.input(example_dir)
+        insist { subject.dependencies.sort } == ["python-dependency2  "]
+      end
+    end
+  end
+
   context "when python_obey_requirements_txt? is true" do
     before :each do
       subject.attributes[:python_obey_requirements_txt?] = true
@@ -114,6 +136,12 @@ describe FPM::Package::Python, :if => python_usable? do
         subject.input(example_dir)
         insist { subject.dependencies.sort } == ["python-rtxt-dep1 > 0.1", "python-rtxt-dep2 = 0.1"]
       end
+
+      it "it should exclude the dependency" do
+        subject.attributes[:python_disable_dependency] = "rtxt-dep1"
+        subject.input(example_dir)
+        insist { subject.dependencies.sort } == ["python-rtxt-dep2 = 0.1"]
+      end
     end
 
     context "and :python_fix_dependencies? is false" do
@@ -124,6 +152,12 @@ describe FPM::Package::Python, :if => python_usable? do
       it "it should load requirements.txt" do
         subject.input(example_dir)
         insist { subject.dependencies.sort } == ["rtxt-dep1 > 0.1", "rtxt-dep2 = 0.1"]
+      end
+
+      it "it should exclude the dependency" do
+        subject.attributes[:python_disable_dependency] = "rtxt-dep1"
+        subject.input(example_dir)
+        insist { subject.dependencies.sort } == ["rtxt-dep2 = 0.1"]
       end
     end
   end


### PR DESCRIPTION
This is useful for example in the case of a dependency on the python
PyYAML package.

By default, this dependency gets translated to a debian package
dependency on python-pyyaml. That package does not exist on Debian
systems (it is called python-yaml), so a way to override the dependency is needed.

A similar option exists already for gems (--gem-disable-dependency).