### PR TITLE
Implement reproducible gem -> deb conversion

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -233,6 +233,11 @@ class FPM::Command < Clamp::Command
     "copying, downloading, etc. Roughly any scratch space fpm needs to build " \
     "your package.", :default => Dir.tmpdir
 
+  option "--source-date-epoch-from-changelog", :flag,
+    "Use release date from changelog as timestamp on generated files to reduce nondeterminism. " \
+    "Experimental; only implemented for gem so far. ",
+    :default => false
+
   option "--source-date-epoch-default", "SOURCE_DATE_EPOCH_DEFAULT",
     "If no release date otherwise specified, use this value as timestamp on generated files to reduce nondeterminism. " \
     "Reproducible build environments such as dpkg-dev and rpmbuild set this via envionment variable SOURCE_DATE_EPOCH " \

--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -233,6 +233,15 @@ class FPM::Command < Clamp::Command
     "copying, downloading, etc. Roughly any scratch space fpm needs to build " \
     "your package.", :default => Dir.tmpdir
 
+  option "--source-date-epoch-default", "SOURCE_DATE_EPOCH_DEFAULT",
+    "If no release date otherwise specified, use this value as timestamp on generated files to reduce nondeterminism. " \
+    "Reproducible build environments such as dpkg-dev and rpmbuild set this via envionment variable SOURCE_DATE_EPOCH " \
+    "variable to the integer unix timestamp to use in generated archives, " \
+    "and expect tools like fpm to use it as a hint to avoid nondeterministic output. " \
+    "This is a Unix timestamp, i.e. number of seconds since 1 Jan 1970 UTC. " \
+    "See https://reproducible-builds.org/specs/source-date-epoch ",
+    :environment_variable => "SOURCE_DATE_EPOCH"
+
   parameter "[ARGS] ...",
     "Inputs to the source package type. For the 'dir' type, this is the files" \
     " and directories you want to include in the package. For others, like " \

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -175,8 +175,8 @@ class FPM::Package
     @directories = []
     @attrs = {}
 
-    staging_path
     build_path
+    # Dont' initialize staging_path just yet, do it lazily so subclass can get a word in.
   end # def initialize
 
   # Get the 'type' for this instance.

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -414,24 +414,6 @@ class FPM::Package::Deb < FPM::Package
       end
     end
 
-    write_control_tarball
-
-    # Tar up the staging_path into data.tar.{compression type}
-    case self.attributes[:deb_compression]
-      when "gz", nil
-        datatar = build_path("data.tar.gz")
-        compression = "-z"
-      when "bzip2"
-        datatar = build_path("data.tar.bz2")
-        compression = "-j"
-      when "xz"
-        datatar = build_path("data.tar.xz")
-        compression = "-J"
-      else
-        raise FPM::InvalidPackageConfiguration,
-          "Unknown compression type '#{self.attributes[:deb_compression]}'"
-    end
-
     # There are two changelogs that may appear:
     #   - debian-specific changelog, which should be archived as changelog.Debian.gz
     #   - upstream changelog, which should be archived as changelog.gz

--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -256,7 +256,7 @@ class FPM::Package::Gem < FPM::Package
     # are not needed, and may contain generated paths that cause
     # different output on successive runs.
     Find.find(installdir) do |path|
-      if path =~ /.*(gem_make.out|Makefile)$/
+      if path =~ /.*(gem_make.out|Makefile|mkmf.log)$/
         logger.info("Removing no longer needed file %s to reduce nondeterminism" % path)
         File.unlink(path)
       end

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -1,6 +1,7 @@
 require "fpm/namespace"
 require "childprocess"
 require "ffi"
+require "fileutils"
 
 # Some utility functions
 module FPM::Util
@@ -190,9 +191,14 @@ module FPM::Util
     if args.size == 1
       args = [ default_shell, "-c", args[0] ]
     end
-    program = args[0]
 
-    exit_code = execmd(args)
+    if args[0].kind_of?(Hash)
+      env = args.shift()
+      exit_code = execmd(env, args)
+    else
+      exit_code = execmd(args)
+    end
+    program = args[0]
     success = (exit_code == 0)
 
     if !success
@@ -226,25 +232,89 @@ module FPM::Util
     return stdout_r_str
   end # def safesystemout
 
