### PR TITLE
Parse depends for deb output even without spaces around operator

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -589,14 +589,15 @@ class FPM::Package::Deb < FPM::Package
 
   def fix_dependency(dep)
     # Deb dependencies are: NAME (OP VERSION), like "zsh (> 3.0)"
-    # Convert anything that looks like 'NAME OP VERSION' to this format.
+    # Convert anything that looks like 'NAME OP VERSION' (even without spaces
+    # around OP) to this format.
     if dep =~ /[\(,\|]/
       # Don't "fix" ones that could appear well formed already.
     else
       # Convert ones that appear to be 'name op version'
-      name, op, version = dep.split(/ +/)
-      if !version.nil?
-        # Convert strings 'foo >= bar' to 'foo (>= bar)'
+      _, name, op, version = dep.match(/([^<>= ]+) *([<>=]*) *(.*)/).to_a
+      if !version.empty?
+        # Convert strings 'foo >= bar' or 'foo>=bar' to 'foo (>= bar)'
         dep = "#{name} (#{debianize_op(op)} #{version})"
       end
     end

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -137,7 +137,7 @@ describe FPM::Package::Deb do
       original.epoch = "5"
       original.architecture = "all"
       original.dependencies << "something > 10"
-      original.dependencies << "hello >= 20"
+      original.dependencies << "hello>=20"
       original.provides << "#{original.name} = #{original.version}"
 
       # Test to cover PR#591 (fix provides names)
@@ -219,7 +219,7 @@ describe FPM::Package::Deb do
       end
 
       it "should have the correct dependencies" do
-        original.dependencies.each do |dep|
+        ["something > 10", "hello >= 20"].each do |dep|
           insist { input.dependencies }.include?(dep)
         end
       end
@@ -253,7 +253,8 @@ describe FPM::Package::Deb do
       end
 
       it "should have the correct dependency list" do
-        # 'something > 10' should convert to 'something (>> 10)', etc.
+        # 'something > 10' should convert to 'something (>> 10)',
+        # 'hello>=20' should convert to 'hello (>= 20)'
         insist { dpkg_field("Depends") } == "something (>> 10), hello (>= 20)"
       end
 
@@ -290,7 +291,7 @@ describe FPM::Package::Deb do
       original.epoch = "5"
       original.architecture = "all"
       original.dependencies << "something > 10"
-      original.dependencies << "hello >= 20"
+      original.dependencies << "hello>=20"
       original.attributes[:no_depends?] = true
       original.output(target)
       input.input(target)


### PR DESCRIPTION
It's very hard to work with arguments containing spaces in POSIX shell, e.g. when you generate some options for fpm dynamically.

This patch allows to specify dependency with version also as `--depends foo>=10`. This is correctly converted to `foo (>= 10)`.