### PR TITLE
add xzmt - multithreaded xz compression for rpmbuild [fixes #1419]

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -25,6 +25,7 @@ class FPM::Package::RPM < FPM::Package
   COMPRESSION_MAP = {
     "none" => "w0.gzdio",
     "xz" => "w9.xzdio",
+    "xzmt" => "w9T.xzdio",
     "gzip" => "w9.gzdio",
     "bzip2" => "w9.bzdio"
   } unless defined?(COMPRESSION_MAP)


### PR DESCRIPTION
This change will allows the user to specify multi-threaded compression of RPMs.

RPM packaging can take a long time. Most of this time is the compression
of the rpm payload. Compression is compute heavy. But it can be speeded up 
if done on many cores in parallel rather than on a single core.
A 5Mb rpm I package takes 25 minutes using single threaded compression.
This goes down to 3 minutes when run multi-threaded.

Fixes https://github.com/jordansissel/fpm/issues/1419