### PR TITLE
fix condition where the output directory's mode is 0700

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -162,6 +162,9 @@ class FPM::Package::Dir < FPM::Package
         copy(path, target)
       end
     end
+
+    logger.debug("Updating destination folder permissions with 0755", :destination => destination)
+    File.chmod(0755, destination)
   end # def clone
 
   # Copy a path.

--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -162,9 +162,6 @@ class FPM::Package::Dir < FPM::Package
         copy(path, target)
       end
     end
-
-    logger.debug("Updating destination folder permissions with 0755", :destination => destination)
-    File.chmod(0755, destination)
   end # def clone
 
   # Copy a path.

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -277,7 +277,7 @@ module FPM::Util
     end
 
     unless source_stat.symlink?
-      File.chmod(mode, destination)
+      File.chmod(mode, destination) unless dest_stat.world_readable?
     end
   end # def copy_metadata
 


### PR DESCRIPTION
I've run into a strange case where `fpm` on one of our jenkins builds outputs our project as $Project.dir with a mode of 775, but another project with an almost identical set of build instructions is creating a $Project.dir with a mode of 700.

I scanned the code really quick, but haven't quite found the source of the problem. I even tried to beat `fpm` to the punch and created the target directory so it would not have to run `mkdir` for me, and it still ended up overriding the mode with 700.

Ordinarily, this wouldn't be an issue, but the build is running with sudo and so the jenkins user cannot `cd` into that directory. If there's a better way to address this, or if you can point in the right direction, I'd certainly appreciate that.
