### PR TITLE
New source: pleaserun

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -52,7 +52,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("ruby-xz") # license: MIT
 
   # For sourcing from pleaserun 
-  spec.add_dependency("pleaserun") # license: Apache 2
+  spec.add_dependency("pleaserun", "~> 0.0.24") # license: Apache 2
 
   spec.add_development_dependency("rspec", "~> 3.0.0") # license: MIT (according to wikipedia)
   spec.add_development_dependency("insist", "~> 1.0.0") # license: Apache 2

--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   # For command-line flag support
   # https://github.com/mdub/clamp/blob/master/README.markdown
-  spec.add_dependency("clamp", "~> 0.6") # license: MIT
+  spec.add_dependency("clamp", "~> 1.0.0") # license: MIT
 
   # For starting external processes across various ruby interpreters
   spec.add_dependency("childprocess") # license: ???
@@ -50,6 +50,9 @@ Gem::Specification.new do |spec|
 
   # For creating FreeBSD package archives (xz-compressed tars)
   spec.add_dependency("ruby-xz") # license: MIT
+
+  # For sourcing from pleaserun 
+  spec.add_dependency("pleaserun") # license: Apache 2
 
   spec.add_development_dependency("rspec", "~> 3.0.0") # license: MIT (according to wikipedia)
   spec.add_development_dependency("insist", "~> 1.0.0") # license: Apache 2

--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -332,12 +332,18 @@ class FPM::Command < Clamp::Command
       end
     end
 
-    # Each remaining command line parameter is used as an 'input' argument.
-    # For directories, this means paths. For things like gem and python, this
-    # means package name or paths to the packages (rails, foo-1.0.gem, django,
-    # bar/setup.py, etc)
-    args.each do |arg|
-      input.input(arg)
+    if input_type == "pleaserun"
+      # Special case for pleaserun that all parameters are considered the 'command'
+      # to run through pleaserun.
+      input.input(args)
+    else
+      # Each remaining command line parameter is used as an 'input' argument.
+      # For directories, this means paths. For things like gem and python, this
+      # means package name or paths to the packages (rails, foo-1.0.gem, django,
+      # bar/setup.py, etc)
+      args.each do |arg|
+        input.input(arg)
+      end
     end
 
     # If --inputs was specified, read it as a file.

--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -99,6 +99,20 @@ class FPM::Package::Dir < FPM::Package
       logger["method"] = "output"
       clone(".", output_path)
     end
+
+    # Write the scripts, too.
+    scripts_path = File.join(output_path, ".scripts")
+    ::Dir.mkdir(scripts_path)
+    [:before_install, :after_install, :before_remove, :after_remove].each do |name|
+      next unless script?(name)
+      out = File.join(scripts_path, name.to_s)
+      logger.debug("Writing script", :source => name, :target => out)
+      File.write(out, script(name))
+      require "pry"
+      binding.pry
+      File.chmod(0755, out)
+    end
+
   ensure
     logger.remove("method")
   end # def output

--- a/lib/fpm/package/pleaserun.rb
+++ b/lib/fpm/package/pleaserun.rb
@@ -21,10 +21,11 @@ class FPM::Package::PleaseRun < FPM::Package
   private
   def input(command)
     platforms = [
-      ::PleaseRun::Platform::Systemd.new("default"),
-      ::PleaseRun::Platform::Upstart.new("1.5"),
-      ::PleaseRun::Platform::Launchd.new("10.9"),
-      ::PleaseRun::Platform::SYSV.new("lsb-3.1")
+      ::PleaseRun::Platform::Systemd.new("default"), # RHEL 7, Fedora 19+, Debian 8, Ubuntu 16.04
+      ::PleaseRun::Platform::Upstart.new("1.5"), # Recent Ubuntus
+      ::PleaseRun::Platform::Upstart.new("0.6.5"), # CentOS 6
+      ::PleaseRun::Platform::Launchd.new("10.9"), # OS X
+      ::PleaseRun::Platform::SYSV.new("lsb-3.1") # Ancient stuff
     ]
 
     attributes[:pleaserun_name] ||= File.basename(command.first)

--- a/lib/fpm/package/pleaserun.rb
+++ b/lib/fpm/package/pleaserun.rb
@@ -44,7 +44,15 @@ class FPM::Package::PleaseRun < FPM::Package
       ::PleaseRun::Installer.write_actions(platform, actions_script)
     end
 
