### PR TITLE
Be consistent in letting newer Perl module versions meet the requirement, if not otherwise specified

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -167,12 +167,14 @@ class FPM::Package::CPAN < FPM::Package
           else
             # The 'version' string can be something complex like:
             #   ">= 0, != 1.0, != 1.2"
+            # If it is not specified explicitly, require the given
+            # version or newer, as that is all CPAN itself enforces
             if version.is_a?(String)
               version.split(/\s*,\s*/).each do |v|
                 if v =~ /\s*[><=]/
                   self.dependencies << "#{name} #{v}"
                 else
-                  self.dependencies << "#{name} = #{v}"
+                  self.dependencies << "#{name} >= #{v}"
                 end
               end
             else


### PR DESCRIPTION
Note that this is the same comparison a few lines later (line 179).  Without this change, I would never get all the Perl modules aligned perfectly.  As far as I can determine, this is what CPAN is enforcing, anyway.