### PR TITLE
Install local module if package is file

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -43,7 +43,7 @@ class FPM::Package::CPAN < FPM::Package
     require "net/http"
     require "json"
 
-    if (attributes[:cpan_local_module?])
+    if File.exist?(package)
       moduledir = package
     else
       result = search(package)


### PR DESCRIPTION
I just removed the unused switch --cpan-local-module and install package if it's file or directory. 