-    scripts[:after_install] = template(File.join("pleaserun", "install.sh")).result(binding)
+    libs = [ "install.sh", "install-path.sh", "generate-cleanup.sh" ]
+    libs.each do |file|
+      base = staging_path(File.join(attributes[:prefix]))
+      File.write(File.join(base, file), template(File.join("pleaserun", file)).result(binding))
+      File.chmod(0755, File.join(base, file))
+    end
+
+    scripts[:after_install] = template(File.join("pleaserun", "scripts", "after-install.sh")).result(binding)
+    scripts[:before_remove] = template(File.join("pleaserun", "scripts", "before-remove.sh")).result(binding)
   end # def input
 
   public(:input)

--- a/lib/fpm/package/pleaserun.rb
+++ b/lib/fpm/package/pleaserun.rb
@@ -1,0 +1,62 @@
+require "fpm/namespace"
+require "fpm/package"
+require "fpm/util"
+require "fileutils"
+
+require "pleaserun/cli"
+
+# A pleaserun package.
+#
+# This does not currently support 'output'
+class FPM::Package::PleaseRun < FPM::Package
+  # Copy flags from the PleaseRun::CLI
+  ::PleaseRun::CLI.declared_options.each do |o|
+    # Skip exposing 'install prefix' flag since only internally we need to use this.
+    next if ["--install", "--install-prefix"].include?(o.long_switch)
+
+    option o.long_switch.gsub("[no-]", ""), o.type, o.description, {
+      :required => o.required?,
+      :multivalued => o.multivalued?,
+      :default => o.default_value,
+      :environment_variable => o.environment_variable,
+      :hidden => o.hidden?
+    }.reject { |k,v| v.nil? }
+  end
+
+  private
+  def input(command)
+    flags = ::PleaseRun::CLI.declared_options.collect do |o|
+      name = "pleaserun_#{o.attribute_name}".to_sym
+      value = attributes[name]
+      next if value.nil?
+
+      case o.type
+      when :flag
+        o.long_switch
+      else
+        [o.long_switch, value]
+      end
+    end.reject(&:nil?).flatten
+
+
+    flags += [ "--install-prefix", staging_path ]
+    pleaserun = ::PleaseRun::CLI.new("fpm -s pleaserun")
+
+    # hack to override the logging setup in pleaserun
+    l = logger
+    pleaserun.define_singleton_method(:setup_logger) do
+      instance_variable_set(:@logger, l)
+    end
+    
+    pleaserun.run(flags + command)
+
+    staging_path("install_actions.sh").tap do |install_actions|
+      if File.exist?(install_actions)
+        scripts[:after_install] = File.read(install_actions)
+        File.unlink(install_actions)
+      end
+    end
+  end # def input
+
+  public(:input)
+end # class FPM::Package::PleaseRun

--- a/lib/fpm/package/pleaserun.rb
+++ b/lib/fpm/package/pleaserun.rb
@@ -36,7 +36,11 @@ class FPM::Package::PleaseRun < FPM::Package
       platform.program = command.first
       platform.name = attributes[:pleaserun_name]
       platform.args = command[1..-1]
-      platform.description = attributes[:description]
+      platform.description = if attributes[:description_given?]
+        attributes[:description]
+      else
+        platform.name
+      end
       base = staging_path(File.join(attributes[:prefix], "#{platform.platform}/#{platform.target_version || "default"}"))
       target = File.join(base, "files")
       actions_script = File.join(base, "install_actions.sh")

--- a/lib/fpm/package/pleaserun.rb
+++ b/lib/fpm/package/pleaserun.rb
@@ -36,7 +36,7 @@ class FPM::Package::PleaseRun < FPM::Package
       platform.name = attributes[:pleaserun_name]
       platform.args = command[1..-1]
       platform.description = attributes[:description]
-      base = staging_path(File.join(attributes[:prefix], "#{platform.platform}-#{platform.target_version || "default"}"))
+      base = staging_path(File.join(attributes[:prefix], "#{platform.platform}/#{platform.target_version || "default"}"))
       target = File.join(base, "files")
       actions_script = File.join(base, "install_actions.sh")
       ::PleaseRun::Installer.install_files(platform, target, false)

--- a/lib/fpm/package/tar.rb
+++ b/lib/fpm/package/tar.rb
@@ -48,6 +48,18 @@ class FPM::Package::Tar < FPM::Package
   # the compression type.
   def output(output_path)
     output_check(output_path)
+
+    # Write the scripts, too.
+    scripts_path = File.join(staging_path, ".scripts")
+    ::Dir.mkdir(scripts_path)
+    [:before_install, :after_install, :before_remove, :after_remove].each do |name|
+      next unless script?(name)
+      out = File.join(scripts_path, name.to_s)
+      logger.debug("Writing script", :source => name, :target => out)
+      File.write(out, script(name))
+      File.chmod(0755, out)
+    end
+
     # Unpack the tarball to the staging path
     args = ["-cf", output_path, "-C", staging_path]
     tar_compression_flag(output_path).tap do |flag|

