### PR TITLE
Fixes #1236 Fixed version number for metacpan search

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -309,17 +309,16 @@ class FPM::Package::CPAN < FPM::Package
                  :distribution => distribution,
                  :version => cpan_version)
 
-    # default to latest versionunless we specify one
+    # default to latest version unless we specify one
     if cpan_version.nil?
-      self.version = metadata["version"]
+      self.version = "#{metadata["version"]}"
     else
-      if metadata["version"] =~ /^v\d/
-        self.version = "v#{cpan_version}"
-      else
-        self.version = cpan_version
-      end
+      self.version = "#{cpan_version}"
     end
-
+    
+    # remove 'v' prefix from version if it is there
+    self.version.sub!(/^v/, '')
+    
     # Search metacpan to get download URL for this version of the module
     metacpan_search_url = "http://api.metacpan.org/v0/release/_search"
     metacpan_search_query = '{"query":{"match_all":{}},"filter":{"term":{"release.name":"' + "#{distribution}-#{self.version}" + '"}}}'


### PR DESCRIPTION
The new way of searching metacpan with an http `POST` consistently requires numerical version number (i.e. no `v` prefix).  This patch tested against 73 CPAN modules: https://gitlab.com/harbottle/epmel/builds/6722395