### PR TITLE
Feature: sh before-install script

### DIFF
--- a/lib/fpm/package/sh.rb
+++ b/lib/fpm/package/sh.rb
@@ -24,12 +24,6 @@ class FPM::Package::Sh < FPM::Package
   end
 
   def create_scripts
-    if script?(:before_install)
-      # the scripts are kept in the payload so what would before install be if we've already
-      # unpacked the payload?
-      raise "sh package does not support before install scripts."
-    end
-
     if script?(:after_install)
       File.write(File.join(fpm_meta_path, "after_install"), script(:after_install))
     end

--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -174,7 +174,7 @@ function set_owner(){
     log "Installing as user $OWNER"
 }
 
-function pre_install(){
+function pre_install() {
     # for rationale on the `:`, see #871
     :
 <% if script?(:before_install) -%>

--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -27,6 +27,7 @@ function main() {
       wait_for_others
       kill_others
       set_owner
+      pre_install
       unpack_payload
 
       if [ "$UNPACK_ONLY" == "1" ] ; then
@@ -171,6 +172,14 @@ function set_install_dir(){
 function set_owner(){
     export OWNER=${OWNER:-$USER}
     log "Installing as user $OWNER"
+}
+
+function pre_install(){
+    # for rationale on the `:`, see #871
+    :
+<% if script?(:before_install) -%>
+<%=    script(:before_install) %>
+<% end %>
 }
 
 function unpack_payload(){


### PR DESCRIPTION
This adds `--before-install` functionality to the `sh` output target. It runs the `--before-install` script as part of the BASH script that is run before the tarball is extracted. Tested :+1: