### PR TITLE
Fix for ignoring --rpm-tag option on command line

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -83,7 +83,7 @@ Packager: <%= maintainer %>
 <% dependencies.each do |req| -%>
 Requires: <%= req %>
 <% end -%>
-<% (attributes[:rpm_tags] or []).each do |tag| -%>
+<% (attributes[:rpm_tag] or []).each do |tag| -%>
 <%= tag %>
 <% end -%>
 <% end -%>


### PR DESCRIPTION
The `--rpm-tag` option was ignored when used on command line.