--- a/spec/acceptance/puppet/manifests/install.pp
+++ b/spec/acceptance/puppet/manifests/install.pp
@@ -1,0 +1,35 @@
+node default {
+  $package_provider = "$operatingsystem-$operatingsystemrelease" ? {
+    /^(Fedora|RedHat|CentOS|OpenSuSE)/ => "rpm",
+    /^(Debian|Ubuntu)/ => "dpkg",
+    default => undef,
+  }
+ 
+  $package_source = "$operatingsystem-$operatingsystemrelease" ? {
+    /^(Fedora|RedHat|CentOS|OpenSuSE)/ => "example-service-1.0-1.noarch.rpm",
+    /^(Debian|Ubuntu)/ => "example-service_1.0_all.deb",
+    default => undef,
+  }
+
+  $service_provider = "$operatingsystem-$operatingsystemrelease" ? {
+    /^CentOS-6/ => "upstart",
+    default => undef,
+  }
+
+  
+
+  package {
+    "example-service": 
+      provider => $package_provider,
+      source => $package_source,
+      ensure => present;
+  }
+
+  service {
+    "example":
+      provider => $service_provider,
+      require => Package["example-service"],
+      enable => true,
+      ensure => running;
+  }
+}

--- a/spec/acceptance/puppet/manifests/remove.pp
+++ b/spec/acceptance/puppet/manifests/remove.pp
@@ -1,0 +1,27 @@
+node default {
+  $package_provider = "$operatingsystem-$operatingsystemrelease" ? {
+    /^(Fedora|RedHat|CentOS)/ => "rpm",
+    /^(Debian|Ubuntu)/ => "dpkg",
+    default => undef,
+  }
+
+  $service_provider = "$operatingsystem-$operatingsystemrelease" ? {
+    /^CentOS-6/ => "upstart",
+    default => undef,
+  }
+
+  package {
+    "example-service": 
+      require => Service["example"],
+      provider => $package_provider,
+      source => "example-service-1.0-1.noarch.rpm",
+      ensure => absent;
+  }
+
+  service {
+    "example":
+      provider => $service_provider,
+      enable => false,
+      ensure => stopped;
+  }
+}

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -605,8 +605,8 @@ describe FPM::Package::RPM do
       insist { subject.architecture } == "noarch" # see #architecture
       insist { subject.iteration } == "100"
       insist { subject.epoch } == 5
-      insist { subject.dependencies[0] }  == "something > 10"
-      insist { subject.dependencies[1] } == "hello >= 20"
+      insist { subject.dependencies }.include?("something > 10")
+      insist { subject.dependencies }.include?("hello >= 20")
       insist { subject.conflicts[0] } == "bad < 2"
       insist { subject.license } == @generator.license.split("\n").join(" ") # See issue #252
       insist { subject.provides[0] } == "bacon = 1.0"

--- a/templates/pleaserun/generate-cleanup.sh
+++ b/templates/pleaserun/generate-cleanup.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+show_cleanup_step() {
+  d="${1##.}"
+  if [ ! -z "$d" ] ; then 
+    if [ -d "$1" -a ! -d "$d" ] ; then 
+      echo "rmdir \"$d\""
+    fi
+    if [ -f "$1" ] ; then 
+      echo "rm \"$d\""
+    fi
+  fi
+}
+
+for i in "$@" ; do
+  show_cleanup_step "$i"
+done

--- a/templates/pleaserun/install-path.sh
+++ b/templates/pleaserun/install-path.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+install_path() {
+  d="${1##.}"
+  if [ ! -z "$d" ] ; then 
+    if [ -d "$1" -a ! -d "$d" ] ; then 
+      mkdir "$d"
+    fi
+    if [ -f "$1" ] ; then 
+      cp -p "$1" "$d"
+    fi
+  fi
+}
+
+for i in "$@" ; do
+  install_path "$i"
+done

--- a/templates/pleaserun/install.sh
+++ b/templates/pleaserun/install.sh
@@ -21,6 +21,7 @@ install_files() {
     # Write a cleanup script
     find . -print0 | xargs -r0 -n1 "$source/generate-cleanup.sh" > "$cleanup_script"
 
+    # Actually do the installation
     find . -print0 | xargs -r0 -n1 "$source/install-path.sh"
   )
 }

