### PR TITLE
Install rpm-build dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ you'll need that to install fpm.
 # deb based distributions:
     apt-get install ruby-dev gcc make
 # rpm ones:
-    yum install ruby-devel gcc make
+    yum install ruby-devel gcc make rpm-build
 ```
 
 Additional packages will be required depending on the source and target package


### PR DESCRIPTION
If you try to create a rpm from a tar file you get: 

"Need executable 'rpmbuild' to convert tar to rpm {:level=>:error}"

Just pull the dependencies

