### PR TITLE
List loaded package types on the help screen

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -24,7 +24,7 @@ class FPM::Command < Clamp::Command
   include FPM::Util
 
   def help(*args)
-    return [
+    lines = [
       "Intro:",
       "",
       "  This is fpm version #{FPM::VERSION}",
@@ -35,10 +35,14 @@ class FPM::Command < Clamp::Command
       "  You can find support on irc (#fpm on freenode irc) or via email with",
       "  fpm-users@googlegroups.com",
       "",
-
-      # Lastly, include the default help output via Clamp.
-      super
-    ].join("\n")
+      "Loaded package types:",
+    ]
+    FPM::Package.types.each do |name, _|
+      lines.push("  - #{name}")
+    end
+    lines.push("")
+    lines.push(super)
+    return lines.join("\n")
   end # def help
 
   option "-t", "OUTPUT_TYPE",


### PR DESCRIPTION
When I first started using `fpm`, I was confused about what package types I could use to make rpm packages or debian packages from. I think it would go a long way to help beginners if we listed the types of packages that `fpm` works with.

This pull request just lists the package types that `fpm` works with. Not strictly necessary, but I think it's a good idea.

Comes pre-tested. :+1: 