### PR TITLE
Use json-2.x with ruby-2.x

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -22,7 +22,11 @@ Gem::Specification.new do |spec|
 
   # For parsing JSON (required for some Python support, etc)
   # http://flori.github.com/json/doc/index.html
-  spec.add_dependency("json", ">= 1.7.7", "< 2.0") # license: Ruby License
+  if Gem::Requirement.new("~> 2.0".freeze).satisfied_by?(Gem.ruby_version)
+    spec.add_dependency("json", "~> 2.0") # license: Ruby License
+  else
+    spec.add_dependency("json", ">= 1.7.7", "< 2.0") # license: Ruby License
+  end
 
   # For logging
   # https://github.com/jordansissel/ruby-cabin


### PR DESCRIPTION
Ruby 2.4.0 no longer works with json 1.8.3

Potential fix for #1264.

I've tested with Ruby 2.4.0. I don't have any machines with ruby 1.x to test on.