### PR TITLE
last_comment is depricated replaced with last_description

### DIFF
--- a/lib/fpm/rake_task.rb
+++ b/lib/fpm/rake_task.rb
@@ -14,7 +14,7 @@ class FPM::RakeTask < Rake::TaskLib
     (@source.empty? || @target.empty? || options.name.empty?) &&
       abort("Must specify package name, source and output")
 
-    desc "Package #{@name}" unless ::Rake.application.last_comment
+    desc "Package #{@name}" unless ::Rake.application.last_description
 
     task(options.name) do |_, task_args|
       block.call(*[options, task_args].first(block.arity)) if block_given?


### PR DESCRIPTION
last_comment is deprecated with Rake 11.1.0 and will be removed with Rake 12.

more info read:
https://github.com/ruby/rake/issues/116