### PR TITLE
Fix broken behaviour in --excludes-file option

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -364,7 +364,7 @@ class FPM::Command < Clamp::Command
       end
 
       # Read each line as a path
-      File.new(exclude-file, "r").each_line do |line| 
+      File.new(exclude_file, "r").each_line do |line|
         # Handle each line as if it were an argument
         # 'excludes' is defined above near the -x option.
         excludes << line.strip

--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -363,11 +363,13 @@ class FPM::Command < Clamp::Command
         return 1
       end
 
+      # Ensure hash is initialized
+      input.attributes[:excludes] ||= []
+
       # Read each line as a path
       File.new(exclude_file, "r").each_line do |line|
         # Handle each line as if it were an argument
-        # 'excludes' is defined above near the -x option.
-        excludes << line.strip
+        input.attributes[:excludes] << line.strip
       end
     end
 

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -379,7 +379,7 @@ class FPM::Package
 
         if File.fnmatch(wildcard, match_path)
           logger.info("Removing excluded path", :path => match_path, :matches => wildcard)
-          FileUtils.remove_entry_secure(path)
+          FileUtils.rm_r(path)
           Find.prune
           break
         end


### PR DESCRIPTION
`--exclude-file` doesn't work due to a variable error on L367