### PR TITLE
If SOURCE_DATE_EPOCH is set, produce identical output every time

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -233,6 +233,17 @@ class FPM::Command < Clamp::Command
     "copying, downloading, etc. Roughly any scratch space fpm needs to build " \
     "your package.", :default => Dir.tmpdir
 
+  option "--source-date-epoch", "SOURCE_DATE_EPOCH",
+    "Integer unix timestamp to use for generated files. " \
+    "See https://reproducible-builds.org/specs/source-date-epoch",
+    :environment_variable => "SOURCE_DATE_EPOCH"
+
+  option "--build-path-prefix-map", "BUILD_PATH_PREFIX_MAP",
+    "If SOURCE_DATE_EPOCH is given without BUILD_PATH_PREFIX_MAP, " \
+    "use a fixed package build directory to avoid nondeterminism. " \
+    "See https://reproducible-builds.org/specs/build-path-prefix-map",
+    :environment_variable => "BUILD_PATH_PREFIX_MAP"
+
   parameter "[ARGS] ...",
     "Inputs to the source package type. For the 'dir' type, this is the files" \
     " and directories you want to include in the package. For others, like " \

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -367,6 +367,12 @@ class FPM::Package::Deb < FPM::Package
     output_check(output_path)
     # Abort if the target path already exists.
 
+    # Abort if we want reproducibility, but can't deliver it.
+    if not attributes[:source_date_epoch].nil?
+      logger.fatal("SOURCE_DATE_EPOCH specified, but deterministic ar not found") if not ar_cmd_deterministic?
+      logger.fatal("SOURCE_DATE_EPOCH specified, but deterministic tar not found") if not tar_cmd_deterministic?
+    end
+
     # create 'debian-binary' file, required to make a valid debian package
     File.write(build_path("debian-binary"), "2.0\n")
 

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -547,11 +547,20 @@ class FPM::Package::Deb < FPM::Package
     end
     safesystem(*args)
 
+    if attributes[:source_date_epoch].nil?
+      ar, ar_create_opts = ["ar", "-qc"]
+    else
+      # We need ar to use the D modifier (i.e. zero uids and timestamps).
+      # Really recent BSD and gnu binutils turn that on by default.
+      # Slightly older ones support it, but don't make it the default.
+      ar, ar_create_opts = ar_cmd
+    end
+
     # pack up the .deb, which is just an 'ar' archive with 3 files
     # the 'debian-binary' file has to be first
     File.expand_path(output_path).tap do |output_path|
       ::Dir.chdir(build_path) do
-        safesystem("ar", "-qc", output_path, "debian-binary", "control.tar.gz", datatar)
+        safesystem(ar, ar_create_opts, output_path, "debian-binary", "control.tar.gz", datatar)
       end
     end
   end # def output

--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -239,7 +239,7 @@ class FPM::Package::Gem < FPM::Package
       # different output on successive runs.
       Find.find(installdir) do |path|
         if path =~ /.*(gem_make.out|Makefile)$/
-          logger.info("Removing %s" % path)
+          logger.info("Removing build file %s to reduce nondeterminism" % path)
           File.unlink(path)
         end
       end

--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -2,6 +2,7 @@ require "fpm/namespace"
 require "fpm/package"
 require "rubygems"
 require "fileutils"
+require "find"
 require "fpm/util"
 require "yaml"
 
@@ -229,6 +230,18 @@ class FPM::Package::Gem < FPM::Package
     if attributes[:gem_version_bins?] and File.directory?(bin_path)
       (::Dir.entries(bin_path) - ['.','..']).each do |bin|
         FileUtils.mv("#{bin_path}/#{bin}", "#{bin_path}/#{bin}-#{self.version}")
+      end
+    end
+
+    if not attributes[:source_date_epoch].nil?
+      # Remove generated Makefile and gem_make.out files, if any; they
+      # are not needed, and may contain generated paths that cause
+      # different output on successive runs.
+      Find.find(installdir) do |path|
+        if path =~ /.*(gem_make.out|Makefile)$/
+          logger.info("Removing %s" % path)
+          File.unlink(path)
+        end
       end
     end
   end # def install_to_staging

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -277,7 +277,7 @@ module FPM::Util
     ["tar", "gtar", "gnutar"].each do |tar|
       opts=[]
       score=0
-      ["-sort=name", "--mtime=@0"].each do |opt|
+      ["--sort=name", "--mtime=@0"].each do |opt|
         system("#{tar} #{opt} -cf fpm-dummy.tar.tmp fpm-dummy.tmp > /dev/null 2>&1")
         if $?.exitstatus == 0
           puts("tar_cmd: #{tar} #{opt} succeeded")

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -290,11 +290,9 @@ module FPM::Util
       ["--sort=name", "--mtime=@0"].each do |opt|
         system("#{tar} #{opt} -cf fpm-dummy.tar.tmp fpm-dummy.tmp > /dev/null 2>&1")
         if $?.exitstatus == 0
-          puts("tar_cmd: #{tar} #{opt} succeeded")
           opts << opt
           score += 1
         end
-        puts("tar_cmd: #{tar} #{opt} failed")
       end
       if score > bestscore
         best=tar

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -278,12 +278,14 @@ module FPM::Util
       opts=[]
       score=0
       ["-sort=name", "--mtime=@0"].each do |opt|