+  # Get an array containing the recommended 'ar' command for this platform
+  # and the recommended options to quickly create/append to an archive
+  # without timestamps or uids (if possible).
+  def ar_cmd
+    return @@ar_cmd if defined? @@ar_cmd
+
+    @@ar_cmd_deterministic = FALSE
+
+    # FIXME: don't assume current directory writeable
+    FileUtils.touch(["fpm-dummy.tmp"])
+    ["ar", "gar"].each do |ar|
+      ["-qc", "-qcD"].each do |ar_create_opts|
+        FileUtils.rm_f(["fpm-dummy.ar.tmp"])
+        # Return this combination if it creates archives without uids or timestamps.
+        # Exitstatus will be nonzero if the archive can't be created,
+        # or its table of contents doesn't match the regular expression.
+        # Be extra-careful about locale and timezone when matching output.
+        system("#{ar} #{ar_create_opts} fpm-dummy.ar.tmp fpm-dummy.tmp 2>/dev/null && env TZ=UTC LANG=C LC_TIME=C #{ar} -tv fpm-dummy.ar.tmp | grep '0/0.*1970' > /dev/null 2>&1")
+        if $?.exitstatus == 0
+           @@ar_cmd = [ar, ar_create_opts]
+           @@ar_cmd_deterministic = TRUE
+           return @@ar_cmd
+        end
+      end
+    end
+    # If no combination of ar and options omits timestamps, fall back to default.
+    @@ar_cmd = ["ar", "-qc"]
+    return @@ar_cmd
+  ensure
+    # Clean up
+    FileUtils.rm_f(["fpm-dummy.ar.tmp", "fpm-dummy.tmp"])
+  end # def ar_cmd
+
+  # Return whether the command returned by ar_cmd can create deterministic archives
+  def ar_cmd_deterministic?
+    ar_cmd if not defined? @@ar_cmd_deterministic
+    return @@ar_cmd_deterministic
+  end
+
   # Get the recommended 'tar' command for this platform.
   def tar_cmd
-    # Rely on gnu tar for solaris and OSX.
-    case %x{uname -s}.chomp
-    when "SunOS"
-      return "gtar"
-    when "Darwin"
-      # Try running gnutar, it was renamed(??) in homebrew to 'gtar' at some point, I guess? I don't know.
-      ["gnutar", "gtar"].each do |tar|
-        system("#{tar} > /dev/null 2> /dev/null")
-        return tar unless $?.exitstatus == 127
+    return @@tar_cmd if defined? @@tar_cmd
+
+    # FIXME: don't assume current directory writeable
+    FileUtils.touch(["fpm-dummy.tmp"])
+
+    # Prefer tar that supports more of the features we want, stop if we find tar of our dreams
+    best="tar"
+    bestscore=0
+    @@tar_cmd_deterministic = FALSE
+    # GNU Tar, if not the default, is usually on the path as gtar, but
+    # Mac OS X 10.8 and earlier shipped it as /usr/bin/gnutar
+    ["tar", "gtar", "gnutar"].each do |tar|
+      opts=[]
+      score=0
+      ["--sort=name", "--mtime=@0"].each do |opt|
+        system("#{tar} #{opt} -cf fpm-dummy.tar.tmp fpm-dummy.tmp > /dev/null 2>&1")
+        if $?.exitstatus == 0
+          opts << opt
+          score += 1
+        end
       end
-    when "FreeBSD"
-      # use gnutar instead
-      return "gtar"
-    else
-      return "tar"
+      if score > bestscore
+        best=tar
+        bestscore=score
+        if score == 2
+          @@tar_cmd_deterministic = TRUE
+          break
+        end
+      end
     end
+    @@tar_cmd = best
+    return @@tar_cmd
+  ensure
+    # Clean up
+    FileUtils.rm_f(["fpm-dummy.tar.tmp", "fpm-dummy.tmp"])
   end # def tar_cmd
+
+  # Return whether the command returned by tar_cmd can create deterministic archives
+  def tar_cmd_supports_sort_names_and_set_mtime?
+    tar_cmd if not defined? @@tar_cmd_deterministic
+    return @@tar_cmd_deterministic
+  end
 
   # wrapper around mknod ffi calls
   def mknod_w(path, mode, dev)

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -412,17 +412,19 @@ describe FPM::Package::Deb do
       # Output a second time with a different timestamp; tar format time resolution is 1 second
       sleep(1)
       package.output(target)
-      if File.exist? "/usr/bin/diffoscope"
-        tmp = ENV['TMP'] || "/tmp"
-        log = File.join(tmp, "diffoscope.log.tmp")
-        system('diffoscope %s %s 2>&1 > %s' % [target, target + '.orig', log])
-        diffoscope_diff_length = File.size(log)
-        if (diffoscope_diff_length > 0)
-           puts("\nDiffoscope reports:")
-           puts(File.read(log))
-        end
-        expect(diffoscope_diff_length).to(be == 0)
+
+      # Show detailed differences, if diffoscope is on PATH; else do nothing
+      tmp = ENV['TMP'] || "/tmp"
+      log = File.join(tmp, "diffoscope.log.tmp")
+      system('diffoscope %s %s > %s 2> /dev/null' % [target, target + '.orig', log])
+      diffoscope_diff_length = File.size(log)
+      if (diffoscope_diff_length > 0)
+         puts("\nDiffoscope reports:")
+         puts(File.read(log))
       end
