### PR TITLE
can't create packages with OUTPUT_TYPE 'virtualenv' from non-public python repos

### DIFF
--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -12,6 +12,9 @@ class FPM::Package::Virtualenv < FPM::Package
   option "--pypi", "PYPI_URL",
   "PyPi Server uri for retrieving packages.",
   :default => "https://pypi.python.org/simple"
+  option "--pypi-extra-index-url", "PYPI_EXTRA_INDEX_URL",
+  "Extra URLs of package indexes to use.",
+  :default => nil
   option "--package-name-prefix", "PREFIX", "Name to prefix the package " \
   "name with.", :default => "virtualenv"
 
@@ -72,9 +75,16 @@ class FPM::Package::Virtualenv < FPM::Package
                "pip", "distribute")
     safesystem(pip_exe, "uninstall", "-y", "distribute")
 
-    safesystem(pip_exe, "install", "-i",
-               attributes[:virtualenv_pypi],
-               package)
+    if !attributes[:virtualenv_pypi_extra_index_url].nil?
+        safesystem(pip_exe, "install", "-i",
+                attributes[:virtualenv_pypi],
+                "--extra-index-url", attributes[:virtualenv_pypi_extra_index_url],
+                package)
+    else
+        safesystem(pip_exe, "install", "-i",
+                attributes[:virtualenv_pypi],
+                package)
+    end
 
     if package_version.nil?
       frozen = safesystemout(pip_exe, "freeze")


### PR DESCRIPTION
I became aware that it is impossible to create a package from a python module which is just stored in a private repository because when you pass the option '--pypi' to fpm with a custom repo it tries to install 'pip' and 'distribute' from the same repo which always fails if you don't include this modules into your custom repo.
It seems like an uglish hack which is also stated at the comment https://github.com/jordansissel/fpm/blob/master/lib/fpm/package/virtualenv.rb#L69.
So either the `pip` and `distribute` modules are not found in your custom repos (why should they be installed at all, `pip` is already installed in the virtualenv and `distibute` is uninstalled a line later), or the custom module which isn't available on https://pypi.python.org/pypi will not be found and the package build process will abort.
I'd suggest to add the option '--pypi-extra-index-url' so that the custom / private repo could be really only additional to the standard pypi repos.
I'd also commit a pull request for this feature, because it prevents me to build custom packages from our own pypi repositories.