### PR TITLE
Enable packaging Perl modules from Github

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -36,7 +36,6 @@ class FPM::Package::CPAN < FPM::Package
         #"me know by filing an issue: " \
         #"https://github.com/jordansissel/fpm/issues"
     #end
-    #require "ftw" # for http access
     require "net/http"
     require "json"
 
@@ -60,7 +59,7 @@ class FPM::Package::CPAN < FPM::Package
       require "yaml"
       metadata = YAML.load_file(File.join(moduledir, ("MYMETA.yml")))
     else
-      raise FPM::InvalidPackageConfiguration, 
+      raise FPM::InvalidPackageConfiguration,
         "Could not find package metadata. Checked for META.json and META.yml"
     end
     self.version = metadata["version"]
@@ -107,7 +106,7 @@ class FPM::Package::CPAN < FPM::Package
 
     safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
 
-    if !attributes[:no_auto_depends?] 
+    if !attributes[:no_auto_depends?]
       unless metadata["requires"].nil?
         metadata["requires"].each do |dep_name, version|
           # Special case for representing perl core as a version.
@@ -116,7 +115,7 @@ class FPM::Package::CPAN < FPM::Package
             next
           end
           dep = search(dep_name)
-          
+
           if dep.include?("distribution")
             name = fix_name(dep["distribution"])
           else
@@ -206,7 +205,7 @@ class FPM::Package::CPAN < FPM::Package
 
 
       else
-        raise FPM::InvalidPackageConfiguration, 
+        raise FPM::InvalidPackageConfiguration,
           "I don't know how to build #{name}. No Makefile.PL nor " \
           "Build.PL found"
       end
@@ -231,10 +230,10 @@ class FPM::Package::CPAN < FPM::Package
     # Find any shared objects in the staging directory to set architecture as
     # native if found; otherwise keep the 'all' default.
     Find.find(staging_path) do |path|
-      if path =~ /\.so$/  
+      if path =~ /\.so$/
         logger.info("Found shared library, setting architecture=native",
                      :path => path)
-        self.architecture = "native" 
+        self.architecture = "native"
       end
     end
   end
@@ -256,7 +255,7 @@ class FPM::Package::CPAN < FPM::Package
                  :distribution => distribution,
                  :version => cpan_version)
 
-    # default to latest versionunless we specify one
+    # default to latest version unless we specify one
     if cpan_version.nil?
       self.version = metadata["version"]
     else
@@ -280,7 +279,7 @@ class FPM::Package::CPAN < FPM::Package
     release_metadata = JSON.parse(data)
     archive = release_metadata["archive"]
 
-    # should probably be basepathed from the url 
+    # should probably be basepathed from the url
     tarball = File.basename(archive)
 
     url_base = "http://www.cpan.org/"
@@ -289,7 +288,7 @@ class FPM::Package::CPAN < FPM::Package
     #url = "http://www.cpan.org/CPAN/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{tarball}"
     url = "#{url_base}/authors/id/#{author[0,1]}/#{author[0,2]}/#{author}/#{archive}"
     logger.debug("Fetching perl module", :url => url)
-    
+
     begin
       response = httpfetch(url)
     rescue Net::HTTPServerException => e
@@ -324,7 +323,7 @@ class FPM::Package::CPAN < FPM::Package
     data = response.body
     metadata = JSON.parse(data)
     return metadata
-  end # def metadata
+  end # def search
 
   def fix_name(name)
     case name
@@ -336,7 +335,7 @@ class FPM::Package::CPAN < FPM::Package
   def httpfetch(url)
     uri = URI.parse(url)
     if ENV['http_proxy']
-      proxy = URI.parse(ENV['http_proxy'])  
+      proxy = URI.parse(ENV['http_proxy'])
       http = Net::HTTP.Proxy(proxy.host,proxy.port,proxy.user,proxy.password).new(uri.host, uri.port)
     else
       http = Net::HTTP.new(uri.host, uri.port)


### PR DESCRIPTION
While CPAN is used for publishing Perl modules, Github nowadays hosts the code of many modules. This patch allows *fpm* to create packages from test or development code not yet published in CPAN, but found from Github.

Three package identifier formats are supported:
+ Github:user/repository
+ git@github.com:user/repository.git
+ https://github.com/user/repository.git

Example usage:
    fpm -s cpan -t deb https://github.com/plack/Plack.git
 
Currently only master branch is supported.