### PR TITLE
Fix copy_entry for symlinks

### DIFF
--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -298,8 +298,8 @@ module FPM::Util
       if known_entry
         FileUtils.ln(known_entry, dst)
       else
-        FileUtils.copy_entry(src, dst, preserve=preserve,
-                             remove_destination=remove_destination)
+        FileUtils.copy_entry(src, dst, preserve, false,
+                             remove_destination)
         copied_entries[[st.dev, st.ino]] = dst
       end
     end # else...

--- a/spec/fpm/util_spec.rb
+++ b/spec/fpm/util_spec.rb
@@ -12,6 +12,29 @@ describe FPM::Util do
   end
 
   context "#copy_entry" do
+    context "when given files that are symlinks" do
+      it "should keep those files as symlinks" do
+        Stud::Temporary.directory do |path|
+          a = File.join(path, "a")
+          b = File.join(path, "b")
+          File.write(a, "hello")
+          File.symlink(a, b)
+
+          Stud::Temporary.directory do |target|
+            ta = File.join(target, "a")
+            tb = File.join(target, "b")
+            subject.copy_entry(a, ta)
+            subject.copy_entry(b, tb, true, true)
+
+            # This seems to work to compare file stat calls.
+            # target 'a' and 'b' should have the same stat result because
+            # they are linked to the same file.
+            insist { File.lstat(ta).ftype } == "file"
+            insist { File.lstat(tb).ftype } == "link"
+          end
+        end
+      end
+    end
     context "when given files that are hardlinks" do
       it "should keep those files as hardlinks" do
         Stud::Temporary.directory do |path|


### PR DESCRIPTION
While creating pacman packages I noticed symbolic links become actual files in the package. Running with `--debug-workspace` I verified that the problem is with the code for pacman. Only the temporary directory for the pathtype "build_path" contained regular files instead of the expected symlinks.

The files are being copied by `FPM::Util:copy_entry` which in turn uses `FileUtils::copy_entry`. The problem is with that call. While the signature is:

    copy_entry(src, dest, preserve = false, dereference_root = false, remove_destination = false)

The function is called like this:

    FileUtils.copy_entry(src, dst, preserve=preserve,
                             remove_destination=remove_destination)

I'm not very familiar with Ruby but what I could get from various sites is that this call is not what it appears to be. `preserve=preserve` doesn't pass the variable `preserve` as the function parameter `preserve`. Instead this is a self-assignment which returns the assigned value. For preserve this works as it's in the correct location. For `remove_destination` it's problematic since the value of `remove_destination` is passed to the `dereference_root` parameter.

I've added a test case showing this and included a fix.