### PR TITLE
remove trailing slash from --prefix option in rpm-packages, fixes #819

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -523,7 +523,11 @@ class FPM::Package::RPM < FPM::Package
   end # def output
 
   def prefix
-    return (attributes[:prefix] or "/")
+    if attributes[:prefix] and attributes[:prefix] != '/'
+      return attributes[:prefix].chomp('/')
+    else
+      return "/"
+    end
   end # def prefix
 
   def build_sub_dir

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -457,6 +457,24 @@ describe FPM::Package::RPM do
     end # dist
   end # #output
 
+  describe "prefix attribute" do
+    it "should default to slash" do
+      insist { subject.prefix } == "/"
+    end
+    it "should leave a single slash as it is" do
+      subject.attributes[:prefix] = "/"
+      insist { subject.prefix } == "/"
+    end
+    it "should leave a path without trailing slash it is" do
+      subject.attributes[:prefix] = "/foo/bar"
+      insist { subject.prefix } == "/foo/bar"
+    end
+    it "should remove trailing slashes" do
+      subject.attributes[:prefix] = "/foo/bar/"
+      insist { subject.prefix } == "/foo/bar"
+    end
+  end
+
   describe "regressions should not occur", :if => program_exists?("rpmbuild") do
     before :each do
       @tempfile_handle =

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -58,9 +58,8 @@ AutoProv: yes
 # Seems specifying BuildRoot is required on older rpmbuild (like on CentOS 5)
 # fpm passes '--define buildroot ...' on the commandline, so just reuse that.
 BuildRoot: %buildroot
-# Add prefix, must not end with /
 <% if !prefix.nil? and !prefix.empty? %>
-Prefix: <%= prefix.gsub(/([^\/]+)(\/$)/, '') %>
+Prefix: <%= prefix %>
 <% end -%>
 
 Group: <%= category %>


### PR DESCRIPTION
This is a new version of PR https://github.com/jordansissel/fpm/issues/820 by @dhajoshi. It fixes rpm-builds breaking, when `--prefix` ends with a slash. Comes with tests included. Details about the problem can be found in issue #819.

In case there are any questions, please feel free to ask them. If you want anything changed about this PR, please just let me know and I'll get it done. Thank you.