+      expect(diffoscope_diff_length).to(be == 0)
+      File.unlink(log)
+
       expect(FileUtils.compare_file(target, target + '.orig')).to be true
     end
   end # #reproducible

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -174,7 +174,7 @@ describe FPM::Package::Deb do
     context "when the deb's control section is extracted" do
       let(:control_dir) { Stud::Temporary.directory }
       before do
-        system("ar p '#{target}' control.tar.gz | tar -zx -C '#{control_dir}' -f -")
+        system(ar_cmd[0] + " p '#{target}' control.tar.gz | tar -zx -C '#{control_dir}' -f -")
         raise "couldn't extract test deb" unless $CHILD_STATUS.success?
       end
 
@@ -375,4 +375,55 @@ describe FPM::Package::Deb do
       end
     end
   end
+
+  describe "#reproducible" do
+
+    let(:package) {
+       # Turn on reproducible build behavior by setting SOURCE_DATE_EPOCH like user would
+       val = FPM::Package::Deb.new
+       val.attributes[:source_date_epoch] = '1'  # one second into Jan 1 1970 UTC... '0' not supported by zlib binding :-(
+       val
+    }
+
+    before :each do
+      package.name = "name"
+      File.unlink(target + '.orig') if File.exist?(target + '.orig')
+    end
+
+    after :each do
+      package.cleanup
+      File.unlink(target + '.orig') if File.exist?(target + '.orig')
+    end # after
+
+    it "it should output bit-for-bit identical packages" do
+      lamecmds = []
+      lamecmds << "ar" if not ar_cmd_deterministic?
+      lamecmds << "tar" if not tar_cmd_supports_sort_names_and_set_mtime?
+      if not lamecmds.empty?
+        skip("fpm searched for variants of #{lamecmds.join(", ")} that support(s) deterministic archives, but found none, so can't test reproducibility.")
+        return
+      end
+
+      package.output(target)
+      # FIXME: 2nd and later runs create changelog.Debian.gz?!, so throw away output of 1st run
+      FileUtils.rm(target)
+      package.output(target)
+      FileUtils.mv(target, target + '.orig')
+      # Output a second time with a different timestamp; tar format time resolution is 1 second
+      sleep(1)
+      package.output(target)
+      if File.exist? "/usr/bin/diffoscope"
+        tmp = ENV['TMP'] || "/tmp"
+        log = File.join(tmp, "diffoscope.log.tmp")
+        system('diffoscope %s %s 2>&1 > %s' % [target, target + '.orig', log])
+        diffoscope_diff_length = File.size(log)
+        if (diffoscope_diff_length > 0)
+           puts("\nDiffoscope reports:")
+           puts(File.read(log))
+        end
+        expect(diffoscope_diff_length).to(be == 0)
+      end
+      expect(FileUtils.compare_file(target, target + '.orig')).to be true
+    end
+  end # #reproducible
 end # describe FPM::Package::Deb

--- a/templates/deb/changelog.erb
+++ b/templates/deb/changelog.erb
@@ -2,4 +2,4 @@
 
   * Package created with FPM.
 
- -- <%= maintainer %>  <%= Time.now.strftime("%a, %d %b %Y %T %z") %>
+ -- <%= maintainer %>  <%= (if attributes[:source_date_epoch].nil? then Time.now() else Time.at(attributes[:source_date_epoch].to_i) end).strftime("%a, %d %b %Y %T %z") %>


### PR DESCRIPTION
Partial fix for https://github.com/jordansissel/fpm/issues/1232
Ready for review and merging.

It fetches the source epoch from the changelog for about a third of the gems I tried.

Native gems still have some randomness on Darwin, but I'm not going to worry about that;
docs/source/gem.rst mentions that it's only been verified to produce identical results on Linux.

The following test passes locally on ubuntu 16.04:
```
 mkdir run1
 ruby -Ilib bin/fpm -s gem -t deb --gem-stagingdir /tmp/gem1.tmp --source-date-epoch-from-changelog json
 mv *.deb run1

 mkdir run2
 ruby -Ilib bin/fpm -s gem -t deb --gem-stagingdir /tmp/gem1.tmp --source-date-epoch-from-changelog json
 mv *.deb run2

 cmp run1/*.deb run2/*.deb
```
