### PR TITLE
python: add option --python-other-files (resolves #1046)

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -73,6 +73,10 @@ class FPM::Package::Python < FPM::Package
     "The python package name to remove from dependency list",
     :multivalued => true, :attribute_name => :python_disable_dependency,
     :default => []
+  option "--other-files-dir", "DIRECTORY", "Optionally, the contents of the " \
+    "specified directory may be added to the package. This is useful if the " \
+    "package needs configuration files, etc.",
+    :default => nil
 
   private
 
@@ -99,6 +103,16 @@ class FPM::Package::Python < FPM::Package
 
     load_package_info(setup_py)
     install_to_staging(setup_py)
+
+    if !attributes[:python_other_files_dir].nil?
+      # Copy all files from other dir to build_path
+      Find.find(attributes[:python_other_files_dir]) do |path|
+        src = path.gsub(/^#{attributes[:python_other_files_dir]}/, '')
+        dst = File.join(staging_path, src)
+        copy_entry(path, dst, preserve=true, remove_destination=true)
+        copy_metadata(path, dst)
+      end
+    end
   end # def input
 
   # Download the given package if necessary. If version is given, that version

--- a/spec/fpm/package/python_spec.rb
+++ b/spec/fpm/package/python_spec.rb
@@ -192,4 +192,24 @@ describe FPM::Package::Python, :if => python_usable? do
       insist { topline.chomp } == "#!fancypants"
     end
   end
+
+  context "with other files dir" do
+    before :each do
+      subject.attributes[:python_other_files_dir] = File.expand_path("../../fixtures/deb/staging/", File.dirname(__FILE__))
+      subject.input("django")
+    end
+
+    it "includes the other files in the package" do
+      other_file_path =  File.join(subject.staging_path, '/etc/init.d/test')
+      expect(File.exists?(other_file_path)).to(be_truthy)
+    end
+
+    # not sure if this is correct behaviour, but it's what it is doing
+    it "ignores the prefix" do
+      subject.attributes[:prefix] = '/usr'
+
+      other_file_path = File.join(subject.staging_path, '/etc/init.d/test')
+      expect(File.exists?(other_file_path)).to(be_truthy)
+    end
+  end
 end # describe FPM::Package::Python


### PR DESCRIPTION
The implementation and tests are ported from virtualenv support.

I’ve done it in rush, so I hope I haven’t overlooked something…