### PR TITLE
In case of a=b syntax where a is symlink, don't create directory

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -147,14 +147,19 @@ class FPM::Package::Dir < FPM::Package
 
     # For single file copies, permit file destinations
     fileinfo = File.lstat(source)
-    if fileinfo.file? && !File.directory?(destination)
+    destination_is_directory = File.directory?(destination)
+    if fileinfo.file? && !destination_is_directory
       if destination[-1,1] == "/"
         copy(source, File.join(destination, source))
       else
         copy(source, destination)
       end
     elsif fileinfo.symlink?
-      copy(source, File.join(destination, source))
+      if destination_is_directory
+        copy(source, File.join(destination, source))
+      else
+        copy(source, destination)
+      end
     else
       # Copy all files from 'path' into staging_path
       Find.find(source) do |path|

--- a/spec/fpm/package/dir_spec.rb
+++ b/spec/fpm/package/dir_spec.rb
@@ -141,4 +141,30 @@ describe FPM::Package::Dir do
       subject.input(path)
     end
   end
+
+  context "symlink=dest_symlink." do
+    it "Should not put the symlink into directory" do
+      filepath = File.join(tmpdir, "target")
+      File.write(filepath, "hello!");
+      symlinkpath = File.join(tmpdir, "properlink.so")
+      File.symlink(filepath, symlinkpath);
+
+      subject.input(symlinkpath + "=" + "/a/b/properlink.so")
+      subject.output(output)
+      insist { File.read(File.join(output, "/a/b/properlink.so")) } == "hello!"
+    end
+  end
+
+  context "symlink=dest_dir/" do
+    it "Should put the symlink into directory with link syntax" do
+      filepath = File.join(tmpdir, "target")
+      File.write(filepath, "hello!");
+      symlinkpath = File.join(tmpdir, "link.so")
+      File.symlink(filepath, symlinkpath);
+
+      subject.input(symlinkpath)
+      subject.output(output)
+      insist { File.read(File.join(output, symlinkpath)) } == "hello!"
+    end
+  end
 end # describe FPM::Package::Dir


### PR DESCRIPTION
Previously, if the symlink is included into the package and specified
with

my-sym-link.so=/usr/lib/my-sym-link.so

fpm would create directory, and put the
symlink inside `/usr/lib/my-sym-link.so/my-sym-link.so
which is very surprising and it doesn't follow the same
pattern as file copying is doing.