### PR TITLE
Added bsdtar installation instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,10 +183,17 @@ Most importantly, you should see the following output from the bundle command
 when it lists the fpm gem:
 
     ...
-    Using json (1.8.1) 
+    Using json (1.8.1)
     Using fpm (0.4.42) from source at .
-    Using hitimes (1.2.1) 
+    Using hitimes (1.2.1)
     ...
+
+If your system doesn't have `bsdtar` by default, make sure to install it or some
+tests will fail:
+
+    apt-get install bsdtar
+    
+    yum install bsdtar
 
 Next, run make in root of the fpm repo.  If there are any problems (such as
 missing dependencies) you should receive an error


### PR DESCRIPTION
This is needed or many tests fail on Ubuntu since bsdtar isn't there by default. 9 tests fail on Ubuntu 15.10 even after that but much less with bsdtar installed.

PS: Cleaned up some whitespace too