### PR TITLE
Add improved abort-install and abort-remove

### DIFF
--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -13,9 +13,13 @@ after_install() {
 <% end -%>
 }
 
-if [ "${1}" = "configure" -a -z "${2}" ]
+if [ "${1}" = "configure" -a -z "${2}" ] || \
+   [ "${1}" = "abort-remove" ]
 then
     # "after install" here
+    # "abort-remove" happens when the pre-removal script failed.
+    #   In that case, this script, which should be idemptoent, is run
+    #   to ensure a clean roll-back of the removal.
     after_install
 elif [ "${1}" = "configure" -a -n "${2}" ]
 then

--- a/templates/deb/postrm_upgrade.sh.erb
+++ b/templates/deb/postrm_upgrade.sh.erb
@@ -10,9 +10,12 @@ dummy() {
 }
 
 
-if [ "${1}" = "remove" ]
+if [ "${1}" = "remove" -o "${1}" = "abort-install" ]
 then
     # "after remove" goes here
+    # "abort-install" happens when the pre-installation script failed.
+    #   In that case, this script, which should be idemptoent, is run
+    #   to ensure a clean roll-back of the installation.
     after_remove
 elif [ "${1}" = "purge" -a -z "${2}" ]
 then


### PR DESCRIPTION
This further improves the postinstall and preremoval scripts' correctness for debian packages when `--*-upgrade` arguments are used. See #661 