### PR TITLE
Add --[no-]cpan-cpanm-force flag to allow passing --force to cpanm

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -30,6 +30,9 @@ class FPM::Package::CPAN < FPM::Package
   option "--sandbox-non-core", :flag,
     "Sandbox all non-core modules, even if they're already installed", :default => true
 
+  option "--cpanm-force", :flag,
+    "Pass the --force parameter to cpanm", :default => false
+
   private
   def input(package)
     #if RUBY_VERSION =~ /^1\.8/
@@ -116,6 +119,7 @@ class FPM::Package::CPAN < FPM::Package
     cpanm_flags += ["-n"] if !attributes[:cpan_test?]
     cpanm_flags += ["--mirror", "#{attributes[:cpan_mirror]}"] if !attributes[:cpan_mirror].nil?
     cpanm_flags += ["--mirror-only"] if attributes[:cpan_mirror_only?] && !attributes[:cpan_mirror].nil?
+    cpanm_flags += ["--force"] if attributes[:cpan_cpanm_force?]
 
     safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
 


### PR DESCRIPTION
This is useful in case the user doesn't care wether or not some test fails