### PR TITLE
Default to HTTPS for --python-pypi URL

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -28,7 +28,7 @@ class FPM::Package::Python < FPM::Package
     "is used instead", :default => nil
   option "--pypi", "PYPI_URL",
     "PyPi Server uri for retrieving packages.",
-    :default => "http://pypi.python.org/simple"
+    :default => "https://pypi.python.org/simple"
   option "--package-prefix", "NAMEPREFIX",
     "(DEPRECATED, use --package-name-prefix) Name to prefix the package " \
     "name with." do |value|


### PR DESCRIPTION
Here's a PR for changing the default PyPi base URL for --python-pypi. I've tested this with both `pip` and `easy_install` on OS X.

Thanks for FPM!