### PR TITLE
symlinks need full dest path for FileUtils.copy_entry

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -140,7 +140,7 @@ class FPM::Package::Dir < FPM::Package
         copy(source, destination)
       end
     elsif fileinfo.symlink?
-      copy(source, destination)
+      copy(source, File.join(destination, source))
     else
       # Copy all files from 'path' into staging_path
       Find.find(source) do |path|


### PR DESCRIPTION
From http://ruby-doc.org/stdlib-2.2.0/libdoc/fileutils/rdoc/FileUtils.html#method-c-copy_entry:

```
Both of src and dest must be a path name. src must exist, dest must not exist.
```

(tested & working)