### PR TITLE
--[no-]cpan-test now works as advertised

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -104,7 +104,7 @@ class FPM::Package::CPAN < FPM::Package
     # This flag causes cpanm to ONLY download dependencies, skipping the target
     # module itself.  This is fine, because the target module has already been
     # downloaded, and there's no need to download twice, test twice, etc.
-    cpanm_flags = ["--installdeps"]
+    cpanm_flags += ["--installdeps"]
     cpanm_flags += ["-n"] if !attributes[:cpan_test?]
     cpanm_flags += ["--mirror", "#{attributes[:cpan_mirror]}"] if !attributes[:cpan_mirror].nil?
     cpanm_flags += ["--mirror-only"] if attributes[:cpan_mirror_only?] && !attributes[:cpan_mirror].nil?

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -109,8 +109,6 @@ class FPM::Package::CPAN < FPM::Package
     cpanm_flags += ["--mirror", "#{attributes[:cpan_mirror]}"] if !attributes[:cpan_mirror].nil?
     cpanm_flags += ["--mirror-only"] if attributes[:cpan_mirror_only?] && !attributes[:cpan_mirror].nil?
 
-require 'pp'
-PP.pp cpanm_flags
     safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
 
     if !attributes[:no_auto_depends?]

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -60,7 +60,7 @@ class FPM::Package::CPAN < FPM::Package
       require "yaml"
       metadata = YAML.load_file(File.join(moduledir, ("MYMETA.yml")))
     else
-      raise FPM::InvalidPackageConfiguration, 
+      raise FPM::InvalidPackageConfiguration,
         "Could not find package metadata. Checked for META.json and META.yml"
     end
     self.version = metadata["version"]
@@ -101,13 +101,13 @@ class FPM::Package::CPAN < FPM::Package
     logger.info("Installing any build or configure dependencies")
 
     cpanm_flags = ["-L", build_path("cpan"), moduledir]
-    cpanm_flags += ["-n"] if attributes[:cpan_test?]
+    cpanm_flags += ["-n"] if !attributes[:cpan_test?]
     cpanm_flags += ["--mirror", "#{attributes[:cpan_mirror]}"] if !attributes[:cpan_mirror].nil?
     cpanm_flags += ["--mirror-only"] if attributes[:cpan_mirror_only?] && !attributes[:cpan_mirror].nil?
 
     safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
 
-    if !attributes[:no_auto_depends?] 
+    if !attributes[:no_auto_depends?]
       unless metadata["requires"].nil?
         metadata["requires"].each do |dep_name, version|
           # Special case for representing perl core as a version.
@@ -116,7 +116,7 @@ class FPM::Package::CPAN < FPM::Package
             next
           end
           dep = search(dep_name)
-          
+
           if dep.include?("distribution")
             name = fix_name(dep["distribution"])
           else
@@ -206,7 +206,7 @@ class FPM::Package::CPAN < FPM::Package
 
 
       else
-        raise FPM::InvalidPackageConfiguration, 
+        raise FPM::InvalidPackageConfiguration,
           "I don't know how to build #{name}. No Makefile.PL nor " \
           "Build.PL found"
       end
@@ -231,10 +231,10 @@ class FPM::Package::CPAN < FPM::Package
     # Find any shared objects in the staging directory to set architecture as
     # native if found; otherwise keep the 'all' default.
     Find.find(staging_path) do |path|
-      if path =~ /\.so$/  
+      if path =~ /\.so$/
         logger.info("Found shared library, setting architecture=native",
                      :path => path)
-        self.architecture = "native" 
+        self.architecture = "native"
       end
     end
   end
@@ -280,7 +280,7 @@ class FPM::Package::CPAN < FPM::Package
     release_metadata = JSON.parse(data)
     archive = release_metadata["archive"]
 
-    # should probably be basepathed from the url 
+    # should probably be basepathed from the url
     tarball = File.basename(archive)
 
     url_base = "http://www.cpan.org/"
@@ -289,7 +289,7 @@ class FPM::Package::CPAN < FPM::Package
     #url = "http://www.cpan.org/CPAN/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{tarball}"
     url = "#{url_base}/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{archive}"
     logger.debug("Fetching perl module", :url => url)
-    
+
     begin
       response = httpfetch(url)
     rescue Net::HTTPServerException => e
@@ -336,7 +336,7 @@ class FPM::Package::CPAN < FPM::Package
   def httpfetch(url)
     uri = URI.parse(url)
     if ENV['http_proxy']
-      proxy = URI.parse(ENV['http_proxy'])  
+      proxy = URI.parse(ENV['http_proxy'])
       http = Net::HTTP.Proxy(proxy.host,proxy.port,proxy.user,proxy.password).new(uri.host, uri.port)
     else
       http = Net::HTTP.new(uri.host, uri.port)

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -101,10 +101,16 @@ class FPM::Package::CPAN < FPM::Package
     logger.info("Installing any build or configure dependencies")
 
     cpanm_flags = ["-L", build_path("cpan"), moduledir]
