### PR TITLE
Add support for using python-package-name-prefix for python dependencies

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -48,6 +48,8 @@ class FPM::Package::RPM < FPM::Package
       value
   end
 
+  option "--prefix-python-dependencies", :flag, "Prepend the python-package-name-prefix to python dependencies"
+
   rpmbuild_define = []
   option "--rpmbuild-define", "DEFINITION",
     "Pass a --define argument to rpmbuild." do |define|
@@ -257,6 +259,14 @@ class FPM::Package::RPM < FPM::Package
           end
         end
       end
+    end
+
+    if origin == FPM::Package::Python and self.attributes[:rpm_prefix_python_dependencies] == true
+      prefixed_defs = []
+      self.dependencies.each do |dep|
+        prefixed_defs << "#{self.attributes[:python_package_name_prefix]}-#{dep}"
+      end
+      self.dependencies = prefixed_defs
     end
 
     # Convert != dependency as Conflict =, as rpm doesn't understand !=


### PR DESCRIPTION
if --rpm-prefix-python-dependencies is specified, then the python-package-name-prefix value is prepended to auto-calculated dependencies.

This simplifies the packaging process for CentOS SCL python packages.

I am making possibly large assumptions about the format of the dependency strings, unsure how safe that is.