### PR TITLE
Add long flag options for chdir, input, and output

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -45,13 +45,13 @@ class FPM::Command < Clamp::Command
     return lines.join("\n")
   end # def help
 
-  option "-t", "OUTPUT_TYPE",
+  option ["-t", "--output-type"], "OUTPUT_TYPE",
     "the type of package you want to create (deb, rpm, solaris, etc)",
     :attribute_name => :output_type
-  option "-s", "INPUT_TYPE",
+  option ["-s", "--input-type"], "INPUT_TYPE",
     "the package type to use as input (gem, rpm, python, etc)",
     :attribute_name => :input_type
-  option "-C", "CHDIR",
+  option ["-C", "--chdir"], "CHDIR",
     "Change directory to here before searching for files",
     :attribute_name => :chdir
   option "--prefix", "PREFIX",

--- a/spec/fpm/command_spec.rb
+++ b/spec/fpm/command_spec.rb
@@ -6,7 +6,7 @@ require "fixtures/mockpackage"
 
 describe FPM::Command do
   describe "--prefix"
-  describe "-C"
+  describe "-C / --chdir"
   describe "-p / --package"
   describe "-f"
   describe "-n"


### PR DESCRIPTION
The flags for chdir, input, and output aren't immediately intuitive as to what they're short for. This commit adds long versions and a spec stub for chdir. Resolves #1187.