### PR TITLE
Some docs for virtualenv support

### DIFF
--- a/docs/source/virtualenv.rst
+++ b/docs/source/virtualenv.rst
@@ -1,0 +1,40 @@
+`virtualenv` - Python virtual environments
+==========================================
+
+Synopsis::
+
+  fpm -s virtualenv [other options] EGG_SPEC|requirements.txt
+
+FPM has support for building packages that provide a python virtualenv from a
+single egg or from a `requirements.txt` file.  This lets you bundle up a set of
+python dependencies separate from system python that you can then distribute.
+
+.. note::
+   `virtualenv` support requires that you have `virtualenv` and  the
+   `virtualenv-tools` binary on your path.  This can usually be achieved with
+   `pip install virtualenv virtualenv-tools`.
+
+Example uses:
+=============
+
+Build an rpm package for ansible::
+
+  fpm -s virtualenv -t deb ansible
+  yum install virtualenv-ansible*.rpm
+  which ansible # /usr/share/python/ansible/bin/ansible
+
+Create a debian package for your project's python dependencies under `/opt`::
+
+  echo 'glade' >> requirements.txt
+  echo 'paramiko' >> requirements.txt
+  echo 'SQLAlchemy' >> requirements.txt
+  fpm -s virtualenv -t deb --name myapp-python-libs \
+    --virtualenv-install-location /opt/myapp \
+    requirements.txt
+
+Create a debian package from a version 0.9 of an egg kept in your internal
+pypi repository, along with it's external dependencies::
+
+  fpm -s virtualenv -t deb \
+    --virtualenv-pypi-extra-url=https://office-pypi.lan/ \
+    proprietary-magic=0.9


### PR DESCRIPTION
Another one.

PS I'm not particularly happy with the inconsistencies in the virtualenv support, it looks like someone else's conventions have been baked in to the way the options are structured, instead of just using prefix </whinge>.  I've thought about changing it, but this will probably make lots of people sad.  Thoughts?