### PR TITLE
spec: stud is runtime dependency

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -56,10 +56,11 @@ Gem::Specification.new do |spec|
   # For sourcing from pleaserun 
   spec.add_dependency("pleaserun", "~> 0.0.24") # license: Apache 2
 
+  spec.add_dependency("stud")
+
   spec.add_development_dependency("rspec", "~> 3.0.0") # license: MIT (according to wikipedia)
   spec.add_development_dependency("insist", "~> 1.0.0") # license: Apache 2
   spec.add_development_dependency("pry")
-  spec.add_development_dependency("stud")
 
   spec.files = files
   spec.require_paths << "lib"


### PR DESCRIPTION
```
$ grep -r require.*stud .
./lib/fpm/package.rb:require "stud/temporary"
./spec/fpm/package/dir_spec.rb:require "stud/temporary"
./spec/fpm/package/deb_spec.rb:require "stud/temporary"
./spec/fpm/package/pacman_spec.rb:require "stud/temporary"
./spec/fpm/package/rpm_spec.rb:require "stud/temporary" # gem 'stud'
./spec/fpm/util_spec.rb:require "stud/temporary"
./spec/fpm/command_spec.rb:require "stud/temporary"
```

introduced to `lib/fpm/package.rb` in 4547540 via #1139 for #1124