### PR TITLE
Call xmknod only if the method exists.

### DIFF
--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -249,8 +249,7 @@ module FPM::Util
   # wrapper around mknod ffi calls
   def mknod_w(path, mode, dev)
     rc = -1
-    case %x{uname -s}.chomp
-    when 'Linux'
+    if respond_to?(:xmknod)
       # bits/stat.h #define _MKNOD_VER_LINUX  0
       rc = xmknod(0, path, mode, FFI::MemoryPointer.new(dev))
     else


### PR DESCRIPTION
The xmknod method will exist if, during setup, FFI cannot find the
`mknod` libc function.

Should fix #1244