--- a/templates/pleaserun/install.sh
+++ b/templates/pleaserun/install.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+BASEDIR="<%= attributes[:prefix] %>"
+
+silent() {
+  "$@" > /dev/null 2>&1
+}
+
+install_files() {
+  # TODO(sissel): Need to know what prefix the files exist at
+  platform="$1"
+
+  cp -Rp "${BASEDIR}/${platform}/files/" "/"
+}
+
+install_actions() {
+  # TODO(sissel): Need to know what prefix the files exist at
+  platform="$1"
+  . "${BASEDIR}/${platform}/activate.sh"
+}
+
+has_systemd() {
+  [ -d "/lib/systemd/system/" ] && silent which systemctl
+}
+
+has_upstart() {
+  [ -d "/etc/init" ] && silent which initctl
+}
+
+has_sysv() {
+  [ -d "/etc/init.d" ] 
+}
+
+has_freebsd_rcng() {
+  [ -d "/etc/rc.d" ] && silent which rcorder
+}
+
+has_daemontools() {
+  [ -d "/service" ] && silent which sv
+}
+
+has_launchd() { 
+  [ -d "/Library/LaunchDaemons" ] && silent which launchtl
+}
+
+platforms="systemd upstart daemontools freebsd_rcng launchd sysv"
+for platform in $platforms ; do
+  if has_$platform ; then
+    echo "Platform $platform detected.."
+    install_files $platform
+    install_actions $platform
+    break
+  fi
+done

--- a/templates/pleaserun/install.sh
+++ b/templates/pleaserun/install.sh
@@ -24,22 +24,38 @@ install_actions() {
   # TODO(sissel): Need to know what prefix the files exist at
   platform="$1"
   version="$(version_${platform})"
-  . "${BASEDIR}/${platform}/${version}/install_actions.sh"
+  
+
+  actions="${BASEDIR}/${platform}/${version}/install_actions.sh"
+  if [ -f "$actions" ] ; then
+    . "$actions"
+  fi
 }
 
 version_systemd() {
+  # Treat all systemd versions the same
   echo default
 }
 
 version_launchd() {
+  # Treat all launchd versions the same
   echo 10.9
 }
 
 version_upstart() {
-  echo "default"
+  # Treat all upstart versions the same
+  # TODO(sissel): Upstart 0.6.5 needs to be handled specially.
+  version="$(initctl --version | head -1 | tr -d '()' | awk '{print $NF}')"
+
+  case $version in
+    0.6.5) echo $version ;;
+    *) echo "1.5" ;; # default modern assumption
+  esac
 }
 
 version_sysv() {
+  # TODO(sissel): Once pleaserun supports multiple sysv implementations, maybe
+  # we inspect the OS to find out what we should target.
   echo lsb-3.1
 }
 