-        system("#{tar} #{opt} -cf fpm-dummy.tar.tmp fpm-dummy.tmp 2>/dev/null")
+        system("#{tar} #{opt} -cf fpm-dummy.tar.tmp fpm-dummy.tmp > /dev/null 2>&1")
         if $?.exitstatus == 0
+          puts("tar_cmd: #{tar} #{opt} succeeded")
           opts << opt
           score += 1
           break
         end
+        puts("tar_cmd: #{tar} #{opt} failed")
       end
       if score > bestscore
         best=tar

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -190,9 +190,14 @@ module FPM::Util
     if args.size == 1
       args = [ default_shell, "-c", args[0] ]
     end
-    program = args[0]
 
-    exit_code = execmd(args)
+    if args[0].kind_of?(Hash)
+      env = args.shift()
+      exit_code = execmd(env, args)
+    else
+      exit_code = execmd(args)
+    end
+    program = args[0]
     success = (exit_code == 0)
 
     if !success

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -283,7 +283,6 @@ module FPM::Util
           puts("tar_cmd: #{tar} #{opt} succeeded")
           opts << opt
           score += 1
-          break
         end
         puts("tar_cmd: #{tar} #{opt} failed")
       end

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -358,7 +358,9 @@ describe FPM::Package::Deb do
 
     it "it should output bit-for-bit identical packages" do
       # Check prerequisites
-      system("#{tar_cmd} -cf /dev/null --mtime=@0 --sort=name /dev/null 2> /dev/null")
+      puts("Using " + `which #{tar_cmd}` + `#{tar_cmd} --version`)
+      puts("Exit status of '#{tar_cmd} -cf /dev/null --mtime=@0 --sort=name /dev/null' is #{$?.exitstatus}")
+      system("#{tar_cmd} -cf /dev/null --mtime=@0 --sort=name /dev/null")
       if $?.exitstatus != 0
         skip("This system doesn't seem to have a tar that supports --mtime=@0 --sort=name")
         return

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -357,6 +357,12 @@ describe FPM::Package::Deb do
     end # after
 
     it "it should output bit-for-bit identical packages" do
+      # Check prerequisites
+      system("#{tar_cmd} -cf /dev/null --mtime=@0 --sort=name /dev/null 2> /dev/null")
+      if $?.exitstatus != 0
+        skip("This system doesn't seem to have a tar that supports --mtime=@0 --sort=name")
+        return
+      end
       package.output(target)
       # FIXME: 2nd and later runs create changelog.Debian.gz?!, so throw away output of 1st run
       FileUtils.rm(target)

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -341,9 +341,8 @@ describe FPM::Package::Deb do
 
     let(:package) {
        # Turn on reproducible build behavior by setting SOURCE_DATE_EPOCH like user would
-       ENV['SOURCE_DATE_EPOCH'] = '12345'
        val = FPM::Package::Deb.new
-       ENV.delete('SOURCE_DATE_EPOCH')
+       val.attributes[:source_date_epoch] = '12345'
        val
     }
 

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -357,21 +357,11 @@ describe FPM::Package::Deb do
     end # after
 
     it "it should output bit-for-bit identical packages" do
-      # Check prerequisites
-      # FIXME: ar_cmd and tar_cmd should tell us this
-      puts("Using ar " + `which #{ar_cmd[0]}` + `#{ar_cmd[0]} --version`)
-      FileUtils.rm_f("foo.ar")
-      system("#{ar_cmd.join(' ')} foo.ar /dev/null && env LC_TIME=C TZ=GMT ar tv foo.ar | grep 1970 > /dev/null")
-      FileUtils.rm_f("foo.ar")
-      if $?.exitstatus != 0
-        skip("This system doesn't seem to have an ar that can omit timestamps")
-        return
-      end
-
-      puts("Using tar " + `which #{tar_cmd}` + `#{tar_cmd} --version`)
-      system("#{tar_cmd} -cf /dev/null --mtime=@0 --sort=name /dev/null")
-      if $?.exitstatus != 0
-        skip("This system doesn't seem to have a tar that supports --mtime=@0 --sort=name")
+      lamecmds = []
+      lamecmds << "ar" if not ar_cmd_deterministic?
+      lamecmds << "tar" if not tar_cmd_deterministic?
+      if lamecmds != ""
+        skip("fpm searched for variants of #{lamecmds.join(", ")} that support(s) deterministic archives, but found none, so can't test reproducibility.")
         return
       end
 

--- a/templates/deb/changelog.erb
+++ b/templates/deb/changelog.erb
@@ -2,4 +2,4 @@
 
   * Package created with FPM.
 
- -- <%= maintainer %>  <%= Time.now.strftime("%a, %d %b %Y %T %z") %>
+ -- <%= maintainer %>  <%= (if attributes[:source_date_epoch].nil? then Time.now() else Time.at(attributes[:source_date_epoch].to_i) end).strftime("%a, %d %b %Y %T %z") %>


### PR DESCRIPTION
Partly fixes #1232

Some work will be required in every package format handler;
for now, all that's been done is the minimum needed to achieve
reproducibility when running the canonical example:
```
   fpm -s gem -t deb json
```

See https://reproducible-builds.org/specs/source-date-epoch/
and https://wiki.debian.org/ReproducibleBuilds/StandardEnvironmentVariables
for why this is an environment variable, and not a commandline option.