### PR TITLE
fix --workdir not having an effect on the build and staging dirs, fixes #1124

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -8,6 +8,7 @@ require "socket" # stdlib, for Socket.gethostname
 require "shellwords" # stdlib, for Shellwords.escape
 require "erb" # stdlib, for template processing
 require "cabin" # gem "cabin"
+require "stud/temporary"
 
 # This class is the parent of all packages.
 # If you want to implement an FPM package type, you'll inherit from this.
@@ -249,7 +250,7 @@ class FPM::Package
   end # def output
 
   def staging_path(path=nil)
-    @staging_path ||= ::Dir.mktmpdir("package-#{type}-staging") #, ::Dir.pwd)
+    @staging_path ||= Stud::Temporary.directory("package-#{type}-staging")
 
     if path.nil?
       return @staging_path
@@ -259,7 +260,7 @@ class FPM::Package
   end # def staging_path
 
   def build_path(path=nil)
-    @build_path ||= ::Dir.mktmpdir("package-#{type}-build") #, ::Dir.pwd)
+    @build_path ||= Stud::Temporary.directory("package-#{type}-build")
 
     if path.nil?
       return @build_path

--- a/spec/fpm/package_spec.rb
+++ b/spec/fpm/package_spec.rb
@@ -193,4 +193,27 @@ describe FPM::Package do
       expect(subject.attributes[:template_scripts?]).to(be_falsey)
     end
   end
+
+  describe "#staging_path and #staging_path" do
+    before() do
+      @oldtmp = ENV["TMP"]
+      ENV["TMP"] = '/var/tmp'
+    end
+
+    after() do
+      ENV["TMP"] = @oldtmp
+    end
+
+    it "should be a subdirectory of workdir (#1124)" do
+      expect(subject.build_path("hello1")).to(start_with("/var/tmp"))
+      expect(subject.build_path("hello1")).to(end_with("hello1"))
+      expect(subject.build_path("hello1")).to(include("build"))
+    end
+
+    it "should be a subdirectory of workdir (#1124)" do
+      expect(subject.staging_path("hello2")).to(start_with("/var/tmp"))
+      expect(subject.staging_path("hello2")).to(end_with("hello2"))
+      expect(subject.staging_path("hello2")).to(include("staging"))
+    end
+  end
 end # describe FPM::Package


### PR DESCRIPTION
This PR uses `Stud::Temporary.directory` instead of `::Dir.mktmpdir` to generate temporary directories for the "build"- and "staging"-dirs. This means that both directories now respect the `--workdir`-argument. Further details on this issue can be found in #1124.

In case there are any questions, please feel free to ask them. If you want anything changed about this PR, please just let me know and I'll get it done. Thank you.