### PR TITLE
Generate .changes file for Debian

### DIFF
--- a/templates/deb/deb.changes.erb
+++ b/templates/deb/deb.changes.erb
@@ -1,0 +1,31 @@
+Format: 1.8
+Date: <%= (if attributes[:source_date_epoch].nil? then Time.now() else Time.at(attributes[:source_date_epoch].to_i) end).strftime("%a, %d %b %Y %T %z") %>
+Source: <%= name %>
+Binary: <%= name %>
+Architecture: <%= architecture %>
+Version: <%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>
+Distribution: <%= distribution %>
+Urgency: medium
+Maintainer: <%= maintainer %>
+<% lines = (description or "no description given").split("\n") -%>
+<% firstline, *remainder = lines -%>
+Description: <%= firstline %>
+<% if remainder.any? -%>
+<%= remainder.collect { |l| l =~ /^ *$/ ? " ." : " #{l}" }.join("\n") %>
+<% end -%>
+Changes:
+<%= name %> (<%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>) whatever; urgency=medium
+ .
+   * Package created with FPM.
+Checksums-Sha1:
+<% changes_files.each do |file| -%>
+ <%= file[:sha1sum] %> <%= file[:size] %> <%= file[:name] %>
+<% end -%>
+Checksums-Sha256:
+<% changes_files.each do |file| -%>
+ <%= file[:sha256sum] %> <%= file[:size] %> <%= file[:name] %>
+<% end -%>
+Files:
+<% changes_files.each do |file| -%>
+ <%= file[:md5sum] %> <%= file[:size] %> default <%= attributes[:deb_priority] %> <%= file[:name] %>
+<% end -%>


### PR DESCRIPTION
Issue #467 calls for creation of .debain.tar.gz, .dsc and .changes files.

This Patch adds generation of .changes file for Debian packages. 
.changes files (containing all files relevant to a package with their checksums) are used by some repository management tools when importing packages. 
Generating a .debian.tar.gz (which would contain the Debian specifics for this package, for example the rules file (basically, Makefile), the control file (specifying dependencies) and Debian specific patches) or a .dsc (which would specify the source package) might not be relevant for the use-case of fpm, though. 
Fixes #467.

The command line option --(no-)deb-generate-changes allows to select to generate the .changes file, the option --deb-dist allows to set a distribution (like sid) for the package.