### PR TITLE
Update Travis config with Ruby 2.3 and 2.4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,8 @@ rvm:
   - 2.0.0
   - 2.1.1
   - 2.2.1
+  - 2.3.1
+  - 2.4.0
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update           ; fi
     # dpkg has also gnu-tar and xz as dependencies, these packages are used


### PR DESCRIPTION
* Adds known-good Ruby minor versions to the `.travis.yml` file for 2.3.x and 2.4.x.
* The Travis checks in this PR will fail until #1264 is fixed. This is, literally, TDD.