### PR TITLE
cpan.rb - export the environment variables output by local::lib.

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -233,11 +233,10 @@ class FPM::Package::CPAN < FPM::Package
   end
 
   def export_local_lib_env(local_lib_path)
-    # Iterate over the output of local::lib
+    # Iterate over the output of local::lib line by line
     `#{attributes[:cpan_perl_bin]} -Mlocal::lib=#{local_lib_path}`.lines.each do |line|
       # local::lib's output is in the form:
-      # ENV_VAR="some value"; export $ENV_VAR;
-      #
+      # 'ENV_VAR="some value"; export $ENV_VAR;'
       # This regular expression strips everything from the semicolon in front
       # of 'export' to the end of the line, then splits on the equals sign,
       # limiting the returned array to two elements.
@@ -249,7 +248,7 @@ class FPM::Package::CPAN < FPM::Package
       # Set the current environment in accordance with local::lib's output.
       # The subshell call to echo is necessary because some environment
       # variables are defined in terms of other such variables; this technique
-      # expands the variables-with-variables.
+      # expands the variables-within-variables.
       ENV[k] = `echo #{v}`
     end
   end

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -171,22 +171,16 @@ class FPM::Package::CPAN < FPM::Package
                      --destdir #{staging_path} --prefix #{prefix} --destdir #{staging_path}")
         else
            safesystem("./Build", "install",
-                     "--prefix", prefix, "--destdir", staging_path,
-                     # Empty install_base to avoid local::lib being used.
-                     "--install_base", "")
+                     "--prefix", prefix, "--destdir", staging_path)
         end
       elsif File.exists?("Makefile.PL")
         if attributes[:cpan_perl_lib_path]
           perl_lib_path = attributes[:cpan_perl_lib_path]
           safesystem(attributes[:cpan_perl_bin],
-                     "Makefile.PL", "PREFIX=#{prefix}", "LIB=#{perl_lib_path}",
-                     # Empty install_base to avoid local::lib being used.
-                     "INSTALL_BASE=")
+                     "Makefile.PL", "PREFIX=#{prefix}", "LIB=#{perl_lib_path}")
         else
           safesystem(attributes[:cpan_perl_bin],
-                     "Makefile.PL", "PREFIX=#{prefix}",
-                     # Empty install_base to avoid local::lib being used.
-                     "INSTALL_BASE=")
+                     "Makefile.PL", "PREFIX=#{prefix}")
         end
         if attributes[:cpan_test?]
           make = [ "env", "PERL5LIB=#{build_path("cpan/lib/perl5")}", "make" ]
@@ -242,7 +236,7 @@ class FPM::Package::CPAN < FPM::Package
       # limiting the returned array to two elements.
       (k, v) = line.chomp.gsub(/;\s+export.*$/, '').split("=", 2)
 
-      # Skip these, since they wreak havoc with the 'INSTALL_BASE=' trick.
+      # Skip these, since they wreak havoc when PREFIX # is set.
       next if k == "PERL_MM_OPT" or k == "PERL_MB_OPT"
 
       # Set the current environment in accordance with local::lib's output.

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -50,28 +50,19 @@ class FPM::Package::CPAN < FPM::Package
 
     # Read package metadata (name, version, etc)
     if File.exists?(File.join(moduledir, "META.json"))
-      local_metadata = JSON.parse(File.read(File.join(moduledir, ("META.json"))))
+      metadata = JSON.parse(File.read(File.join(moduledir, ("META.json"))))
     elsif File.exists?(File.join(moduledir, ("META.yml")))
       require "yaml"
-      local_metadata = YAML.load_file(File.join(moduledir, ("META.yml")))
+      metadata = YAML.load_file(File.join(moduledir, ("META.yml")))
     elsif File.exists?(File.join(moduledir, "MYMETA.json"))
-      local_metadata = JSON.parse(File.read(File.join(moduledir, ("MYMETA.json"))))
+      metadata = JSON.parse(File.read(File.join(moduledir, ("MYMETA.json"))))
     elsif File.exists?(File.join(moduledir, ("MYMETA.yml")))
       require "yaml"
