### PR TITLE
Fix syntax error in Debian prerm template

### DIFF
--- a/templates/deb/prerm_upgrade.sh.erb
+++ b/templates/deb/prerm_upgrade.sh.erb
@@ -5,6 +5,7 @@ before_remove() {
 }
 
 dummy() {
+ :
 }
 
 if [ "${1}" = "remove" -a -z "${2}" ]


### PR DESCRIPTION
Bash functions may not be empty (http://tldp.org/LDP/abs/html/functions.html) otherwise this error is thrown:

```
prerm: line 9: syntax error near unexpected token `}'
prerm: line 9: `}'
```

Instead, put a single colon (':') in the function body as a NULL operator.