### PR TITLE
Feature/697

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,12 @@
 # vim
 .*.sw[a-z]
 
+# emacs
+\#*#
+
+# other editors
+*~
+
 # build byproducts
 build-*/*
 fpm.wiki

--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -203,27 +203,5 @@ class FPM::Package::Dir < FPM::Package
     copy_metadata(source, destination)
   end # def copy
 
-  def copy_metadata(source, destination)
-    source_stat = File::lstat(source)
-    dest_stat = File::lstat(destination)
-
-    # If this is a hard-link, there's no metadata to copy.
-    # If this is a symlink, what it points to hasn't been copied yet.
-    return if source_stat.ino == dest_stat.ino || dest_stat.symlink?
-
-    File.utime(source_stat.atime, source_stat.mtime, destination)
-    mode = source_stat.mode
-    begin
-      File.lchown(source_stat.uid, source_stat.gid, destination)
-    rescue Errno::EPERM
-      # clear setuid/setgid
-      mode &= 01777
-    end
-
-    unless source_stat.symlink?
-      File.chmod(mode, destination)
-    end
-  end # def copy_metadata
-
   public(:input, :output)
 end # class FPM::Package::Dir

--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -1,0 +1,127 @@
+require "fpm/namespace"
+require "fpm/package"
+require "fpm/util"
+require "rubygems/package"
+require "rubygems"
+require "fileutils"
+require "tmpdir"
+require "json"
+
+# Support for python virtualenv packages.
+#
+# This supports input, but not output.
+#
+# Example:
+#
+#     # Download the django python package:
+#     pkg = FPM::Package::Python.new
+#     pkg.input("Django")
+#
+class FPM::Package::Virtualenv < FPM::Package
+  # Flags '--foo' will be accessable  as attributes[:python_foo]
+  option "--pypi", "PYPI_URL",
+  "PyPi Server uri for retrieving packages.",
+  :default => "https://pypi.python.org/simple"
+  option "--package-name-prefix", "PREFIX", "Name to prefix the package " \
+  "name with.", :default => "virtualenv"
+  option "--fix-name", :flag, "Should the target package name be prefixed?",
+  :default => true
+  option "--install-folder", "BIN_PATH", "The path to where python scripts " \
+  "should be installed to.", :default => "/usr/share/python"
+  option "--other-files-directory", "DIRECTORY", "Optionally, the contents of the " \
+  "specified directory may be added to the package.", :default => nil
+
+  private
+
+  # Input a package.
+  #
+  def input(package)
+    m = /^([^=]+)==([^=]+)$/.match(package)
+    package_version = nil
+    if m
+      self.name ||= m[1]
+      self.version ||= m[2]
+      package = m[1]
+      package_version = m[2]
+    else
+      self.name ||= package
+    end
+
+    if self.attributes[:virtualenv_fix_name?]
+      self.name = [self.attributes[:virtualenv_package_name_prefix],
+                   self.name].join("-")
+    end
+
+    virtualenv_folder =
+      File.join(attributes[:virtualenv_install_folder],
+                package)
+    virtualenv_build_folder = build_path(virtualenv_folder)
+
+    ::FileUtils.mkdir_p(virtualenv_build_folder)
+
+    safesystem("virtualenv", virtualenv_build_folder)
+    pip_exe = File.join(virtualenv_build_folder, "bin", "pip")
+    python_exe = File.join(virtualenv_build_folder, "bin", "python")
+
+    # Why is this hack here? It looks important, so I'll keep it in.
+    safesystem(pip_exe, "install", "-U", "-i",
+               attributes[:virtualenv_pypi],
+               "pip", "distribute")
+    safesystem(pip_exe, "uninstall", "-y", "distribute")
+
+    safesystem(pip_exe, "install", "-i",
+               attributes[:virtualenv_pypi],
+               package)
+
+    if package_version.nil?
+      frozen = safesystemout(pip_exe, "freeze")
+      package_version = frozen[/#{package}==[^=]+$/].split("==")[1].chomp!
+      self.version ||= package_version
+    end
+
+    ::Dir[build_path + "/**/*"].each do |f|
+      if ! File.world_readable? f
+        File.lchmod(File.stat(f).mode | 444)
+      end
+    end
+
+    ::Dir.chdir(virtualenv_build_folder) do
+      safesystem("virtualenv-tools", "--update-path", virtualenv_folder)
+    end
+
+    if !attributes[:virtualenv_other_files_directory].nil?
+      ::Dir.foreach(attributes[:virtualenv_other_files_directory]) do |i|
+        next if i == '.' or i == '..'
+        copy_entry(File.join(attributes[:virtualenv_other_files_directory], i),
+                   build_path(i))
+      end
+    end
+
+    logger.debug("Now removing python object and compiled files from the virtualenv")
+
+    ::Dir[build_path + "/**/*.pyo"].each do |f|
+      ::FileUtils.rm_f(f)
+    end
+
+    ::Dir[build_path + "/**/*.pyc"].each do |f|
+      ::FileUtils.rm_f(f)
+    end
+
+    # use dir to set stuff up properly, mainly so I don't have to reimplement
+    # the chdir/prefix stuff special for tar.
+    dir = convert(FPM::Package::Dir)
+    if attributes[:chdir]
+      dir.attributes[:chdir] = File.join(build_path, attributes[:chdir])
+    else
+      dir.attributes[:chdir] = build_path
+    end
+    cleanup_staging
+    # Tell 'dir' to input "." and chdir/prefix will help it figure out the
+    # rest.
+    dir.input(".")
+    @staging_path = dir.staging_path
+    dir.cleanup_build
+  end # def input
+
+  public(:input)
+end # class FPM::Package::Python

