### PR TITLE
Add `:` to pre- and post- removal scripts to make them safer

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -184,6 +184,10 @@ fi
 %preun
 if [ "${1}" -eq 0 ]
 then
+<%# Making sure that at least one command is in the function -%>
+<%# avoids a lot of potential errors, including the case that -%>
+<%# the script is non-empty, but just whitespace and/or comments -%>
+    :
 <%=    script(:before_remove) %>
 fi
 <%   end -%>
@@ -191,6 +195,10 @@ fi
 %postun
 if [ "${1}" -eq 0 ]
 then
+<%# Making sure that at least one command is in the function -%>
+<%# avoids a lot of potential errors, including the case that -%>
+<%# the script is non-empty, but just whitespace and/or comments -%>
+    :
 <%=    script(:after_remove) %>
 fi
 <%   end -%>


### PR DESCRIPTION
This goes back to #875 . It makes sure that no-op scripts put into the templated version of removal scripts in the case of a `--*-upgrade` option doesn't explode. Tested :+1: