### PR TITLE
Remove artifact of old code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ You can install fpm with gem:
     
 (On OS X, you may also need gnutar: `brew install gnu-tar`.)
 
-Building a package named "awesome" might look something like this:
+Building a package might look something like this:
 
     fpm -s <source type> -t <target type> [list of sources]...
 


### PR DESCRIPTION
This removes a slightly confusing bit of information from the readme that no longer looks relevant.

I think this is a result of the work done in 7ced849. The package name "awesome" was removed from the example `fpm` command in the readme, but the leading paragraph was not updated.