### PR TITLE
gem: make it posssible to set the shebang

### DIFF
--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -209,7 +209,7 @@ class FPM::Package::Gem < FPM::Package
         next unless File.ftype(file_path) == 'file'
         # replace shebang in files if there is one
         file = File.read(file_path)
-        if file.gsub!(/^#!.*$/, "#!#{attributes[:gem_shebang]}")
+        if file.gsub!(/\A#!.*$/, "#!#{attributes[:gem_shebang]}")
           File.open(file_path, 'w'){|f| f << file}
         end
       end

--- a/spec/fpm/package/gem_spec.rb
+++ b/spec/fpm/package/gem_spec.rb
@@ -74,4 +74,29 @@ describe FPM::Package::Gem, :if => have_gem do
       insist { subject.name } == "example"
     end
   end
+
+  context "when :gem_shebang is nil/default" do
+    before :each do
+      subject.attributes[:gem_bin_path] = '/usr/bin'
+    end
+
+    it 'should not change the shebang' do
+      subject.input(example_gem)
+      file_path = File.join(subject.staging_path, '/usr/bin/example')
+      insist { File.readlines(file_path).grep(/^#!\/usr\/bin\/env /).any? } == true
+    end
+  end
+
+  context "when :gem_shebang is set" do
+    before :each do
+      subject.attributes[:gem_shebang] = '/opt/special/bin/ruby'
+      subject.attributes[:gem_bin_path] = '/usr/bin'
+    end
+
+    it 'should change the shebang' do
+      subject.input(example_gem)
+      file_path = File.join(subject.staging_path, '/usr/bin/example')
+      insist { File.readlines(file_path).grep("#!/opt/special/bin/ruby\n").any? } == true
+    end
+  end
 end # describe FPM::Package::Gem


### PR DESCRIPTION
This makes it possible to create packages from gems for ruby versions
which are not currently installed on the machine you build the package on.

Tests are included.