### PR TITLE
Fix OSX Python tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,10 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which python || brew install python; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which easy_install || echo 'easy_install not found'; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which rpm || brew install rpm ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then which virtualenv || pip install --user virtualenv ; fi
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then which virtualenv-tools || pip install --user virtualenv virtualenv-tools ; fi
-script: PATH=${PATH}:${HOME}/.local/bin bundle exec rspec
+  - virtualenv ${HOME}/.venv
+script: source ${HOME}/.venv/bin/activate && PATH=${PATH}:${HOME}/.local/bin bundle exec rspec
 addons:
   apt:
     packages:


### PR DESCRIPTION
The test was failing because the calculated staging path is incorrect
with brew. If done in a virtualenv it is correct.