### PR TITLE
Copy symlinks to prevent bogus conversion to hard links

### DIFF
--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -194,6 +194,12 @@ class FPM::Package::Dir < FPM::Package
                       :destination => destination)
         FileUtils.copy_entry(source, destination)
       end
+    elsif File.symlink?(source)
+      # Linking symlinks seems to turn them into hard links in the package when
+      # building on a Mac (but not Linux...), so copy it instead
+      logger.debug("Copying symlinked file", :source => source,
+                    :destination => destination)
+      FileUtils.copy_entry(source, destination)
     else
       # Otherwise try copying the file.
       begin


### PR DESCRIPTION
Fixes #1017 (?)

I have to admit, i know extremely little about Ruby and even less about fpm's internals. I tested this change on macOS 10.12.6 + Ruby 2.4.2 and on Ubuntu 16.04.3 + Ruby 2.3.1 (see #1017 for test cases), and it seems to produce the correct result on both, but that's the extent of what i tried. I don't have a Ruby development environment set up and am not sure how/if to run or update the unit tests. Someone else who knows better might want to double-check.