### PR TITLE
Follow debian systemd packaging guide #2

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -478,7 +478,7 @@ class FPM::Package::Deb < FPM::Package
 
     attributes.fetch(:deb_systemd_list, []).each do |systemd|
       name = File.basename(systemd, ".service")
-      dest_systemd = staging_path("etc/systemd/system/#{name}.service")
+      dest_systemd = staging_path("lib/systemd/system/#{name}.service")
       FileUtils.mkdir_p(File.dirname(dest_systemd))
       FileUtils.cp(systemd, dest_systemd)
       File.chmod(0644, dest_systemd)


### PR DESCRIPTION
Oh god, sorry, i did'nt see that systemd unit files are handled two times !

(See: https://github.com/jordansissel/fpm/pull/1040)

If i don't replace this path too, unit files are presents 2 times in the debian package, first in /lib/systemd, second in /etc/systemd

Btw, i suspect another bug, that's a strange behaviour, don't you think ?