### PR TITLE
Fixes typo with APK control scripts

### DIFF
--- a/lib/fpm/package/apk.rb
+++ b/lib/fpm/package/apk.rb
@@ -144,9 +144,9 @@ class FPM::Package::APK< FPM::Package
     scripts = {}
 
     scripts = register_script('post-install',   :after_install,   scripts)
-    scripts = register_script('post-install',   :before_install,  scripts)
-    scripts = register_script('post-install',   :before_upgrade,  scripts)
-    scripts = register_script('post-install',   :after_upgrade,  scripts)
+    scripts = register_script('pre-install',   :before_install,  scripts)
+    scripts = register_script('pre-upgrade',   :before_upgrade,  scripts)
+    scripts = register_script('post-upgrade',   :after_upgrade,  scripts)
     scripts = register_script('pre-deinstall',  :before_remove,   scripts)
     scripts = register_script('post-deinstall', :after_remove,    scripts)
 


### PR DESCRIPTION
Alpine Linux describes the available control scripts at https://wiki.alpinelinux.org/wiki/Creating_an_Alpine_package.

This patch fixes an issue where `post-install` was registered multiple times, preventing `:after_install`, `:before_install`, `:before_upgrade`, and `:after_upgrade` from running the correct script if multiple options were declared.

The issue appeared in https://github.com/jordansissel/fpm/commit/87ce028644b0bb9913b00ccd814be58056d9c28f.