### PR TITLE
Add rubygems to CentOS install line

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -21,7 +21,7 @@ On OSX/macOS::
 
 On Red Hat systems (Fedora 22 or older, CentOS, etc)::
 
-    yum install ruby-devel gcc make rpm-build
+    yum install ruby-devel gcc make rpm-build rubygems
 
 On Fedora 23 or newer::
 


### PR DESCRIPTION
For CentOS7, I needed to install rubygems.
Not sure if it is included in e.g. ruby-devel for previous versions?