### PR TITLE
Improve gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,13 @@
 
 # emacs
 \#*#
-
-# other editors
 *~
+.#*
+
+# package builds
+*.rpm
+*.deb
+*.pkg.tar*
 
 # build byproducts
 build-*/*
@@ -15,6 +19,7 @@ fpm.wiki
 
 # python
 *.pyc
+*.egg-info
 
 # RVM
 .rvmrc


### PR DESCRIPTION
Add entry for the `*.egg-info` directory generated by new rspecs, and also adds entries for redhat, debian, and archLinux package types. 