### PR TITLE
Use `fix_dependency` when populating debian `Replaces` field

### DIFF
--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -144,6 +144,7 @@ describe FPM::Package::Deb do
       original.provides << "Some-SILLY_name"
 
       original.conflicts = ["foo < 123"]
+      original.replaces  = ["package < 1.2.3"]
       original.attributes[:deb_breaks] = ["baz < 123"]
 
       original.attributes[:deb_build_depends_given?] = true
@@ -261,6 +262,11 @@ describe FPM::Package::Deb do
       it "should have the correct dependency list" do
         # 'something > 10' should convert to 'something (>> 10)', etc.
         insist { dpkg_field("Depends") } == "something (>> 10), hello (>= 20)"
+      end
+
+      it "should have the correct replaces list" do
+        # 'package < 1.2.3' should convert to 'package (<< 1.2.3)'
+        insist { dpkg_field("Replaces") } == "package (<< 1.2.3)"
       end
 
       it "should have the correct build dependency list" do

--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -28,7 +28,7 @@ Build-Depends: <%= attributes[:deb_build_depends].collect { |d| fix_dependency(d
 Provides: <%= provides.map {|p| p.split(" ").first}.join ", " %>
 <% end -%>
 <% if !replaces.empty? -%>
-Replaces: <%= replaces.join(", ") %>
+Replaces: <%= replaces.collect { |d| fix_dependency(d) }.flatten.join(", ") %>
 <% end -%>
 <% if attributes[:deb_recommends] and !attributes[:deb_recommends].empty? -%>
 Recommends: <%= attributes[:deb_recommends].collect { |d| fix_dependency(d) }.flatten.join(", ") %>


### PR DESCRIPTION
The `Replaces` field needs to be formated 'package (operator version)'.
This makes use of the `fix_dependency` method for consistent formatting
with other dependencies.