-      local_metadata = YAML.load_file(File.join(moduledir, ("MYMETA.yml")))
+      metadata = YAML.load_file(File.join(moduledir, ("MYMETA.yml")))
+    else
+      raise FPM::InvalidPackageConfiguration, 
+        "Could not find package metadata. Checked for META.json and META.yml"
     end
-
-    # Merge the MetaCPAN query result and the metadata pulled from the local
-    # META file(s).  The local data overwrites the query data for all keys the
-    # two hashes have in common.  Merge with an empty hash if there was no
-    # local META file.
-    metadata = result.merge(local_metadata || {})
-
-    if metadata.empty?
-      raise FPM::InvalidPackageConfiguration,
-        "Could not find package metadata. Checked for META.json, META.yml, and MetaCPAN API data"
-    end
-
     self.version = metadata["version"]
     self.description = metadata["abstract"]
 
@@ -116,7 +107,7 @@ class FPM::Package::CPAN < FPM::Package
 
     safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
 
-    if !attributes[:no_auto_depends?]
+    if !attributes[:no_auto_depends?] 
       unless metadata["requires"].nil?
         metadata["requires"].each do |dep_name, version|
           # Special case for representing perl core as a version.
@@ -125,7 +116,7 @@ class FPM::Package::CPAN < FPM::Package
             next
           end
           dep = search(dep_name)
-
+          
           if dep.include?("distribution")
             name = fix_name(dep["distribution"])
           else
@@ -215,7 +206,7 @@ class FPM::Package::CPAN < FPM::Package
 
 
       else
-        raise FPM::InvalidPackageConfiguration,
+        raise FPM::InvalidPackageConfiguration, 
           "I don't know how to build #{name}. No Makefile.PL nor " \
           "Build.PL found"
       end
@@ -240,10 +231,10 @@ class FPM::Package::CPAN < FPM::Package
     # Find any shared objects in the staging directory to set architecture as
     # native if found; otherwise keep the 'all' default.
     Find.find(staging_path) do |path|
-      if path =~ /\.so$/
+      if path =~ /\.so$/  
         logger.info("Found shared library, setting architecture=native",
                      :path => path)
-        self.architecture = "native"
+        self.architecture = "native" 
       end
     end
   end
@@ -289,7 +280,7 @@ class FPM::Package::CPAN < FPM::Package
     release_metadata = JSON.parse(data)
     archive = release_metadata["archive"]
 
-    # should probably be basepathed from the url
+    # should probably be basepathed from the url 
     tarball = File.basename(archive)
 
     url_base = "http://www.cpan.org/"
@@ -298,7 +289,7 @@ class FPM::Package::CPAN < FPM::Package
     #url = "http://www.cpan.org/CPAN/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{tarball}"
     url = "#{url_base}/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{archive}"
     logger.debug("Fetching perl module", :url => url)
-
+    
     begin
       response = httpfetch(url)
     rescue Net::HTTPServerException => e
@@ -345,7 +336,7 @@ class FPM::Package::CPAN < FPM::Package
   def httpfetch(url)
     uri = URI.parse(url)
     if ENV['http_proxy']
-      proxy = URI.parse(ENV['http_proxy'])
+      proxy = URI.parse(ENV['http_proxy'])  
       http = Net::HTTP.Proxy(proxy.host,proxy.port,proxy.user,proxy.password).new(uri.host, uri.port)
     else
       http = Net::HTTP.new(uri.host, uri.port)

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -50,19 +50,28 @@ class FPM::Package::CPAN < FPM::Package
 
     # Read package metadata (name, version, etc)
     if File.exists?(File.join(moduledir, "META.json"))
-      metadata = JSON.parse(File.read(File.join(moduledir, ("META.json"))))
+      local_metadata = JSON.parse(File.read(File.join(moduledir, ("META.json"))))
     elsif File.exists?(File.join(moduledir, ("META.yml")))
       require "yaml"
-      metadata = YAML.load_file(File.join(moduledir, ("META.yml")))
+      local_metadata = YAML.load_file(File.join(moduledir, ("META.yml")))
     elsif File.exists?(File.join(moduledir, "MYMETA.json"))
