### PR TITLE
Use latest setuptools rather than distribute

### DIFF
--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -102,11 +102,11 @@ class FPM::Package::Virtualenv < FPM::Package
     pip_exe = File.join(virtualenv_build_folder, "bin", "pip")
     python_exe = File.join(virtualenv_build_folder, "bin", "python")
 
-    # Why is this hack here? It looks important, so I'll keep it in.
     safesystem(python_exe, pip_exe, "install", "-U", "-i",
                attributes[:virtualenv_pypi],
-               "pip", "distribute")
-    safesystem(python_exe, pip_exe, "uninstall", "-y", "distribute")
+               "pip", "setuptools")
+    # Uninstall pip
+    safesystem(python_exe, pip_exe, "uninstall", "-y", "setuptools")
 
     extra_index_url_args = []
     if attributes[:virtualenv_pypi_extra_index_urls]

--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -34,7 +34,7 @@ class FPM::Package::Virtualenv < FPM::Package
     :default => nil
 
   option "--setup-install", :flag, "After building virtualenv run setup.py install "\
-  "useful when building a virtualenv for packages and including their requirements from "
+  "useful when building a virtualenv for packages and including their requirements from "\
   "requirements.txt"
 
   option "--system-site-packages", :flag, "Give the virtual environment access to the "\


### PR DESCRIPTION
Hi,

I hit a bug when using `virtualenv` source:

```
Building wheels for collected packages: distribute {:level=>:info}
  Running setup.py bdist_wheel for distribute: started {:level=>:info}                                                                                              
  Running setup.py bdist_wheel for distribute: finished with status 'error' {:level=>:info}                                                                                                                                
  Complete output from command /workspace/build-jessie/package-virtualenv-build-cd83cf2616a1a6db492dc3080f69eb077bc8119ee7b123de7968004955f7/usr/share/python/temboard/bin/python -u -c "import setuptools, tokenize;__file__='/workspace/build-jessie/pip-build-o5vB2p/distribute/setup.p
y';f=getattr(tokenize, 'open', open)(__file__);code=f.read().replace('\r\n', '\n');f.close();exec(compile(code, __file__, 'exec'))" bdist_wheel -d /workspace/build-jessie/tmp9ETJLOpip-wheel- --python-tag cp27: {:level=>:info}
  Traceback (most recent call last): {:level=>:info}
    File "<string>", line 1, in <module> {:level=>:info}
    File "/workspace/build-jessie/pip-build-o5vB2p/distribute/setup.py", line 58, in <module> {:level=>:info}
      setuptools.setup(**setup_params) {:level=>:info}
  Failed building wheel for distribute {:level=>:info}
    File "/usr/lib/python2.7/distutils/core.py", line 137, in setup {:level=>:info}
      ok = dist.parse_command_line() {:level=>:info}
    File "setuptools/dist.py", line 276, in parse_command_line {:level=>:info}
      result = _Distribution.parse_command_line(self) {:level=>:info}
    File "/usr/lib/python2.7/distutils/dist.py", line 467, in parse_command_line {:level=>:info}
      args = self._parse_command_opts(parser, args) {:level=>:info}
    File "setuptools/dist.py", line 602, in _parse_command_opts {:level=>:info}
      nargs = _Distribution._parse_command_opts(self, parser, args) {:level=>:info}
    File "/usr/lib/python2.7/distutils/dist.py", line 523, in _parse_command_opts {:level=>:info}
      cmd_class = self.get_command_class(command) {:level=>:info}
    File "setuptools/dist.py", line 406, in get_command_class {:level=>:info}
      ep.require(installer=self.fetch_build_egg) {:level=>:info}
    File "pkg_resources.py", line 2254, in require {:level=>:info}                       
      working_set.resolve(self.dist.requires(self.extras),env,installer))) {:level=>:info}
    File "pkg_resources.py", line 2471, in requires {:level=>:info}
      dm = self._dep_map {:level=>:info}    
    File "pkg_resources.py", line 2682, in _dep_map {:level=>:info}                                                                                                                         
      self.__dep_map = self._compute_dependencies() {:level=>:info}                                                                                                                     
    File "pkg_resources.py", line 2699, in _compute_dependencies {:level=>:info}                                                                                                     
      from _markerlib import compile as compile_marker {:level=>:info}                                                                                                    
  ImportError: No module named _markerlib {:level=>:info}                                                                                  
   {:level=>:info}                                          
  ---------------------------------------- {:level=>:info}       
  Running setup.py clean for distribute {:level=>:info}         
Failed to build distribute {:level=>:info}                        
```

`distribute` is quite old now. I suggest to simply continue with setuptools.