### PR TITLE
rspec: fix lintian test

### DIFF
--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -21,7 +21,7 @@ describe FPM::Package::Deb do
       .warn("Skipping some deb tests because 'lintian' isn't in your PATH")
   end
 
-  let(:target) { Stud::Temporary.pathname }
+  let(:target) { Stud::Temporary.pathname + ".deb" }
   after do
     subject.cleanup
     File.unlink(target) if File.exist?(target)
@@ -351,12 +351,12 @@ describe FPM::Package::Deb do
       subject.attributes[:deb_group] = "root"
 
       subject.instance_variable_set(:@config_files, ["/etc/init.d/test"])
-      subject.instance_variable_set(:staging_path, staging_path)
+      subject.instance_variable_set(:@staging_path, staging_path)
 
       subject.output(target)
     end
 
-    after :all do
+    after do
       FileUtils.rm_r staging_path if File.exist? staging_path
     end # after
 


### PR DESCRIPTION
lintian expects the package name to ends with ".deb". Also, rspec
disallows the use of a let variable in an `after(:context)` hook. Also
fix the name of instance variable `@staging_path`.