### PR TITLE
Allow source=dest/ syntax for symlinks

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -144,7 +144,8 @@ class FPM::Package::Dir < FPM::Package
         copy(source, destination)
       end
     elsif fileinfo.symlink?
-      if destination_is_directory
+      # Treat them same as files
+      if destination[-1,1] == "/"
         copy(source, File.join(destination, source))
       else
         copy(source, destination)

--- a/spec/fpm/package/dir_spec.rb
+++ b/spec/fpm/package/dir_spec.rb
@@ -155,6 +155,19 @@ describe FPM::Package::Dir do
     end
   end
 
+  context "symlink=dest_directory/" do
+    it "Should allow source=destination/ for symlinks" do
+      filepath = File.join(tmpdir, "target")
+      File.write(filepath, "hello!");
+      symlinkpath = File.join(tmpdir, "properlink.so")
+      File.symlink(filepath, symlinkpath);
+
+      subject.input(symlinkpath + "=" + "/a/b/")
+      subject.output(output)
+      insist { File.read(File.join(output, "/a/b/properlink.so")) } == "hello!"
+    end
+  end
+
   context "symlink=dest_dir/" do
     it "Should put the symlink into directory with link syntax" do
       filepath = File.join(tmpdir, "target")


### PR DESCRIPTION
PR #1253, while fixed the bug where `source.link=dest/source.link`
resulted in `source.link=dest/source.link/source.link` introduced a bug
where `source=dest/` syntax stopped working for symlinks (it is ok for
files). This is now fixed, as the symlink source now behaves the same as
it would with a single file input. Test case testing this behaviour is
also added.

Fixes #1395