-      metadata = JSON.parse(File.read(File.join(moduledir, ("MYMETA.json"))))
+      local_metadata = JSON.parse(File.read(File.join(moduledir, ("MYMETA.json"))))
     elsif File.exists?(File.join(moduledir, ("MYMETA.yml")))
       require "yaml"
-      metadata = YAML.load_file(File.join(moduledir, ("MYMETA.yml")))
-    else
-      raise FPM::InvalidPackageConfiguration, 
-        "Could not find package metadata. Checked for META.json and META.yml"
+      local_metadata = YAML.load_file(File.join(moduledir, ("MYMETA.yml")))
     end
+
+    # Merge the MetaCPAN query result and the metadata pulled from the local
+    # META file(s).  The local data overwrites the query data for all keys the
+    # two hashes have in common.  Merge with an empty hash if there was no
+    # local META file.
+    metadata = result.merge(local_metadata || {})
+
+    if metadata.empty?
+      raise FPM::InvalidPackageConfiguration,
+        "Could not find package metadata. Checked for META.json, META.yml, and MetaCPAN API data"
+    end
+
     self.version = metadata["version"]
     self.description = metadata["abstract"]
 
@@ -107,7 +116,7 @@ class FPM::Package::CPAN < FPM::Package
 
     safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
 
-    if !attributes[:no_auto_depends?] 
+    if !attributes[:no_auto_depends?]
       unless metadata["requires"].nil?
         metadata["requires"].each do |dep_name, version|
           # Special case for representing perl core as a version.
@@ -116,7 +125,7 @@ class FPM::Package::CPAN < FPM::Package
             next
           end
           dep = search(dep_name)
-          
+
           if dep.include?("distribution")
             name = fix_name(dep["distribution"])
           else
@@ -206,7 +215,7 @@ class FPM::Package::CPAN < FPM::Package
 
 
       else
-        raise FPM::InvalidPackageConfiguration, 
+        raise FPM::InvalidPackageConfiguration,
           "I don't know how to build #{name}. No Makefile.PL nor " \
           "Build.PL found"
       end
@@ -231,10 +240,10 @@ class FPM::Package::CPAN < FPM::Package
     # Find any shared objects in the staging directory to set architecture as
     # native if found; otherwise keep the 'all' default.
     Find.find(staging_path) do |path|
-      if path =~ /\.so$/  
+      if path =~ /\.so$/
         logger.info("Found shared library, setting architecture=native",
                      :path => path)
-        self.architecture = "native" 
+        self.architecture = "native"
       end
     end
   end
@@ -280,7 +289,7 @@ class FPM::Package::CPAN < FPM::Package
     release_metadata = JSON.parse(data)
     archive = release_metadata["archive"]
 
-    # should probably be basepathed from the url 
+    # should probably be basepathed from the url
     tarball = File.basename(archive)
 
     url_base = "http://www.cpan.org/"
@@ -289,7 +298,7 @@ class FPM::Package::CPAN < FPM::Package
     #url = "http://www.cpan.org/CPAN/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{tarball}"
     url = "#{url_base}/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{archive}"
     logger.debug("Fetching perl module", :url => url)
-    
+
     begin
       response = httpfetch(url)
     rescue Net::HTTPServerException => e
@@ -336,7 +345,7 @@ class FPM::Package::CPAN < FPM::Package
   def httpfetch(url)
     uri = URI.parse(url)
     if ENV['http_proxy']
-      proxy = URI.parse(ENV['http_proxy'])  
+      proxy = URI.parse(ENV['http_proxy'])
       http = Net::HTTP.Proxy(proxy.host,proxy.port,proxy.user,proxy.password).new(uri.host, uri.port)
     else
       http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
See #843 -- `ExtUtils::MakeMaker` doesn't like it when both `PREFIX` and `INSTALL_BASE` are defined, and some CPAN packages don't play nice with the `INSTALL_BASE=` trick.  This pull request deals with this issue by exporting `local::lib`'s environment variables into the environment of the current process prior to calling `Build.PL`/`Makefile.PL`, skipping the `PERL_MM_OPT` and `PERL_MB_OPT` environment variables that were at the root of the problem.