### PR TITLE
Fix #1179 Remove .packlist files and empty parent directories from CPAN packages

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -3,6 +3,7 @@ require "fpm/package"
 require "fpm/util"
 require "fileutils"
 require "find"
+require "pathname"
 
 class FPM::Package::CPAN < FPM::Package
   # Flags '--foo' will be accessable  as attributes[:npm_foo]
@@ -256,6 +257,21 @@ class FPM::Package::CPAN < FPM::Package
         logger.debug("Removing useless file.",
                       :path => path.gsub(staging_path, ""))
         File.unlink(path)
+      end
+      
+      # Remove useless .packlist files and their empty parent folders
+      # https://github.com/jordansissel/fpm/issues/1179
+      ::Dir.glob(File.join(staging_path, glob_prefix, "**/.packlist")).each do |path|
+        logger.debug("Removing useless file.",
+                      :path => path.gsub(staging_path, ""))
+        File.unlink(path)
+        Pathname.new(path).parent.ascend do |parent|
+          if ::Dir.entries(parent).sort == ['.', '..'].sort
+            FileUtils.rmdir parent
+          else
+            break
+          end
+        end
       end
     end
 


### PR DESCRIPTION
@liger1978

`.packlist` files are useless junk containing irrelevant build information. In `noarch` packages they end up being the only file in the `lib64` directory when converting to e.g. RPMs (breaking the standard for `noarch` packages). This patch removes them from the package and also removes all empty parent directories of the unlinked `.packlist` file resulting in no more pollution of the `lib64` directory on the target system.

This is the second iteration of this patch after further testing.  This version breaks out of the `do` loop when a non-empty directory is found (more efficient) and sorts the directory contents before comparison to find empty dirs (annoyingly some platforms list contents as `[".", ".."]` and others as `["..", '.']`).