### PR TITLE
workaround rubygems issue #1608 and remove dependency of corefines

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   # For parsing JSON (required for some Python support, etc)
   # http://flori.github.com/json/doc/index.html
   spec.add_dependency("json", ">= 1.7.7") # license: Ruby License
-  
+
   # For logging
   # https://github.com/jordansissel/ruby-cabin
-  spec.add_dependency("cabin", ">= 0.6.0") # license: Apache 2 
+  spec.add_dependency("cabin", ">= 0.6.0") # license: Apache 2
 
   # For backports to older rubies
   # https://github.com/marcandre/backports
@@ -50,9 +50,6 @@ Gem::Specification.new do |spec|
 
   # For creating FreeBSD package archives (xz-compressed tars)
   spec.add_dependency("ruby-xz") # license: MIT
-
-  # For backward compatibility with older rubies
-  spec.add_dependency("corefines", "~>1.9") # license: MIT
 
   spec.add_development_dependency("rspec", "~> 3.0.0") # license: MIT (according to wikipedia)
   spec.add_development_dependency("insist", "~> 1.0.0") # license: Apache 2

--- a/lib/fpm/package/freebsd.rb
+++ b/lib/fpm/package/freebsd.rb
@@ -3,9 +3,7 @@ require "fpm/package"
 require "fpm/util"
 require "digest"
 require "fileutils"
-require "rubygems/package"
 require "xz"
-require "corefines"
 
 class FPM::Package::FreeBSD < FPM::Package
   SCRIPT_MAP = {
@@ -94,7 +92,7 @@ class FPM::Package::FreeBSD < FPM::Package
     # Create the .txz package archive from the files in staging_path.
     File.open(output_path, "wb") do |file|
       XZ::StreamWriter.new(file) do |xz|
-        ::Gem::Package::TarWriter.new(xz) do |tar|
+        FPM::Util::TarWriter.new(xz) do |tar|
           # The manifests must come first for pkg.
           add_path(tar, "+COMPACT_MANIFEST",
                    File.join(staging_path, "+COMPACT_MANIFEST"))
@@ -144,33 +142,3 @@ class FPM::Package::FreeBSD < FPM::Package
     return super(format.nil? ? "NAME-FULLVERSION.EXTENSION" : format)
   end # def to_s
 end # class FPM::Package::FreeBSD
-
-# Backport Symlink Support to TarWriter
-# https://github.com/rubygems/rubygems/blob/4a778c9c2489745e37bcc2d0a8f12c601a9c517f/lib/rubygems/package/tar_writer.rb#L239-L253
-module TarWriterAddSymlink
-  refine Gem::Package::TarWriter do
-    def add_symlink(name, target, mode)
-      check_closed
-
-      name, prefix = split_name name
-
-      header = Gem::Package::TarHeader.new(:name => name, :mode => mode,
-                                           :size => 0, :typeflag => "2",
-                                           :linkname => target,
-                                           :prefix => prefix,
-                                           :mtime => Time.now).to_s
-
-      @io.write header
-
-      self
-    end # def add_symlink
-  end # refine Gem::Package::TarWriter
-end # module TarWriterAddSymlink
-
-module Util
-  module Tar
-    unless Gem::Package::TarWriter.public_instance_methods.include? :add_symlink
-      using TarWriterAddSymlink
-    end
-  end # module Tar
-end # module Util

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -354,3 +354,5 @@ module FPM::Util
     @logger ||= Cabin::Channel.get
   end # def logger
 end # module FPM::Util
+
+require 'fpm/util/tar_writer'

--- a/lib/fpm/util/tar_writer.rb
+++ b/lib/fpm/util/tar_writer.rb
@@ -1,0 +1,80 @@
+require 'rubygems/package'
+
+module FPM
+  module Issues
+    module TarWriter
+      # See https://github.com/rubygems/rubygems/issues/1608
+      def self.has_issue_1608?
+        name, prefix = nil,nil
+        io = StringIO.new
+        ::Gem::Package::TarWriter.new(io) do |tw|
+          name, prefix = tw.split_name('/123456789'*9 + '/1234567890') # abs name 101 chars long
+        end
+        return prefix.empty?
+      end
+
+      def self.has_issues_with_split_name?
+        return false unless ::Gem::Package::TarWriter.method_defined?(:split_name)
+        return has_issue_1608?
+      end
+
+      def self.has_issues_with_add_symlink?
+        return !::Gem::Package::TarWriter.public_instance_methods.include?(:add_symlink)
+      end
+    end # module TarWriter
+  end # module Issues
+end # module FPM
+
+module FPM; module Util; end; end
+
+# Like the ::Gem::Package::TarWriter but contains some backports and bug fixes
+class FPM::Util::TarWriter < ::Gem::Package::TarWriter
+  if FPM::Issues::TarWriter.has_issues_with_split_name?
+    def split_name(name)
+      if name.bytesize > 256 then
+        raise ::Gem::Package::TooLongFileName.new("File \"#{name}\" has a too long path (should be 256 or less)")
+      end
+
+      prefix = ''
+      if name.bytesize > 100 then
+        parts = name.split('/', -1) # parts are never empty here
+        name = parts.pop            # initially empty for names with a trailing slash ("foo/.../bar/")
+        prefix = parts.join('/')    # if empty, then it's impossible to split (parts is empty too)
+        while !parts.empty? && (prefix.bytesize > 155 || name.empty?)
+          name = parts.pop + '/' + name
+          prefix = parts.join('/')
+        end
+
+        if name.bytesize > 100 or prefix.empty? then
+          raise ::Gem::Package::TooLongFileName.new("File \"#{prefix}/#{name}\" has a too long name (should be 100 or less)")
+        end
+
+        if prefix.bytesize > 155 then
+          raise ::Gem::Package::TooLongFileName.new("File \"#{prefix}/#{name}\" has a too long base path (should be 155 or less)")
+        end
+      end
+
+      return name, prefix
+    end
+  end # if FPM::Issues::TarWriter.spit_name_has_issues?
+
+  if FPM::Issues::TarWriter.has_issues_with_add_symlink?
+    # Backport Symlink Support to TarWriter
+    # https://github.com/rubygems/rubygems/blob/4a778c9c2489745e37bcc2d0a8f12c601a9c517f/lib/rubygems/package/tar_writer.rb#L239-L253
+    def add_symlink(name, target, mode)
+      check_closed
+
+      name, prefix = split_name name
+
+      header = ::Gem::Package::TarHeader.new(:name => name, :mode => mode,
+                                             :size => 0, :typeflag => "2",
+                                             :linkname => target,
+                                             :prefix => prefix,
+                                             :mtime => Time.now).to_s
+
+      @io.write header
+
+      self
+    end # def add_symlink
+  end
+end


### PR DESCRIPTION
Fixes #1107. I had to provide new class ``FPM::Util::TarWriter`` to patch problems with ``Gem::Package::TarWriter``. Refinemends didn't seem to be useful in this case so I decided to get rid of the only refinement used in ``freebsd.rb``, as well as to remove the dependency of ``corefines``.

Tested on FreeBSD 10.3 (used to succesfully build [vagrant-installers](https://github.com/mitchellh/vagrant-installers)).

BTW. Is it possible to have fpm-1.5.1 with this PR included soon?