### PR TITLE
Fix parsing of --description

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -152,8 +152,7 @@ class FPM::Command < Clamp::Command
 
   option "--description", "DESCRIPTION", "Add a description for this package." \
     " You can include '\\n' sequences to indicate newline breaks.",
-    :default => "no description" do |val|
-  end
+    :default => "no description"
   option "--url", "URI", "Add a url for this package.",
     :default => "http://example.com/no-uri-given"
   option "--inputs", "INPUTS_PATH",


### PR DESCRIPTION
Current handling of option --description does not accept a description 'value' anymore as former commit 52ac00b5b3f7bc56c13ea0a57d8af609f1075b18 seems to be incomplete.