### PR TITLE
Don't crash on empty description when building RPM

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -43,7 +43,7 @@ Epoch: <%= epoch %>
 <% end -%>
 Release: <%= iteration or 1 %><%= "%{?dist}" if attributes[:rpm_dist] %>
 <%# use the first line of the description as the summary -%>
-Summary: <%= description.split("\n").first.empty? ? "_" :  description.split("\n").first %>
+Summary: <%= description.split("\n").first || "_" %>
 <% if !attributes[:rpm_autoreqprov?] -%>
 AutoReqProv: no
 <% else -%>


### PR DESCRIPTION
I experienced issue #825 when using `fpm -s npm -t rpm` for a node module that had no `description` field in its package.json. Applying the suggested patch fixed things, so I thought I'd go ahead and open a PR for it.

Let me know if there's anything else I can do to help get this merged. Thanks!

Closes #825