### PR TITLE
Add fpm namespace require for rake task

### DIFF
--- a/lib/fpm/rake_task.rb
+++ b/lib/fpm/rake_task.rb
@@ -1,3 +1,4 @@
+require "fpm/namespace"
 require "ostruct"
 require "rake"
 require "rake/tasklib"


### PR DESCRIPTION
The rake task class needs to require the fpm namespace in order
to be included elsewhere.