### PR TITLE
Revert "symlinks need full dest path for FileUtils.copy_entry"

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -154,7 +154,7 @@ class FPM::Package::Dir < FPM::Package
         copy(source, destination)
       end
     elsif fileinfo.symlink?
-      copy(source, File.join(destination, source))
+      copy(source, destination)
     else
       # Copy all files from 'path' into staging_path
       Find.find(source) do |path|


### PR DESCRIPTION
This reverts commit 0de9c3aa0c152ace64df7982f2d09b20730635e4.

The reason for reverting is that this disallows the same usage
pattern as expected from rsync:

my-sym-link.so=/usr/lib/my-sym-link.so

The patch that this reverts will create directory, and put the
symlink inside `/usr/lib/my-sym-link.so/my-sym-link.so
which is very surprising and it doesn't follow the same
pattern as file copying is doing.

Fixes #1135