### PR TITLE
Add more clear description of --directories option

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -122,7 +122,9 @@ class FPM::Command < Clamp::Command
     "directory all files inside it will be recursively marked as config files.",
     :multivalued => true, :attribute_name => :config_files
   option "--directories", "DIRECTORIES", "Recursively mark a directory as being owned " \
-    "by the package", :multivalued => true, :attribute_name => :directories
+    "by the package. Use this flag multiple times if you have multiple directories " \
+    "and they are not under the same parent directory ", :multivalued => true,
+    :attribute_name => :directories
   option ["-a", "--architecture"], "ARCHITECTURE",
     "The architecture name. Usually matches 'uname -m'. For automatic values," \
     " you can use '-a all' or '-a native'. These two strings will be " \


### PR DESCRIPTION
Add (hopefully) more clear description of _'--directories'_ option, when it should be used multiple times if directories are not under same parent directory. Current explanation is not very clear about this, and it seems there are no other usage examples with _'--directories'_ option in fpm project' wiki, I think it is a good idea to explain it in this place.