### PR TITLE
Fix conffiles naming for upstart scripts for deb packages

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -152,7 +152,9 @@ class FPM::Package::Deb < FPM::Package
     next File.expand_path(file)
   end
 
-  option "--upstart", "FILEPATH", "Add FILEPATH as an upstart script",
+  option "--upstart", "FILEPATH", "Add FILEPATH as an upstart script. It is " \
+    "expected to be named <service>.upstart and will placed in " \
+    "/etc/init/<service>.conf",
     :multivalued => true do |file|
     next File.expand_path(file)
   end
@@ -812,7 +814,7 @@ class FPM::Package::Deb < FPM::Package
       end
       upstarts.each do |upstart|
         name = File.basename(upstart, ".upstart")
-        upstartscript = "etc/init/#{name}.conf"
+        upstartscript = "/etc/init/#{name}.conf"
         logger.debug("Add conf file declaration for upstart script", :script => upstartscript)
         allconfigs << upstartscript[1..-1]
       end


### PR DESCRIPTION
Firstly, I had to look in the code to find out that the upstart scripts should be named ```something.upstart```. I named them ```something.conf``` and ended up with ```/etc/init/something.conf.conf```. I've added some documentation for this.

Next the command:

```
--deb-upstart something.upstart
```

Resulted in the conffiles:

```
/etc/init/something.conf
/tc/init/something.conf
```

Which is because ```upstartscript``` was missing the leading ```/```
