### PR TITLE
Resolve deb-creation bug with docker

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,6 +21,7 @@ sbuss
 Brett Gailey (github: dnbert)
 Daniel Haskin (github: djhaskin987)
 Richard Grainger (github: liger1978)
+Frank Petrilli (github: FrankPetrilli)
 
 If you have contributed (bug reports, feature requests, help in IRC, blog
 posts, code, etc) and aren't listed here, please let me know if you wish to be

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN apk add --update \
         libffi-dev \
         make \
         libc-dev \
+	tar \
         rpm && \
         gem install --no-ri --no-rdoc fpm
 


### PR DESCRIPTION
Without this, I receive an error on attempting to create a deb, since it calls `tar` with the `--user` flag among others which busybox tar does not have.