### PR TITLE
Change FreeBSD to use gtar

### DIFF
--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -135,6 +135,9 @@ module FPM::Util
         system("#{tar} > /dev/null 2> /dev/null")
         return tar unless $?.exitstatus == 127
       end
+    when "FreeBSD"
+      # use gnutar instead
+      return "gtar"
     else
       return "tar"
     end


### PR DESCRIPTION
The FreeBSD version of tar doesn't include the options --owner and
--group among others. Instead change to use gnutar as the default.
This adds a dependency of installing
https://freshports.org/archivers/gtar/ for anyone creating packages
under FreeBSD (similar to doing brew install gnu-tar under OSX)