### PR TITLE
Until python wheel format is supported, tell pip to --no-use-wheel

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -127,7 +127,7 @@ class FPM::Package::Python < FPM::Package
                  "--build-directory", target, want_pkg)
     else
       logger.debug("using pip", :pip => attributes[:python_pip])
-      safesystem(attributes[:python_pip], "install", "--no-deps", "--no-install", "-i", attributes[:python_pypi], "-U", "--build", target, want_pkg)
+      safesystem(attributes[:python_pip], "install", "--no-deps", "--no-install", "--no-use-wheel", "-i", attributes[:python_pypi], "-U", "--build", target, want_pkg)
     end
 
     # easy_install will put stuff in @tmpdir/packagename/, so find that:


### PR DESCRIPTION
See https://github.com/jordansissel/fpm/issues/587.

When using fpm to package python modules using pip, we need to avoid "wheel" format until it is explicitly supported.