### PR TITLE
Add --deb-after-purge FILE

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -18,6 +18,7 @@ class FPM::Package::Deb < FPM::Package
     :after_install      => "postinst",
     :before_remove      => "prerm",
     :after_remove       => "postrm",
+    :after_purge        => "postrm",
   } unless defined?(SCRIPT_MAP)
 
   # The list of supported compression types. Default is gz (gzip)
@@ -163,6 +164,12 @@ class FPM::Package::Deb < FPM::Package
   end
 
   option "--systemd-restart-after-upgrade", :flag , "Restart service after upgrade", :default => true
+
+  option "--after-purge", "FILE",
+    "A script to be run after package removal to purge remaining (config) files " \
+    "(a.k.a. postrm purge within apt-get purge)" do |val|
+    File.expand_path(val) # Get the full path to the script
+  end # --after-purge
 
   def initialize(*args)
     super(*args)
@@ -411,6 +418,9 @@ class FPM::Package::Deb < FPM::Package
       end
       if script?(:after_remove)
         scripts[:after_remove] = template("deb/postrm_upgrade.sh.erb").result(binding)
+      end
+      if script?(:after_purge)
+        scripts[:after_purge] = template("deb/postrm_upgrade.sh.erb").result(binding)
       end
     end
 

--- a/templates/deb/postrm_upgrade.sh.erb
+++ b/templates/deb/postrm_upgrade.sh.erb
@@ -9,6 +9,16 @@ after_remove() {
 <% end -%>
 }
 
+after_purge() {
+<%# Making sure that at least one command is in the function -%>
+<%# avoids a lot of potential errors, including the case that -%>
+<%# the script is non-empty, but just whitespace and/or comments -%>
+    :
+<% if script?(:after_purge) -%>
+<%=  script(:after_purge) %>
+<% end -%>
+}
+
 dummy() {
     :
 }
@@ -25,11 +35,8 @@ elif [ "${1}" = "purge" -a -z "${2}" ]
 then
     # like "on remove", but executes after dpkg deletes config files
     # 'apt-get purge' runs 'on remove' section, then this section.
-    # Maybe we ignore this; it seems really fine-grained.
-    # There is no equivalent in RPM or ARCH. A debian-specific argument
-    # might perhaps be used here, but most people
-    # probably don't need it.
-    dummy
+    # There is no equivalent in RPM or ARCH.
+    after_purge
 elif [ "${1}" = "upgrade" ]
 then
     # This represents the case where the old package's postrm is called after


### PR DESCRIPTION
Makes Debian's `postrm purge` hook usable.

Adds a new CLI argument `--deb-after-remove-purge` and extends the already prepared (thanks a lot!) `postrm_upgrade.sh.erb` template.

Thanks for `fpm`!