### PR TITLE
add support for scoped npm packages

### DIFF
--- a/lib/fpm/package/npm.rb
+++ b/lib/fpm/package/npm.rb
@@ -62,7 +62,7 @@ class FPM::Package::NPM < FPM::Package
     npm_ls = JSON.parse(npm_ls_out)
     name, info = npm_ls["dependencies"].first
 
-    self.name = [attributes[:npm_package_name_prefix], name].join("-")
+    self.name = [attributes[:npm_package_name_prefix], name].join("-").sub!('/', '-').sub!('@', '')
     self.version = info.fetch("version", "0.0.0")
 
     if info.include?("repository")


### PR DESCRIPTION
Currently building an rpm from a scoped npm package explodes because of the `/` between the scope and name as well as the `@` in the scope.

If this is a PR you are interested in accepting, I can put some more time and effort into cleaning this up.