### PR TITLE
Fix pacman packages having symlinks.

### DIFF
--- a/lib/fpm/package/pacman.rb
+++ b/lib/fpm/package/pacman.rb
@@ -245,7 +245,7 @@ class FPM::Package::Pacman < FPM::Package
     Find.find(staging_path) do |path|
       src = path.gsub(/^#{staging_path}/, '')
       dst = build_path(src)
-      copy_entry(path, dst, preserve=true, remove_destination=true)
+      copy_entry(path, dst, remove_destination=true)
       copy_metadata(path, dst)
     end
 


### PR DESCRIPTION
Hi,

I am having issues with pacman packages involving symlinks. Symlinks are not keep in the final package, instead, they are copied. Trivial reproducer:

> root@c12e18c630ff:/tmp# mkdir package.src
> root@c12e18c630ff:/tmp# echo "some file" > package.src/some-file
> root@c12e18c630ff:/tmp# ln -s some-file package.src/some-file.symlink
> root@c12e18c630ff:/tmp# ls -l package.src/
> total 4
> -rw-r--r-- 1 root root 10 Jul  7 16:47 some-file
> lrwxrwxrwx 1 root root  9 Jul  7 16:47 some-file.symlink -> some-file
> root@c12e18c630ff:/tmp# fpm -s dir -t pacman -n package-name package.src
> Created package {:path=>"package-name-1.0-1-x86_64.pkg.tar.xz"}
> root@c12e18c630ff:/tmp# tar -tvf package-name-1.0-1-x86_64.pkg.tar.xz
> -rw-r--r-- 0/0             316 2016-07-07 16:48 .MTREE
> -rw-r--r-- 0/0             645 2016-07-07 16:48 .PKGINFO
> drwxr-xr-x 0/0               0 2016-07-07 16:48 package.src/
> -rw-r--r-- 0/0              10 2016-07-07 16:47 package.src/some-file.symlink
> -rw-r--r-- 0/0              10 2016-07-07 16:47 package.src/some-file

This can be fixed by removing the `preserve=true` argument when copying entries.

Cheers,
Romain