### PR TITLE
Removed the numeric-owner tar flag when deb_user=root

### DIFF
--- a/CHANGELIST
+++ b/CHANGELIST
@@ -1,3 +1,5 @@
+1.3.4 ( June, 2015)
+  - Correct issue with using one of the --deb-user or --deb-group instead of both
 1.3.3 (December 11, 2014)
   - The fpm project now uses Contributor Covenant. You can read more about this on
     the website: http://contributor-covenant.org/

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -784,19 +784,11 @@ class FPM::Package::Deb < FPM::Package
     data_tar_flags = []
     if attributes[:deb_use_file_permissions?].nil?
       if !attributes[:deb_user].nil?
-        if attributes[:deb_user] == 'root'
-          data_tar_flags += [ "--numeric-owner", "--owner", "0" ]
-        else
-          data_tar_flags += [ "--owner", attributes[:deb_user] ]
-        end
+        data_tar_flags += [ "--owner", attributes[:deb_user] ]
       end
 
       if !attributes[:deb_group].nil?
-        if attributes[:deb_group] == 'root'
-          data_tar_flags += [ "--numeric-owner", "--group", "0" ]
-        else
-          data_tar_flags += [ "--group", attributes[:deb_group] ]
-        end
+        data_tar_flags += [ "--group", attributes[:deb_group] ]
       end
     end
     return data_tar_flags

--- a/lib/fpm/version.rb
+++ b/lib/fpm/version.rb
@@ -1,3 +1,3 @@
 module FPM
-  VERSION = "1.3.3"
+  VERSION = "1.3.3.1"
 end


### PR DESCRIPTION
I removed a couple of lines that made it impossible to specify only a deb-user or deb-group without the other. I don't know why this was the way it was, so feel free to explain me if this should be the way it is now.

Example old situation
fpm --verbose -s dir -t deb -n testpackage --architecture all -C test --prefix /opt  --deb-user testuser --iteration 1 .
dpkg-deb -c testpackage_1.0-1_all.deb 
drwx------ 1000/0            0 2015-06-10 22:53 ./
drwxrwxr-x 1000/0            0 2015-06-10 22:53 ./usr/
drwxrwxr-x 1000/0            0 2015-06-10 22:53 ./usr/share/
drwxrwxr-x 1000/0            0 2015-06-10 22:53 ./usr/share/doc/

You can see the deb-user being set to 1000, where I expect to see 'testuser'.

With the change, there's no more numerical tar tag and therefor folllowing result:
/fpm --verbose -s dir -t deb -n testpackage --architecture all -C test --prefix /opt  --deb-user testuser --iteration 2 .
dpkg -c testpackage_1.0-2_all.deb 
drwx------ testuser/root     0 2015-06-10 22:55 ./
drwxrwxr-x testuser/root     0 2015-06-10 22:55 ./usr/
drwxrwxr-x testuser/root     0 2015-06-10 22:55 ./usr/share/
