### PR TITLE
Feature: empty output package target

### DIFF
--- a/lib/fpm/package/empty.rb
+++ b/lib/fpm/package/empty.rb
@@ -4,4 +4,10 @@ require "backports"
 # Empty Package type. For strict/meta/virtual package creation
 
 class FPM::Package::Empty < FPM::Package
+  def output(output_path)
+    logger.warn("Your package has gone into the void.")
+  end
+  def to_s(fmt)
+    return ""
+  end
 end

--- a/lib/fpm/package/tar.rb
+++ b/lib/fpm/package/tar.rb
@@ -23,9 +23,6 @@ class FPM::Package::Tar < FPM::Package
       args << flag unless flag.nil?
     end
 
-    # preserve permissions of files when extracting if possible
-    args << "-p"
-
     safesystem("tar", *args)
 
     # use dir to set stuff up properly, mainly so I don't have to reimplement

--- a/lib/fpm/package/tar.rb
+++ b/lib/fpm/package/tar.rb
@@ -23,6 +23,9 @@ class FPM::Package::Tar < FPM::Package
       args << flag unless flag.nil?
     end
 
+    # preserve permissions of files when extracting if possible
+    args << "-p"
+
     safesystem("tar", *args)
 
     # use dir to set stuff up properly, mainly so I don't have to reimplement

--- a/spec/fpm/package/empty_spec.rb
+++ b/spec/fpm/package/empty_spec.rb
@@ -1,10 +1,5 @@
 require "spec_setup"
-require 'fileutils'
 require "fpm" # local
-require "fpm/package/deb" # local
-require "fpm/package/dir" # local
-require "stud/temporary"
-require "English" # for $CHILD_STATUS
 
 describe FPM::Package::Empty do
   describe "#to_s" do

--- a/spec/fpm/package/empty_spec.rb
+++ b/spec/fpm/package/empty_spec.rb
@@ -1,0 +1,25 @@
+require "spec_setup"
+require 'fileutils'
+require "fpm" # local
+require "fpm/package/deb" # local
+require "fpm/package/dir" # local
+require "stud/temporary"
+require "English" # for $CHILD_STATUS
+
+describe FPM::Package::Empty do
+  describe "#to_s" do
+    before do
+      subject.name = "name"
+      subject.version = "123"
+      subject.architecture = "all"
+      subject.iteration = "100"
+      subject.epoch = "5"
+    end
+    it "should always return the empty string" do
+      expect(subject.to_s "NAME-VERSION-ITERATION.ARCH.TYPE").to(be == "")
+      expect(subject.to_s "gobbledegook").to(be == "")
+      expect(subject.to_s "").to(be == "")
+      expect(subject.to_s nil).to(be == "")
+    end
+  end # describe to_s
+end # describe FPM::Package::Deb


### PR DESCRIPTION
I think it is useful to have `empty` as an output target. Sometimes, when converting from a certain package type to another, there is a problem with how the conversion takes place. I want to be able to run fpm with `--debug-workspace` and see what the result of converting from the source type, without regard to the target type until I've worked out what went wrong converting the source type. I don't care what type of package it outputs. In this case, having an `empty` output target is nice.

PR comes pre-tested, and includes a unit test for the `#to_s` function used to make `empty` an output target.