### PR TITLE
prevents json dependency from creeping to version 2.0

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   # For parsing JSON (required for some Python support, etc)
   # http://flori.github.com/json/doc/index.html
-  spec.add_dependency("json", ">= 1.7.7") # license: Ruby License
+  spec.add_dependency("json", ">= 1.7.7", "< 2.0") # license: Ruby License
 
   # For logging
   # https://github.com/jordansissel/ruby-cabin


### PR DESCRIPTION
json 2.0.1 was published today and requires ruby's version
to be greater than 2.0.