### PR TITLE
Add command line flag for --exclude-file.

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -140,7 +140,6 @@ class FPM::Command < Clamp::Command
     next excludes
   end # -x / --exclude
 
-  # jal 2015.03.13
   option "--exclude-file", "EXLCUDE_PATH",
     "The path to a file containing a newline-sparated list of "\
     "patterns to exclude from input."
@@ -352,7 +351,6 @@ class FPM::Command < Clamp::Command
       end
     end
 
-    # jal
     # If --exclude-file was specified, read it as a file and append to
     # the exclude pattern list.
     if !exclude-file.nil?

--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -139,6 +139,12 @@ class FPM::Command < Clamp::Command
     excludes << val
     next excludes
   end # -x / --exclude
+
+  # jal 2015.03.13
+  option "--exclude-file", "EXLCUDE_PATH",
+    "The path to a file containing a newline-sparated list of "\
+    "patterns to exclude from input."
+
   option "--description", "DESCRIPTION", "Add a description for this package." \
     " You can include '\n' sequences to indicate newline breaks.",
     :default => "no description" do |val|
@@ -343,6 +349,23 @@ class FPM::Command < Clamp::Command
       File.new(inputs, "r").each_line do |line| 
         # Handle each line as if it were an argument
         input.input(line.strip)
+      end
+    end
+
+    # jal
+    # If --exclude-file was specified, read it as a file and append to
+    # the exclude pattern list.
+    if !exclude-file.nil?
+      if !File.exists?(exclude-file)
+        logger.fatal("File given for --exclude-file does not exist (#{exclude-file})")
+        return 1
+      end
+
+      # Read each line as a path
+      File.new(exclude-file, "r").each_line do |line| 
+        # Handle each line as if it were an argument
+        # 'excludes' is defined above near the -x option.
+        excludes << line.strip
       end
     end
 


### PR DESCRIPTION
Works like a series of `--exclude`s; sort of a counterpart to --include.

The rationale is to allow a file under developer control to specify exclusion patterns separate from fpm execution, which is under CI control (in our world).