### PR TITLE
fixes for FPM::Package#to_s and relatives

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -339,15 +339,14 @@ class FPM::Package
   def to_s_arch; architecture.to_s; end
   def to_s_name; name.to_s;         end
   def to_s_fullversion
-    ver = to_s_version
-    ver += "-#{iteration}" if iteration
-    return ver
+    return "#{version}-#{iteration}" if iteration
+    return "#{version}"
   end
   def to_s_version;   version.to_s;   end
   def to_s_iteration; iteration.to_s; end
   def to_s_epoch;     epoch.to_s;     end
   def to_s_type;      type.to_s;      end
-  def to_s_extension; to_s_type;      end
+  def to_s_extension; type.to_s;      end
   #######################################
 
   def to_s(fmt=nil)

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -336,17 +336,14 @@ class FPM::Package
   # easily override particular substitut-
   # ions performed by to_s for subclasses
   #######################################
-  def to_s_arch; architecture.to_s; end
-  def to_s_name; name.to_s;         end
-  def to_s_fullversion
-    return "#{version}-#{iteration}" if iteration
-    return "#{version}"
-  end
-  def to_s_version;   version.to_s;   end
-  def to_s_iteration; iteration.to_s; end
-  def to_s_epoch;     epoch.to_s;     end
-  def to_s_type;      type.to_s;      end
-  def to_s_extension; type.to_s;      end
+  def to_s_arch;        architecture.to_s;  end
+  def to_s_name;        name.to_s;          end
+  def to_s_fullversion; iteration ? "#{version}-#{iteration}" : "#{version}"; end
+  def to_s_version;     version.to_s;       end
+  def to_s_iteration;   iteration.to_s;     end
+  def to_s_epoch;       epoch.to_s;         end
+  def to_s_type;        type.to_s;          end
+  def to_s_extension;   type.to_s;          end
   #######################################
 
   def to_s(fmt=nil)

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -331,17 +331,35 @@ class FPM::Package
     return erb
   end # def template
 
-  def to_s(fmt="NAME.TYPE")
-    fmt = "NAME.TYPE" if fmt.nil?
-    fullversion = version.to_s
-    fullversion += "-#{iteration}" if iteration
-    return fmt.gsub("ARCH", architecture.to_s) \
-      .gsub("NAME", name.to_s) \
-      .gsub("FULLVERSION", fullversion) \
-      .gsub("VERSION", version.to_s) \
-      .gsub("ITERATION", iteration.to_s) \
-      .gsub("EPOCH", epoch.to_s) \
-      .gsub("TYPE", type.to_s)
+  #######################################
+  # The following methods are provided to
+  # easily override particular substitut-
+  # ions performed by to_s for subclasses
+  #######################################
+  def to_s_arch; architecture.to_s; end
+  def to_s_name; name.to_s;         end
+  def to_s_fullversion
+    ver = to_s_version
+    ver += "-#{iteration}" if iteration
+    return ver
+  end
+  def to_s_version;   version.to_s;   end
+  def to_s_iteration; iteration.to_s; end
+  def to_s_epoch;     epoch.to_s;     end
+  def to_s_type;      type.to_s;      end
+  def to_s_extension; to_s_type;      end
+  #######################################
+
+  def to_s(fmt=nil)
+    fmt = "NAME.EXTENSION" if fmt.nil?
+    return fmt.gsub("ARCH", to_s_arch) \
+      .gsub("NAME",         to_s_name) \
+      .gsub("FULLVERSION",  to_s_fullversion) \
+      .gsub("VERSION",      to_s_version) \
+      .gsub("ITERATION",    to_s_iteration) \
+      .gsub("EPOCH",        to_s_epoch) \
+      .gsub("TYPE",         to_s_type) \
+      .gsub("EXTENSION",    to_s_extension)
   end # def to_s
 
   def edit_file(path)

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -905,8 +905,7 @@ class FPM::Package::Deb < FPM::Package
   def to_s(format=nil)
     # Default format if nil
     # git_1.7.9.3-1_amd64.deb
-    return super("NAME_FULLVERSION_ARCH.EXTENSION") if format.nil?
-    return super(format)
+    return super(format.nil? ? "NAME_FULLVERSION_ARCH.EXTENSION" : format)
   end # def to_s
 
   def data_tar_flags

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -905,7 +905,7 @@ class FPM::Package::Deb < FPM::Package
   def to_s(format=nil)
     # Default format if nil
     # git_1.7.9.3-1_amd64.deb
