### PR TITLE
Changed the mode of templates file for deb packages to 0644

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -901,7 +901,7 @@ class FPM::Package::Deb < FPM::Package
 
     if attributes[:deb_templates]
       FileUtils.cp(attributes[:deb_templates], control_path("templates"))
-      File.chmod(0755, control_path("templates"))
+      File.chmod(0644, control_path("templates"))
     end
   end # def write_debconf
 


### PR DESCRIPTION
If "--deb-templates" is used, fpm uses the wrong mode for this file. Since it is not an executable file, it should not have the executable bits set. The lintian tool complains (with an error) that the mode is incorrect, and that it should not be executable. Changing the mode to 0644 resolves this.