+    # This flag causes cpanm to ONLY download dependencies, skipping the target
+    # module itself.  This is fine, because the target module has already been
+    # downloaded, and there's no need to download twice, test twice, etc.
+    cpanm_flags = ["--installdeps"]
     cpanm_flags += ["-n"] if !attributes[:cpan_test?]
     cpanm_flags += ["--mirror", "#{attributes[:cpan_mirror]}"] if !attributes[:cpan_mirror].nil?
     cpanm_flags += ["--mirror-only"] if attributes[:cpan_mirror_only?] && !attributes[:cpan_mirror].nil?
 
+require 'pp'
+PP.pp cpanm_flags
     safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
 
     if !attributes[:no_auto_depends?]

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -50,28 +50,19 @@ class FPM::Package::CPAN < FPM::Package
 
     # Read package metadata (name, version, etc)
     if File.exists?(File.join(moduledir, "META.json"))
-      local_metadata = JSON.parse(File.read(File.join(moduledir, ("META.json"))))
+      metadata = JSON.parse(File.read(File.join(moduledir, ("META.json"))))
     elsif File.exists?(File.join(moduledir, ("META.yml")))
       require "yaml"
-      local_metadata = YAML.load_file(File.join(moduledir, ("META.yml")))
+      metadata = YAML.load_file(File.join(moduledir, ("META.yml")))
     elsif File.exists?(File.join(moduledir, "MYMETA.json"))
-      local_metadata = JSON.parse(File.read(File.join(moduledir, ("MYMETA.json"))))
+      metadata = JSON.parse(File.read(File.join(moduledir, ("MYMETA.json"))))
     elsif File.exists?(File.join(moduledir, ("MYMETA.yml")))
       require "yaml"
-      local_metadata = YAML.load_file(File.join(moduledir, ("MYMETA.yml")))
+      metadata = YAML.load_file(File.join(moduledir, ("MYMETA.yml")))
+    else
+      raise FPM::InvalidPackageConfiguration, 
+        "Could not find package metadata. Checked for META.json and META.yml"
     end
-
-    # Merge the MetaCPAN query result and the metadata pulled from the local
-    # META file(s).  The local data overwrites the query data for all keys the
-    # two hashes have in common.  Merge with an empty hash if there was no
-    # local META file.
-    metadata = result.merge(local_metadata || {})
-
-    if metadata.empty?
-      raise FPM::InvalidPackageConfiguration,
-        "Could not find package metadata. Checked for META.json, META.yml, and MetaCPAN API data"
-    end
-
     self.version = metadata["version"]
     self.description = metadata["abstract"]
 
@@ -116,7 +107,7 @@ class FPM::Package::CPAN < FPM::Package
 
     safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
 
-    if !attributes[:no_auto_depends?]
+    if !attributes[:no_auto_depends?] 
       unless metadata["requires"].nil?
         metadata["requires"].each do |dep_name, version|
           # Special case for representing perl core as a version.
@@ -125,7 +116,7 @@ class FPM::Package::CPAN < FPM::Package
             next
           end
           dep = search(dep_name)
-
+          
           if dep.include?("distribution")
             name = fix_name(dep["distribution"])
           else
@@ -215,7 +206,7 @@ class FPM::Package::CPAN < FPM::Package
 
 
       else
-        raise FPM::InvalidPackageConfiguration,
+        raise FPM::InvalidPackageConfiguration, 
           "I don't know how to build #{name}. No Makefile.PL nor " \
           "Build.PL found"
       end
@@ -240,10 +231,10 @@ class FPM::Package::CPAN < FPM::Package
     # Find any shared objects in the staging directory to set architecture as
     # native if found; otherwise keep the 'all' default.
     Find.find(staging_path) do |path|
-      if path =~ /\.so$/
+      if path =~ /\.so$/  
         logger.info("Found shared library, setting architecture=native",
                      :path => path)
-        self.architecture = "native"
+        self.architecture = "native" 
       end
     end
   end
@@ -289,7 +280,7 @@ class FPM::Package::CPAN < FPM::Package
     release_metadata = JSON.parse(data)
     archive = release_metadata["archive"]
 
-    # should probably be basepathed from the url
+    # should probably be basepathed from the url 
     tarball = File.basename(archive)
 
     url_base = "http://www.cpan.org/"
@@ -298,7 +289,7 @@ class FPM::Package::CPAN < FPM::Package
     #url = "http://www.cpan.org/CPAN/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{tarball}"
     url = "#{url_base}/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{archive}"
     logger.debug("Fetching perl module", :url => url)
-
+    
     begin
       response = httpfetch(url)
     rescue Net::HTTPServerException => e
@@ -345,7 +336,7 @@ class FPM::Package::CPAN < FPM::Package
   def httpfetch(url)
     uri = URI.parse(url)
     if ENV['http_proxy']
