### PR TITLE
Ensure --deb-shlibs file permission to keep lintian happy

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -714,6 +714,7 @@ class FPM::Package::Deb < FPM::Package
     File.open(control_path("shlibs"), "w") do |out|
       out.write(attributes[:deb_shlibs])
     end
+    File.chmod(0644, control_path("shlibs"))
   end # def write_shlibs
 
   def write_debconf


### PR DESCRIPTION
Hello, this change prevents `lintian` (and therefore Ubuntu Package Manager) generating the
```
control-file-has-bad-permissions shlibs 0664 != 0644
````
error and the subsequent "violates the quality standards" alert when the `--deb-shlibs` option is used.

Originally discovered via https://github.com/dimensio/libpng16-deb/issues/1
