### PR TITLE
remove archive-tar-minitar as a dependency

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -47,9 +47,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency("rake", "~> 10") # license: MIT
 
-  # For creating tar archives (many packages are just tar archives)
-  spec.add_dependency("archive-tar-minitar", "0.5.2") # license: GPL2+
-
   # For creating FreeBSD package archives (xz-compressed tars)
   spec.add_dependency("ruby-xz") # license: MIT
 


### PR DESCRIPTION
`archive-tar-minitar` is not used on `fpm` and version 0.5.2, pinned on current version of `fpm`, has [vulnerabilities](https://github.com/atoulme/minitar/issues/5).