### PR TITLE
Require only the used backports

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -20,6 +20,8 @@ Gem::Specification.new do |spec|
     "management without wasting pointless hours debugging bad rpm specs!"
   spec.license = "MIT-like"
 
+  spec.required_ruby_version = '>= 1.9.3'
+
   # For parsing JSON (required for some Python support, etc)
   # http://flori.github.com/json/doc/index.html
   spec.add_dependency("json", ">= 1.7.7", "< 2.0") # license: Ruby License

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -3,7 +3,8 @@ require "fpm/util" # local
 require "pathname" # stdlib
 require "find"
 require "tmpdir" # stdlib
-require "backports" # gem 'backports'
+require "ostruct"
+require "backports/2.0.0/stdlib/ostruct"
 require "socket" # stdlib, for Socket.gethostname
 require "shellwords" # stdlib, for Shellwords.escape
 require "erb" # stdlib, for template processing
@@ -507,7 +508,7 @@ class FPM::Package
       end
     end
   end
-  
+
   # Get the contents of the script by a given name.
   #
   # If template_scripts? is set in attributes (often by the --template-scripts


### PR DESCRIPTION
Looking at the .travis.yml, it looks like you are supporting Ruby 1.9.3+.

Assuming this is correct, this PR:

1) specifies that in the gemspec

2) loads the backports that are still in use.

As I'm ready to publish a bunch of backports for Ruby 2.5, I'd like to deprecate the `require 'backports'` (which loads all of the backports). That was, in retrospect, not such a great idea as the number of backports is increasing with every Ruby version, and could potentially be an issue for some code. Moreover, it is wasteful to load the hundreds of backports when only a few are needed.

I wrote a script to run your test suite while making a list of the backports used. Assuming the coverage is good, there's only one used in the library.

Thanks