### PR TITLE
Erase release candidate spec from deps when converting from Gem to RPM

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -302,6 +302,11 @@ class FPM::Package::RPM < FPM::Package
       end.flatten
     end
 
+    # Erase troublesome release candidate declarations.
+    self.dependencies = self.dependencies.collect do |dep|
+      dep.gsub(/.rc\d*/, '')
+    end
+
   setscript = proc do |scriptname|
       script_path = self.attributes[scriptname]
       # Skip scripts not set

--- a/spec/fpm/package_convert_spec.rb
+++ b/spec/fpm/package_convert_spec.rb
@@ -11,6 +11,7 @@ describe "FPM::Package#convert" do
     prefix = source.attributes[:gem_package_name_prefix ] = 'rubygem19'
     name = source.name = "whatever"
     version = source.version = "1.0"
+    source.dependencies = ["something > 10", "another >= 1.2.3.rc4"]
     source.provides << "#{prefix}-#{name} = #{version}"
     source.convert(FPM::Package::RPM)
   end
@@ -25,5 +26,10 @@ describe "FPM::Package#convert" do
 
   it "should list provides matching the gem_package_name_prefix (#585)" do
     insist { subject.provides }.include?("rubygem19(whatever) = 1.0")
+  end
+
+  it "should erase release candidate declariations from dependencies" do
+    insist { subject.dependencies[0] } == "something > 10"
+    insist { subject.dependencies[1] } == "another >= 1.2.3"
   end
 end


### PR DESCRIPTION
This is the second coming of https://github.com/jordansissel/fpm/pull/1105, which I closed after horking the rebase.

---

A while ago I encountered an issue when building RPMs for Nokogiri and its dependencies. The issue is that Nokogiri lists a release candidate version of mini_portile2 as a dependency.

When I build this RC version of mini_portile2 the resulting RPM's version will not include the RC suffix (2.0.0 instead of 2.0.0.rc2). When I build Nokogirl, the RPM dependencies will include mini_portile2 v2.0.0.rc2. Thus, Nokogiri will fail to install (via yum) since the mini_portile2 dependency cannot be satisfied.

I made small tweak to FPM to erase release candidate suffixes from RPM dependencies in order to prevent this situation.
