### PR TITLE
Fix for --help output

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -56,8 +56,8 @@ class FPM::Command < Clamp::Command
     :attribute_name => :chdir
   option "--prefix", "PREFIX",
     "A path to prefix files with when building the target package. This may " \
-    "be necessary for all input packages. For example, the 'gem' type will " \
-    "prefix with your gem directory automatically."
+    "not be necessary for all input packages. For example, the 'gem' type " \
+    "will prefix with your gem directory automatically."
   option ["-p", "--package"], "OUTPUT", "The package file path to output."
   option ["-f", "--force"], :flag, "Force output even if it will overwrite an " \
     "existing file", :default => false


### PR DESCRIPTION
The help output for --prefix states:

> A path to prefix files with when building the target package. This may be necessary for all input packages. For example, the 'gem' type will prefix with your gem directory automatically.


This should probably be:

> A path to prefix files with when building the target package. This may **not** be necessary for all input packages. For example, the 'gem' type will prefix with your gem directory automatically.