### PR TITLE
rspec tests use .reject

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("ffi") # license: GPL3/LGPL3
 
   spec.add_development_dependency("rspec", "~> 3.0.0") # license: MIT (according to wikipedia)
-  spec.add_development_dependency("insist", "~> 0.0.5") # license: ???
+  spec.add_development_dependency("insist", "~> 1.0.0") # license: Apache 2
   spec.add_development_dependency("pry")
   spec.add_development_dependency("stud")
 


### PR DESCRIPTION
and .reject seems to came from insist 0.0.6
but work with 1.0.0 as well

the error i was getting was:
```
 
  1) FPM::Package::Deb#output when the deb's control section is extracted should have the requested triggers in the triggers file
     Failure/Error: reject { triggers =~ /^interest from-meta-file$/ }.nil?
     NoMethodError:
       undefined method `reject' for #<RSpec::Core::ExampleGroup::Nested_3::Nested_8::Nested_1:0x00000001b13248>
     # /usr/share/ruby/vendor_ruby/rspec/matchers/method_missing.rb:9:in `method_missing'
     # ./spec/fpm/package/deb_spec.rb:191:in `block (4 levels) in <top (required)>'

```