### PR TITLE
Fix zipfile target.

### DIFF
--- a/lib/fpm/package/zip.rb
+++ b/lib/fpm/package/zip.rb
@@ -36,28 +36,13 @@ class FPM::Package::Zip < FPM::Package
     dir.cleanup_build
   end # def input
 
-  # Output a tarball.
-  #
-  # If the output path ends predictably (like in .tar.gz) it will try to obey
-  # the compression type.
+  # Output a zipfile.
   def output(output_path)
     output_check(output_path)
-
-    files = Find.find(staging_path).to_a
-    safesystem("zip", output_path, *files)
-  end # def output
-
-  # Generate the proper tar flags based on the path name.
-  def tar_compression_flag(path)
-    case path
-      when /\.tar\.bz2$/
-        return "-j"
-      when /\.tar\.gz$|\.tgz$/
-        return "-z"
-      when /\.tar\.xz$/
-        return "-J"
-      else
-        return nil
+    realpath = Pathname.new(output_path).realdirpath.to_s
+    ::Dir.chdir(staging_path) do
+      files = Find.find('.').to_a
+      safesystem("zip", realpath, *files)
     end
-  end # def tar_compression_flag
+  end # def output
 end # class FPM::Package::Tar


### PR DESCRIPTION
See [Issue 1313](https://github.com/jordansissel/fpm/issues/1313):

When using fpm with source `dir` and target `zip`, a random tempdir is prepended to packaged file paths.

To demonstrate:

    mkdir foo
    echo test > foo/bar
    fpm -s dir -t zip -n foo -p foo.zip foo
    unzip -v foo.zip

Expected output:

    Archive:  foo.zip
     Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
    --------  ------  ------- ---- ---------- ----- --------  ----
           0  Stored        0   0% 2017-03-31 18:42 00000000  foo/
           5  Stored        5   0% 2017-03-31 18:42 3bb935c6  foo/bar
    --------          -------  ---                            -------
           5                5   0%                            2 files

Actual output:

    Archive:  foo.zip
     Length   Method    Size  Cmpr    Date    Time   CRC-32   Name
    --------  ------  ------- ---- ---------- ----- --------  ----
           0  Stored        0   0% 2017-03-31 18:45 00000000  tmp/package-dir-staging-
    43e99d3c99bf3e340d26126f2a1002b341d844c5454e7a2442cbcf15cd0d/
           0  Stored        0   0% 2017-03-31 18:45 00000000  tmp/package-dir-staging-
    43e99d3c99bf3e340d26126f2a1002b341d844c5454e7a2442cbcf15cd0d/foo/
           5  Stored        5   0% 2017-03-31 18:42 3bb935c6  tmp/package-dir-staging-
    43e99d3c99bf3e340d26126f2a1002b341d844c5454e7a2442cbcf15cd0d/foo/bar
    --------          -------  ---                            -------
           5                5   0%                            3 files