-    return super("NAME_FULLVERSION_ARCH.TYPE") if format.nil?
+    return super("NAME_FULLVERSION_ARCH.EXTENSION") if format.nil?
     return super(format)
   end # def to_s
 

--- a/lib/fpm/package/freebsd.rb
+++ b/lib/fpm/package/freebsd.rb
@@ -50,7 +50,15 @@ class FPM::Package::FreeBSD < FPM::Package
       pkg_origin = "fpm/#{name}"
     end
 
-    pkg_version = "#{version}-#{iteration || 1}"
+    # Follow similar rules to these used in ``to_s_fullversion`` method.
+    # FIXME: maybe epoch should also be introduced somehow ("#{version},#{epoch})?
+    #        should it go to pkgdata["version"] or to another place?
+    # https://www.freebsd.org/doc/en/books/porters-handbook/makefile-naming.html
+    if iteration and iteration.to_i > 0
+      pkg_version = "#{version}-#{iteration}"
+    else
+      pkg_version = "#{version}"
+    end
 
     pkgdata = {
       "abi" => attributes[:freebsd_abi],
@@ -133,8 +141,8 @@ class FPM::Package::FreeBSD < FPM::Package
   def to_s_fullversion()
     # iteration (PORTREVISION on FreeBSD) shall be appended only(?) if non-zero.
     # https://www.freebsd.org/doc/en/books/porters-handbook/makefile-naming.html
-    return "#{to_s_version}_#{iteration}" if iteration and (iteration.to_i > 0)
-    return to_s_version
+    return "#{version}_#{iteration}" if iteration and (iteration.to_i > 0)
+    return "#{version}"
   end
 
   def to_s(format=nil)

--- a/lib/fpm/package/freebsd.rb
+++ b/lib/fpm/package/freebsd.rb
@@ -54,11 +54,7 @@ class FPM::Package::FreeBSD < FPM::Package
     # FIXME: maybe epoch should also be introduced somehow ("#{version},#{epoch})?
     #        should it go to pkgdata["version"] or to another place?
     # https://www.freebsd.org/doc/en/books/porters-handbook/makefile-naming.html
-    if iteration and iteration.to_i > 0
-      pkg_version = "#{version}-#{iteration}"
-    else
-      pkg_version = "#{version}"
-    end
+    pkg_version = (iteration and (iteration.to_i > 0)) ?  "#{version}-#{iteration}" : "#{version}"
 
     pkgdata = {
       "abi" => attributes[:freebsd_abi],
@@ -141,13 +137,11 @@ class FPM::Package::FreeBSD < FPM::Package
   def to_s_fullversion()
     # iteration (PORTREVISION on FreeBSD) shall be appended only(?) if non-zero.
     # https://www.freebsd.org/doc/en/books/porters-handbook/makefile-naming.html
-    return "#{version}_#{iteration}" if iteration and (iteration.to_i > 0)
-    return "#{version}"
+    (iteration and (iteration.to_i > 0)) ?  "#{version}_#{iteration}" : "#{version}"
   end
 
   def to_s(format=nil)
-    return super("NAME-FULLVERSION.EXTENSION") if format.nil?
-    return super(format)
+    return super(format.nil? ? "NAME-FULLVERSION.EXTENSION" : format)
   end # def to_s
 end # class FPM::Package::FreeBSD
 

--- a/lib/fpm/package/freebsd.rb
+++ b/lib/fpm/package/freebsd.rb
@@ -128,8 +128,17 @@ class FPM::Package::FreeBSD < FPM::Package
     end
   end # def add_path
 
+  def to_s_extension; "txz"; end
+
+  def to_s_fullversion()
+    # iteration (PORTREVISION on FreeBSD) shall be appended only(?) if non-zero.
+    # https://www.freebsd.org/doc/en/books/porters-handbook/makefile-naming.html
+    return "#{to_s_version}_#{iteration}" if iteration and (iteration.to_i > 0)
+    return to_s_version
+  end
+
   def to_s(format=nil)
-    return "#{name}-#{version}_#{iteration || 1}.txz"
+    return super("NAME-FULLVERSION.EXTENSION") if format.nil?
     return super(format)
   end # def to_s
 end # class FPM::Package::FreeBSD

--- a/lib/fpm/package/osxpkg.rb
+++ b/lib/fpm/package/osxpkg.rb
@@ -154,8 +154,10 @@ class FPM::Package::OSXpkg < FPM::Package
     FileUtils.remove_file(temp_info)
   end # def output
 
+  def to_s_extension; "pkg"; end
+
   def to_s(format=nil)
-    return super("NAME-VERSION.pkg") if format.nil?
+    return super("NAME-VERSION.EXTENSION") if format.nil?
     return super(format)
   end # def to_s
 

--- a/lib/fpm/package/osxpkg.rb
+++ b/lib/fpm/package/osxpkg.rb
@@ -157,8 +157,7 @@ class FPM::Package::OSXpkg < FPM::Package
   def to_s_extension; "pkg"; end
 
   def to_s(format=nil)
-    return super("NAME-VERSION.EXTENSION") if format.nil?
-    return super(format)
+    return super(format.nil? ? "NAME-VERSION.EXTENSION" : format)
   end # def to_s
 
   public(:input, :output, :identifier, :to_s)

--- a/lib/fpm/package/pacman.rb
+++ b/lib/fpm/package/pacman.rb
@@ -306,10 +306,12 @@ class FPM::Package::Pacman < FPM::Package
     end
   end # def default_output
 
+  def to_s_extension; "pkg.tar#{compression_ending}"; end
+
   def to_s(format=nil)
     # Default format if nil
     # git_1.7.9.3-1_amd64.deb
-    return super("NAME-FULLVERSION-ARCH.pkg.tar#{compression_ending}") if format.nil?
+    return super("NAME-FULLVERSION-ARCH.EXTENSION") if format.nil?
     return super(format)
   end # def to_s
 

--- a/lib/fpm/package/pacman.rb
+++ b/lib/fpm/package/pacman.rb
@@ -310,9 +310,8 @@ class FPM::Package::Pacman < FPM::Package
 
   def to_s(format=nil)
     # Default format if nil
-    # git_1.7.9.3-1_amd64.deb
-    return super("NAME-FULLVERSION-ARCH.EXTENSION") if format.nil?
-    return super(format)
+    # git_1.7.9.3-1-amd64.pkg.tar.xz
+    return super(format.nil? ? "NAME-FULLVERSION-ARCH.EXTENSION" : format)
   end # def to_s
 
   private

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -560,12 +560,19 @@ class FPM::Package::RPM < FPM::Package
     return @epoch
   end # def epoch
 
+  def to_s_dist;
+    attributes[:rpm_dist] ? "#{attributes[:rpm_dist]}" : "DIST";
+  end
+
   def to_s(format=nil)
     if format.nil?
-      return super("NAME-VERSION-ITERATION.DIST.ARCH.EXTENSION").gsub('DIST', attributes[:rpm_dist]) if attributes[:rpm_dist]
-      return super("NAME-VERSION-ITERATION.ARCH.EXTENSION")
+      format = if attributes[:rpm_dist]
+        "NAME-VERSION-ITERATION.DIST.ARCH.EXTENSION"
+      else
+        "NAME-VERSION-ITERATION.ARCH.EXTENSION"
+      end
     end
-    return super(format)
+    return super(format.gsub("DIST", to_s_dist))
   end # def to_s
 
   def payload_compression

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -562,8 +562,8 @@ class FPM::Package::RPM < FPM::Package
 
   def to_s(format=nil)
     if format.nil?
-      return super("NAME-VERSION-ITERATION.DIST.ARCH.TYPE").gsub('DIST', attributes[:rpm_dist]) if attributes[:rpm_dist]
-      return super("NAME-VERSION-ITERATION.ARCH.TYPE")
+      return super("NAME-VERSION-ITERATION.DIST.ARCH.EXTENSION").gsub('DIST', attributes[:rpm_dist]) if attributes[:rpm_dist]
+      return super("NAME-VERSION-ITERATION.ARCH.EXTENSION")
     end
     return super(format)
   end # def to_s


### PR DESCRIPTION
The main issue that this patch tries to address it that ``freebsd`` packager ignored ``--package`` CLI option. Working on it I also decided to add some customization points to ``FPM::Package#to_s`` such that subclasses can easily overload certain bits of its behavior.