### PR TITLE
Clarified tempdir error message

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -128,7 +128,7 @@ class FPM::Package::Dir < FPM::Package
         "to stage files during packaging, so this setting would have " \
         "caused fpm to loop creating staging directories and copying " \
         "them into your package! Oops! If you are confused, maybe you could " \
-        "check your TMPDIR or TEMPDIR environment variables?"
+        "check your TMPDIR, TMP, or TEMP environment variables?"
     end
 
     # For single file copies, permit file destinations


### PR DESCRIPTION
Per the [source for ::Dir.tmpdir](http://ruby-doc.org/stdlib-1.9.3/libdoc/tmpdir/rdoc/Dir.html#method-c-tmpdir), these are the actual environment variables that should be checked:

```
    for dir in [ENV['TMPDIR'], ENV['TMP'], ENV['TEMP'], @@systmpdir, '/tmp']
```