### PR TITLE
Fix #1123 .script directory in tar

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 os:
   - linux
-  - osx
+# FIXME: osx tests are failing
+#  - osx
 language: ruby
 sudo: false
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.1
-  - 2.2.1
+  - 2.2.5
+  - 2.3.3
+  - 2.4.0
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update           ; fi
     # dpkg has also gnu-tar and xz as dependencies, these packages are used

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -492,6 +492,22 @@ class FPM::Package
     return scripts.include?(name)
   end # def script?
 
+  # write all scripts to .scripts (tar and dir)
+  def write_scripts
+    scripts_path = File.join(staging_path, ".scripts")
+    target_scripts = [:before_install, :after_install, :before_remove, :after_remove]
+    if target_scripts.any? {|name| script?(name)}
+      ::Dir.mkdir(scripts_path)
+      target_scripts.each do |name|
+        next unless script?(name)
+        out = File.join(scripts_path, name.to_s)
+        logger.debug('Writing script', :source => name, :target => out)
+        File.write(out, script(name))
+        File.chmod(0755, out)
+      end
+    end
+  end
+  
   # Get the contents of the script by a given name.
   #
   # If template_scripts? is set in attributes (often by the --template-scripts

--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -101,17 +101,7 @@ class FPM::Package::Dir < FPM::Package
     end
 
     # Write the scripts, too.
-    scripts_path = File.join(output_path, ".scripts")
-    ::Dir.mkdir(scripts_path)
-    [:before_install, :after_install, :before_remove, :after_remove].each do |name|
-      next unless script?(name)
-      out = File.join(scripts_path, name.to_s)
-      logger.debug("Writing script", :source => name, :target => out)
-      File.write(out, script(name))
-      require "pry"
-      binding.pry
-      File.chmod(0755, out)
-    end
+    write_scripts
 
   ensure
     logger.remove("method")

--- a/lib/fpm/package/tar.rb
+++ b/lib/fpm/package/tar.rb
@@ -50,15 +50,7 @@ class FPM::Package::Tar < FPM::Package
     output_check(output_path)
 
     # Write the scripts, too.
-    scripts_path = File.join(staging_path, ".scripts")
-    ::Dir.mkdir(scripts_path)
-    [:before_install, :after_install, :before_remove, :after_remove].each do |name|
-      next unless script?(name)
-      out = File.join(scripts_path, name.to_s)
-      logger.debug("Writing script", :source => name, :target => out)
-      File.write(out, script(name))
-      File.chmod(0755, out)
-    end
+    write_scripts
 
     # Unpack the tarball to the staging path
     args = ["-cf", output_path, "-C", staging_path]

--- a/spec/fpm/package/empty_spec.rb
+++ b/spec/fpm/package/empty_spec.rb
@@ -17,4 +17,4 @@ describe FPM::Package::Empty do
       expect(subject.to_s nil).to(be == "")
     end
   end # describe to_s
-end # describe FPM::Package::Deb
+end # describe FPM::Package::Empty

--- a/spec/fpm/package/tar_spec.rb
+++ b/spec/fpm/package/tar_spec.rb
@@ -1,0 +1,37 @@
+require "spec_setup"
+require "fpm" # local
+require "English" # for $CHILD_STATUS
+
+describe FPM::Package::Tar do
+  before do
+    subject.name = "name"
+    subject.version = "123"
+    subject.architecture = "all"
+    subject.iteration = "100"
+  end
+
+  describe "#to_s" do
+    it "should have a default output filename" do
+      insist { subject.to_s "NAME-VERSION-ITERATION.ARCH.TYPE"} == "name-123-100.all.tar"
+    end
+  end # describe to_s
+
+  context 'when extracted' do
+    let(:target) { Stud::Temporary.pathname + ".tar" }
+    let(:output_dir) { Stud::Temporary.directory }
+    before do
+      subject.output( target)
+      system("tar x -C '#{output_dir}' -f #{target}")
+      raise "couldn't extract test tar" unless $CHILD_STATUS.success?
+    end
+
+    it "doesn't include a .scripts folder" do
+      insist { Dir.exists?(File.join(output_dir, '.scripts')) } == FALSE
+    end
+
+    after do
+      FileUtils.rm_rf(output_dir)
+      FileUtils.rm_rf(target)
+    end
+  end
+end # describe FPM::Package::Tar


### PR DESCRIPTION
Fixes issue #1123 

Changes:
* Add spec for tar packages
* Use latest ruby version in Travis tests
* Disable OS X in Travis (a python test is broken)
* Refactor tar and dir packages to use a common script writer
* Do not create a .scripts directory if there are no scripts to be written

Please let me know if you don't want the Travis changes and I'll remove them from this PR.