### PR TITLE
[Fixes #1397] It's no longer necessary to explicitly require 'rubygems'

### DIFF
--- a/bin/fpm
+++ b/bin/fpm
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require "rubygems"
 $: << File.join(File.dirname(__FILE__), "..", "lib")
 require "fpm"
 require "fpm/command"


### PR DESCRIPTION
Ruby 1.9 requires Rubygems internally and this is no longer strictly required. It's been this way since 2009, so it's a little hard to come by official documentation. I hope this works...

> Note: For Ruby 1.8 you must require 'rubygems' before requiring any gems.

http://guides.rubygems.org/rubygems-basics/#requiring-code