### PR TITLE
Update installing.rst

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -29,7 +29,7 @@ On Fedora 23 or newer::
 
 On Debian-derived systems (Debian, Ubuntu, etc)::
 
-    apt-get install ruby ruby-dev rubygems gcc make
+    apt-get install ruby ruby-dev rubygems build-essentials
 
 Installing FPM
 --------------


### PR DESCRIPTION
Apart from gcc and make you need other dependencies.
Without build-essentials I had an error complaining about "stdio.h not found"