--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -6,12 +6,6 @@ require "fpm/util"
 #
 # This supports input, but not output.
 #
-# Example:
-#
-#     # Download the django python package:
-#     pkg = FPM::Package::Python.new
-#     pkg.input("Django")
-#
 class FPM::Package::Virtualenv < FPM::Package
   # Flags '--foo' will be accessable  as attributes[:virtualenv_foo]
 
@@ -36,6 +30,7 @@ class FPM::Package::Virtualenv < FPM::Package
 
   # Input a package.
   #
+  #     `package` can look like `psutil==2.2.1` or `psutil`.
   def input(package)
     installdir = attributes[:virtualenv_install_location]
     m = /^([^=]+)==([^=]+)$/.match(package)
@@ -62,8 +57,6 @@ class FPM::Package::Virtualenv < FPM::Package
     virtualenv_folder =
       File.join(installdir,
                 virtualenv_name)
-
-    puts "virtualenv_folder: " + virtualenv_folder
 
     virtualenv_build_folder = build_path(virtualenv_folder)
 

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -159,7 +159,30 @@ module FPM::Util
     rc
   end
 
-  def copy_entry(src, dst)
+  def copy_metadata(source, destination)
+    source_stat = File::lstat(source)
+    dest_stat = File::lstat(destination)
+
+    # If this is a hard-link, there's no metadata to copy.
+    # If this is a symlink, what it points to hasn't been copied yet.
+    return if source_stat.ino == dest_stat.ino || dest_stat.symlink?
+
+    File.utime(source_stat.atime, source_stat.mtime, destination)
+    mode = source_stat.mode
+    begin
+      File.lchown(source_stat.uid, source_stat.gid, destination)
+    rescue Errno::EPERM
+      # clear setuid/setgid
+      mode &= 01777
+    end
+
+    unless source_stat.symlink?
+      File.chmod(mode, destination)
+    end
+  end # def copy_metadata
+
+
+  def copy_entry(src, dst, preserve=false, remove_destination=false)
     case File.ftype(src)
     when 'fifo', 'characterSpecial', 'blockSpecial', 'socket'
       st = File.stat(src)
@@ -175,7 +198,8 @@ module FPM::Util
       if known_entry
         FileUtils.ln(known_entry, dst)
       else
-        FileUtils.copy_entry(src, dst)
+        FileUtils.copy_entry(src, dst, preserve=preserve,
+                             remove_destination=remove_destination)
         copied_entries[[st.dev, st.ino]] = dst
       end
     end # else...


### PR DESCRIPTION
This PR is for #697 .

My shot at a virtualenv input plugin, after taking a look at @evilsocket 's code. Thanks for letting me stand on your shoulders, @evilsocket ! 

# Features
1. Virtualenv named based on the pip package it's built around
2. You can specify a particular version of a pip package to build a virtualenv around e.g. `psutil==2.2.1`
2. No surprises. I took the script from here --> https://github.com/brutasse/graphite-api/blob/master/fpm/build-deb.sh and put it straight into FPM as much as possible
3. Version resolution: The version of the "chief" package is used if no other version is specified
4. Optionally add extra files, like [the script above does](https://github.com/brutasse/graphite-api/blob/master/fpm/build-deb.sh) when it adds files that go under `/etc`
5. By default, prefixes virtualenv package names with `virtualenv`, but this can be overridden
6. Option exists to change the index url which pip uses to build the virtualenv
5. Tried as much as possible to conform to how other FPM plugins are coded

# Caveats
1. You cannot currently use '>=' or '<=' in the package specification, only '==' currently exists as an option.
5. Places virtualenvs in an install location specified by the `--virtualenv-install-location`. Couldn't use prefix, as this changes both where the virtualenv *and* the extra files go. If I specified `--prefix foo` and `--virtualenv-install-location /bar`, the virtual env for `psutil` would be installed under `/foo/bar/psutil`
2. You get bad results if you use a relative path for the value of `--virtualenv-install-location`.
3. No specs yet (they will be forthcoming) but I have manually tested everything here and it works :+1:

# Example

A default case:
```

~/Workspace/compute/src/github.com/djhaskin987/fpm $ bin/fpm -s virtualenv -t deb --virtualenv-other-files-dir pkg/ example
Debian packaging tools generally labels all files in /etc as config files, as mandated by policy, so fpm defaults to this behavior for deb packages. You can disable this default behavior with --deb-no-default-config-files flag {:level=>:warn}
Created package {:path=>"virtualenv-example_1.0_amd64.deb"}
```

A rather involved example:
```
~/Workspace/compute/src/github.com/djhaskin987/fpm $ bin/fpm -f -n barg -v 3.0.0 --prefix /boogar --virtualenv-install-location /junie --no-virtualenv-fix-name -s virtualenv -t rpm --virtualenv-other-files-dir pkg/ psutil==2.2.1
virtualenv_folder: /junie/psutil
no value for epoch is set, defaulting to nil {:level=>:warn}
Force flag given. Overwriting package at barg-3.0.0-1.x86_64.rpm {:level=>:warn}
no value for epoch is set, defaulting to nil {:level=>:warn}
Created package {:path=>"barg-3.0.0-1.x86_64.rpm"}
```