### PR TITLE
Fixed markdown errors

### DIFF
--- a/docs/use-cases/make-install.rst
+++ b/docs/use-cases/make-install.rst
@@ -49,6 +49,8 @@ Install the package, test it out::
 Package up the manpages (create nodejs-doc)
 -------------------------------------------
 
+Package up the manpages via::
+
     # Create a package of the node manpage
     % fpm -s dir -t deb -p nodejs-doc_VERSION_ARCH.deb -n nodejs-doc -v 0.6.0 -C /tmp/installdir usr/share/man
 
@@ -59,6 +61,8 @@ Look in the nodejs-doc package::
 
 Package up the headers (create nodejs-dev)
 ------------------------------------------
+
+Package up the headers via::
 
     % fpm -s dir -t deb -p nodejs-dev_VERSION_ARCH.deb -n nodejs-dev -v 0.6.0 -C /tmp/installdir usr/include  
     % dpkg -c nodejs-dev_0.6.0-1_amd64.deb | grep -F .h 


### PR DESCRIPTION
Fixed markdown config to add text trailed by double colons to have the subsequent blocks correctly formatted as code.