### PR TITLE
Update --description in help to display a literal \n instead of a newline

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -149,10 +149,8 @@ class FPM::Command < Clamp::Command
     "patterns to exclude from input."
 
   option "--description", "DESCRIPTION", "Add a description for this package." \
-    " You can include '\n' sequences to indicate newline breaks.",
+    " You can include '\\n' sequences to indicate newline breaks.",
     :default => "no description" do |val|
-    # Replace literal "\n" sequences with a newline character.
-    val.gsub("\\n", "\n")
   end
   option "--url", "URI", "Add a url for this package.",
     :default => "http://example.com/no-uri-given"


### PR DESCRIPTION
The help currently displays a line break instead of a literal \n, this replaces \n with \\n.