### PR TITLE
Fix rpm regression tests put in place for #802

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -375,7 +375,9 @@ class FPM::Package::RPM < FPM::Package
     end
     #input.replaces += replaces
 
-    self.config_files += rpm.config_files
+    if !tags[:fileflags].nil?
+      self.config_files += rpm.config_files
+    end
 
     # rpms support '%dir' things for specifying empty directories to package,
     # but the rpm header itself doesn't actually record this information.


### PR DESCRIPTION
I don't know if this PR should be merged, but maybe it should, but I created it just in case.

This PR attempts to fix the rspec test cases that were failing. Example:
```
  2) FPM::Package::RPM input validation stuff should not cause errors when reading basic rpm in input (#802)
     Failure/Error: subject.input(@target)
     NoMethodError:
       undefined method `each_with_index' for nil:NilClass
     # ./lib/fpm/package/rpm.rb:378:in `input'
     # ./spec/fpm/package/rpm_spec.rb:499:in `block (3 levels) in <top (required)>'
```
After some digging, it turns out that [arrr-pm is calling `each_with_index` on the `:fileflags` tag, when it is `nil`.](https://github.com/jordansissel/ruby-arr-pm/blob/bd26319d1362f104859626eca448706e124b544f/lib/arr-pm/file.rb#L182)

If this isn't the proper fix, let me know, but I wanted to make it available in case it was useful for fpm.
