### PR TITLE
Use capabilities in Perl dependencies

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -98,6 +98,9 @@ class FPM::Package::CPAN < FPM::Package
                    :name => metadata["name"])
       self.name = fix_name(metadata["name"])
     end
+    metadata["module"].each do |m|
+      self.provides << cap_name(m["name"]) + " = " + self.version
+    end
 
     # author is not always set or it may be a string instead of an array
     self.vendor = case metadata["author"]
@@ -155,11 +158,7 @@ class FPM::Package::CPAN < FPM::Package
           end
           dep = search(dep_name)
 
-          if dep.include?("distribution")
-            name = fix_name(dep["distribution"])
-          else
-            name = fix_name(dep_name)
-          end
+          name = cap_name(dep_name)
 
           if version.to_s == "0"
             # Assume 'Foo = 0' means any version?
@@ -378,6 +377,10 @@ class FPM::Package::CPAN < FPM::Package
     metadata = JSON.parse(data)
     return metadata
   end # def metadata
+
+  def cap_name(name)
+    return "perl(" + name.gsub("-", "::") + ")"
+  end # def cap_name
 
   def fix_name(name)
     case name


### PR DESCRIPTION
This is a somewhat notable change to depend upon (and provide) Perl "capabilities" such as `perl(Capture::Tiny)`, instead of `perl-Capture-Tiny`.  Truthfully, I don't know how widespread this is, but it was absolutely _critical_ to get things running on my SLES system.  (Dealing with `Test2`, which presents itself as `Test-Simple`, which is also the name of a core module, was particulary problematic until I full switched over to dependencies)