-      proxy = URI.parse(ENV['http_proxy'])
+      proxy = URI.parse(ENV['http_proxy'])  
       http = Net::HTTP.Proxy(proxy.host,proxy.port,proxy.user,proxy.password).new(uri.host, uri.port)
     else
       http = Net::HTTP.new(uri.host, uri.port)

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -50,19 +50,28 @@ class FPM::Package::CPAN < FPM::Package
 
     # Read package metadata (name, version, etc)
     if File.exists?(File.join(moduledir, "META.json"))
-      metadata = JSON.parse(File.read(File.join(moduledir, ("META.json"))))
+      local_metadata = JSON.parse(File.read(File.join(moduledir, ("META.json"))))
     elsif File.exists?(File.join(moduledir, ("META.yml")))
       require "yaml"
-      metadata = YAML.load_file(File.join(moduledir, ("META.yml")))
+      local_metadata = YAML.load_file(File.join(moduledir, ("META.yml")))
     elsif File.exists?(File.join(moduledir, "MYMETA.json"))
-      metadata = JSON.parse(File.read(File.join(moduledir, ("MYMETA.json"))))
+      local_metadata = JSON.parse(File.read(File.join(moduledir, ("MYMETA.json"))))
     elsif File.exists?(File.join(moduledir, ("MYMETA.yml")))
       require "yaml"
-      metadata = YAML.load_file(File.join(moduledir, ("MYMETA.yml")))
-    else
-      raise FPM::InvalidPackageConfiguration, 
-        "Could not find package metadata. Checked for META.json and META.yml"
+      local_metadata = YAML.load_file(File.join(moduledir, ("MYMETA.yml")))
     end
+
+    # Merge the MetaCPAN query result and the metadata pulled from the local
+    # META file(s).  The local data overwrites the query data for all keys the
+    # two hashes have in common.  Merge with an empty hash if there was no
+    # local META file.
+    metadata = result.merge(local_metadata || {})
+
+    if metadata.empty?
+      raise FPM::InvalidPackageConfiguration,
+        "Could not find package metadata. Checked for META.json, META.yml, and MetaCPAN API data"
+    end
+
     self.version = metadata["version"]
     self.description = metadata["abstract"]
 
@@ -107,7 +116,7 @@ class FPM::Package::CPAN < FPM::Package
 
     safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
 
-    if !attributes[:no_auto_depends?] 
+    if !attributes[:no_auto_depends?]
       unless metadata["requires"].nil?
         metadata["requires"].each do |dep_name, version|
           # Special case for representing perl core as a version.
@@ -116,7 +125,7 @@ class FPM::Package::CPAN < FPM::Package
             next
           end
           dep = search(dep_name)
-          
+
           if dep.include?("distribution")
             name = fix_name(dep["distribution"])
           else
@@ -206,7 +215,7 @@ class FPM::Package::CPAN < FPM::Package
 
 
       else
-        raise FPM::InvalidPackageConfiguration, 
+        raise FPM::InvalidPackageConfiguration,
           "I don't know how to build #{name}. No Makefile.PL nor " \
           "Build.PL found"
       end
@@ -231,10 +240,10 @@ class FPM::Package::CPAN < FPM::Package
     # Find any shared objects in the staging directory to set architecture as
     # native if found; otherwise keep the 'all' default.
     Find.find(staging_path) do |path|
-      if path =~ /\.so$/  
+      if path =~ /\.so$/
         logger.info("Found shared library, setting architecture=native",
                      :path => path)
-        self.architecture = "native" 
+        self.architecture = "native"
       end
     end
   end
@@ -280,7 +289,7 @@ class FPM::Package::CPAN < FPM::Package
     release_metadata = JSON.parse(data)
     archive = release_metadata["archive"]
 
-    # should probably be basepathed from the url 
+    # should probably be basepathed from the url
     tarball = File.basename(archive)
 
     url_base = "http://www.cpan.org/"
@@ -289,7 +298,7 @@ class FPM::Package::CPAN < FPM::Package
     #url = "http://www.cpan.org/CPAN/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{tarball}"
     url = "#{url_base}/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{archive}"
     logger.debug("Fetching perl module", :url => url)
-    
+
     begin
       response = httpfetch(url)
     rescue Net::HTTPServerException => e
@@ -336,7 +345,7 @@ class FPM::Package::CPAN < FPM::Package
   def httpfetch(url)
     uri = URI.parse(url)
     if ENV['http_proxy']
-      proxy = URI.parse(ENV['http_proxy'])  
+      proxy = URI.parse(ENV['http_proxy'])
       http = Net::HTTP.Proxy(proxy.host,proxy.port,proxy.user,proxy.password).new(uri.host, uri.port)
     else
       http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
There was a missing `!` in front of `attributes[:cpan_test]`, such that the `-n` (no test) flag was passed to `cpanm` if and only if `attributes[:cpan_test]` was `true`.  This inverts the proper logic: `cpanm` should skip tests if and only if `attributes[:cpan_test]` is `false`.