### PR TITLE
Translate Perl version dependencies

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -150,6 +150,10 @@ class FPM::Package::CPAN < FPM::Package
        found_dependencies.each do |dep_name, version|
           # Special case for representing perl core as a version.
           if dep_name == "perl"
+            m = version.match(/^(\d)\.(\d{3})(\d{3})$/)
+            if m
+               version = m[1] + '.' + m[2].sub(/^0*/, '') + '.' + m[3].sub(/^0*/, '')
+            end
             self.dependencies << "#{dep_name} >= #{version}"
             next
           end


### PR DESCRIPTION
Some CPAN modules have things like `use 5.008001`, which shows up in their dependencies.  However, that's not the version format used by the perl RPMs, which would be `5.8.1` (or newer).  This detects such situations and re-formats the version string.