--- a/templates/pleaserun/install.sh
+++ b/templates/pleaserun/install.sh
@@ -15,7 +15,6 @@ install_files() {
 
   (
     # TODO(sissel): Should I just rely on rsync for this stuff?
-    #rsync -av "${source}/${platform}/${version}/files/" /
     cd "${source}/${platform}/${version}/files/" || exit 1
 
     # Write a cleanup script
@@ -66,7 +65,8 @@ version_sysv() {
 }
 
 has_systemd() {
-  [ -d "/lib/systemd/system/" ] && silent which systemctl
+  # Some OS vendors put systemd in ... different places ...
+  [ -d "/lib/systemd/system/" -o -d "/usr/lib/systemd/system" ] && silent which systemctl
 }
 
 has_upstart() {

--- a/templates/pleaserun/install.sh
+++ b/templates/pleaserun/install.sh
@@ -9,14 +9,38 @@ silent() {
 install_files() {
   # TODO(sissel): Need to know what prefix the files exist at
   platform="$1"
+  version="$(version_${platform})"
 
-  cp -Rp "${BASEDIR}/${platform}/files/" "/"
+  (
+    # TODO(sissel): Should I just rely on rsync for this stuff?
+    #rsync -av "${BASEDIR}/${platform}/${version}/files/" /
+    cd "${BASEDIR}/${platform}/${version}/files/" || exit 1
+    find . -print0 \
+      | xargs -0 -n1 sh -c 'd="${1##.}"; if [ ! -z "$d" ] ; then if [ -d "$1" -a ! -d "$d" ] ; then mkdir "$d"; fi; if [ -f "$1" ] ; then cp -p "$1" "$d" ; fi; fi' -
+  )
 }
 
 install_actions() {
   # TODO(sissel): Need to know what prefix the files exist at
   platform="$1"
-  . "${BASEDIR}/${platform}/activate.sh"
+  version="$(version_${platform})"
+  . "${BASEDIR}/${platform}/${version}/install_actions.sh"
+}
+
+version_systemd() {
+  echo default
+}
+
+version_launchd() {
+  echo 10.9
+}
+
+version_upstart() {
+  echo "default"
+}
+
+version_sysv() {
+  echo lsb-3.1
 }
 
 has_systemd() {
@@ -43,12 +67,19 @@ has_launchd() {
   [ -d "/Library/LaunchDaemons" ] && silent which launchtl
 }
 
-platforms="systemd upstart daemontools freebsd_rcng launchd sysv"
+platforms="systemd upstart launchd sysv"
+installed=0
 for platform in $platforms ; do
   if has_$platform ; then
-    echo "Platform $platform detected.."
+    version="$(version_$platform)"
+    echo "Platform $platform ($version) detected. Installing service."
     install_files $platform
     install_actions $platform
+    installed=1
     break
   fi
 done
+
+if [ "$installed" -eq 0 ] ; then
+  echo "Failed to detect any service platform, so no service was installed. Files are available in ${BASEDIR} if you need them."
+fi

--- a/templates/pleaserun/install.sh
+++ b/templates/pleaserun/install.sh
@@ -71,9 +71,9 @@ has_sysv() {
   [ -d "/etc/init.d" ] 
 }
 
-has_freebsd_rcng() {
-  [ -d "/etc/rc.d" ] && silent which rcorder
-}
+#has_freebsd_rcng() {
+  #[ -d "/etc/rc.d" ] && silent which rcorder
+#}
 
 has_daemontools() {
   [ -d "/service" ] && silent which sv
@@ -81,6 +81,15 @@ has_daemontools() {
 
 has_launchd() { 
   [ -d "/Library/LaunchDaemons" ] && silent which launchtl
+}
+
+install_help() {
+  case $platform in
+    systemd) echo "To start this service, use: systemctl start <%= attributes[:pleaserun_name] %>" ;;
+    upstart) echo "To start this service, use: initctl start <%= attributes[:pleaserun_name] %>" ;;
+    launchd) echo "To start this service, use: launchctl start <%= attributes[:pleaserun_name] %>" ;;
+    sysv) echo "To start this service, use: /etc/init.d/<%= attributes[:pleaserun_name] %> start" ;;
+  esac
 }
 
 platforms="systemd upstart launchd sysv"
@@ -91,6 +100,7 @@ for platform in $platforms ; do
     echo "Platform $platform ($version) detected. Installing service."
     install_files $platform
     install_actions $platform
+    install_help $platform
     installed=1
     break
   fi

--- a/templates/pleaserun/scripts/after-install.sh
+++ b/templates/pleaserun/scripts/after-install.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+source="<%= attributes[:prefix] %>"
+exec sh "$source/install.sh"

--- a/templates/pleaserun/scripts/before-remove.sh
+++ b/templates/pleaserun/scripts/before-remove.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+source="<%= attributes[:prefix] %>"
+
+if [ -f "$source/cleanup.sh" ] ; then
+  echo "Running cleanup to remove service for package <%= attributes[:name] %>"
+  set -e
+  sh "$source/cleanup.sh"
+
+  # Remove the script also since the package installation generated it.
+  rm "$source/cleanup.sh"
+fi


### PR DESCRIPTION
The `pleaserun` tool helps generate service manifests for different service platforms such as systemd and runit.

This PR introduces `pleaserun` as a package source. The goal is to have a package you can install that will "do the right thing" and install the best-fitting service manifest for the target system.

Example usage:

```
% fpm -s pleaserun -t rpm -a all -n redis-service --pleaserun-name redis /usr/bin/redis-server
...

% sudo yum install redis-service-1.0-1.noarch.rpm
...
  Installing  : redis-service-1.0-1.noarch                                                            1/1
Platform systemd (default) detected. Installing service.
To start this service, use: systemctl start redis
  Verifying   : redis-service-1.0-1.noarch                                                            1/1

Installed:
  redis-service.noarch 1.0-1
...

% systemctl status redis
● redis.service - redis
   Loaded: loaded (/usr/lib/systemd/system/redis.service; disabled; vendor preset: disabled)
   Active: inactive (dead)
```

Yay, easy services!

It also tries to clean up during package removal:

```
% sudo yum remove redis-service
...
Running cleanup to remove service for package redis-service
...

% sudo systemctl status redis
● redis.service
   Loaded: not-found (Reason: No such file or directory)
   Active: inactive (dead)
```