### PR TITLE
Fix gem error

### DIFF
--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -178,7 +178,7 @@ class FPM::Package::Gem < FPM::Package
     ::FileUtils.mkdir_p(installdir)
     # TODO(sissel): Allow setting gem tool path
     args = [attributes[:gem_gem], "install", "--quiet", "--no-ri", "--no-rdoc",
-       "--install-dir", installdir, "--ignore-dependencies"]
+       "--no-user-install", "--install-dir", installdir, "--ignore-dependencies"]
     if attributes[:gem_env_shebang?]
       args += ["-E"]
     end


### PR DESCRIPTION
Without `--no-user-install`, the gem command fails with:

    ERROR:  User --install-dir or --user-install but not both

Apparently, on some circumstances, gem can default to a user install and prevent it from using `--install-dir`.

I am using gem 2.5.1 on ruby 2.3.0p0 (2015-12-25 revision 53290)