### PR TITLE
Allow auto-enable and auto-start for deb-systemd services after install

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -181,6 +181,10 @@ class FPM::Package::Deb < FPM::Package
     next File.expand_path(file)
   end
 
+  option "--systemd-enable", :flag , "Enable service on install or upgrade", :default => true
+
+  option "--systemd-auto-start", :flag , "Start service after install or upgrade", :default => true
+
   option "--systemd-restart-after-upgrade", :flag , "Restart service after upgrade", :default => true
 
   option "--after-purge", "FILE",

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -181,9 +181,9 @@ class FPM::Package::Deb < FPM::Package
     next File.expand_path(file)
   end
 
-  option "--systemd-enable", :flag , "Enable service on install or upgrade", :default => true
+  option "--systemd-enable", :flag , "Enable service on install or upgrade", :default => false
 
-  option "--systemd-auto-start", :flag , "Start service after install or upgrade", :default => true
+  option "--systemd-auto-start", :flag , "Start service after install or upgrade", :default => false
 
   option "--systemd-restart-after-upgrade", :flag , "Restart service after upgrade", :default => true
 
@@ -444,7 +444,7 @@ class FPM::Package::Deb < FPM::Package
       attributes[:deb_systemd] << name
     end
 
-    if script?(:before_upgrade) or script?(:after_upgrade) or not attributes[:deb_systemd].empty?
+    if script?(:before_upgrade) or script?(:after_upgrade) or attributes[:deb_systemd].any?
       puts "Adding action files"
       if script?(:before_install) or script?(:before_upgrade)
         scripts[:before_install] = template("deb/preinst_upgrade.sh.erb").result(binding)
@@ -452,7 +452,7 @@ class FPM::Package::Deb < FPM::Package
       if script?(:before_remove) or not attributes[:deb_systemd].empty?
         scripts[:before_remove] = template("deb/prerm_upgrade.sh.erb").result(binding)
       end
-      if script?(:after_install) or script?(:after_upgrade) or not attributes[:deb_systemd].empty?
+      if script?(:after_install) or script?(:after_upgrade) or attributes[:deb_systemd].any?
         scripts[:after_install] = template("deb/postinst_upgrade.sh.erb").result(binding)
       end
       if script?(:after_remove)

--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -9,9 +9,9 @@ after_upgrade() {
 <% end -%>
 
 <%# if any systemd services specified, loop through and start them -%>
-<% unless attributes[:deb_systemd].empty? -%>
+<% if attributes[:deb_systemd].any? -%>
 systemctl --system daemon-reload >/dev/null || true
-sysctl=$(command -v deb-systemd-invoke || echo systemctl)
+debsystemctl=$(command -v deb-systemd-invoke || echo systemctl)
 <% attributes[:deb_systemd].each do |service| -%>
 if ! systemctl is-enabled <%= service %> >/dev/null 
 then
@@ -19,11 +19,11 @@ then
     systemctl enable <%= service %> >/dev/null || true
 <% end -%>
 <% if attributes[:deb_systemd_auto_start?]-%>
-    $sysctl start <%= service %> >/dev/null || true
+    $debsystemctl start <%= service %> >/dev/null || true
 <% end -%>
 <% if attributes[:deb_systemd_restart_after_upgrade?] -%>
 else
-    $sysctl restart <%= service %> >/dev/null || true
+    $debsystemctl restart <%= service %> >/dev/null || true
 <% end -%>
 fi
 <% end -%>
@@ -40,15 +40,15 @@ after_install() {
 <% end -%>
 
 <%# if any systemd services specified, loop through and start them -%>
-<% unless attributes[:deb_systemd].empty? -%>
+<% if attributes[:deb_systemd].any? -%>
 systemctl --system daemon-reload >/dev/null || true
-sysctl=$(command -v deb-systemd-invoke || echo systemctl)
+debsystemctl=$(command -v deb-systemd-invoke || echo systemctl)
 <% attributes[:deb_systemd].each do |service| -%>
 <% if attributes[:deb_systemd_enable?]-%>
 systemctl enable <%= service %> >/dev/null || true
 <% end -%>
 <% if attributes[:deb_systemd_auto_start?]-%>
-$sysctl start <%= service %> >/dev/null || true
+$debsystemctl start <%= service %> >/dev/null || true
 <% end -%>
 <% end -%>
 <% end -%>

--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -8,22 +8,25 @@ after_upgrade() {
 <%=  script(:after_upgrade) %>
 <% end -%>
 
-<% if attributes[:deb_systemd] -%>
+<%# if any systemd services specified, loop through and start them -%>
+<% unless attributes[:deb_systemd].empty? -%>
 systemctl --system daemon-reload >/dev/null || true
 sysctl=$(command -v deb-systemd-invoke || echo systemctl)
-if ! systemctl is-enabled <%= attributes[:deb_systemd] %> >/dev/null 
+<% attributes[:deb_systemd].each do |service| -%>
+if ! systemctl is-enabled <%= service %> >/dev/null 
 then
 <% if attributes[:deb_systemd_enable?]-%>
-    systemctl enable <%= attributes[:deb_systemd] %> >/dev/null || true
+    systemctl enable <%= service %> >/dev/null || true
 <% end -%>
 <% if attributes[:deb_systemd_auto_start?]-%>
-    $sysctl start <%= attributes[:deb_systemd] %> >/dev/null || true
+    $sysctl start <%= service %> >/dev/null || true
 <% end -%>
 <% if attributes[:deb_systemd_restart_after_upgrade?] -%>
 else
-    $sysctl restart <%= attributes[:deb_systemd] %> >/dev/null || true
+    $sysctl restart <%= service %> >/dev/null || true
 <% end -%>
 fi
+<% end -%>
 <% end -%>
 }
 
@@ -36,14 +39,17 @@ after_install() {
 <%=  script(:after_install) %>
 <% end -%>
 
-<% if attributes[:deb_systemd] -%>
+<%# if any systemd services specified, loop through and start them -%>
+<% unless attributes[:deb_systemd].empty? -%>
 systemctl --system daemon-reload >/dev/null || true
 sysctl=$(command -v deb-systemd-invoke || echo systemctl)
+<% attributes[:deb_systemd].each do |service| -%>
 <% if attributes[:deb_systemd_enable?]-%>
-systemctl enable <%= attributes[:deb_systemd] %> >/dev/null || true
+systemctl enable <%= service %> >/dev/null || true
 <% end -%>
 <% if attributes[:deb_systemd_auto_start?]-%>
-$sysctl start <%= attributes[:deb_systemd] %> >/dev/null || true
+$sysctl start <%= service %> >/dev/null || true
+<% end -%>
 <% end -%>
 <% end -%>
 }

--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -10,13 +10,18 @@ after_upgrade() {
 
 <% if attributes[:deb_systemd] -%>
 systemctl --system daemon-reload >/dev/null || true
+sysctl=$(command -v deb-systemd-invoke || echo systemctl)
 if ! systemctl is-enabled <%= attributes[:deb_systemd] %> >/dev/null 
 then
+<% if attributes[:deb_systemd_enable?]-%>
     systemctl enable <%= attributes[:deb_systemd] %> >/dev/null || true
-    systemctl start <%= attributes[:deb_systemd] %> >/dev/null || true
+<% end -%>
+<% if attributes[:deb_systemd_auto_start?]-%>
+    $sysctl start <%= attributes[:deb_systemd] %> >/dev/null || true
+<% end -%>
 <% if attributes[:deb_systemd_restart_after_upgrade?] -%>
 else
-    systemctl restart <%= attributes[:deb_systemd] %> >/dev/null || true
+    $sysctl restart <%= attributes[:deb_systemd] %> >/dev/null || true
 <% end -%>
 fi
 <% end -%>
@@ -33,8 +38,13 @@ after_install() {
 
 <% if attributes[:deb_systemd] -%>
 systemctl --system daemon-reload >/dev/null || true
+sysctl=$(command -v deb-systemd-invoke || echo systemctl)
+<% if attributes[:deb_systemd_enable?]-%>
 systemctl enable <%= attributes[:deb_systemd] %> >/dev/null || true
-systemctl start <%= attributes[:deb_systemd] %> >/dev/null || true
+<% end -%>
+<% if attributes[:deb_systemd_auto_start?]-%>
+$sysctl start <%= attributes[:deb_systemd] %> >/dev/null || true
+<% end -%>
 <% end -%>
 }
 

--- a/templates/deb/prerm_upgrade.sh.erb
+++ b/templates/deb/prerm_upgrade.sh.erb
@@ -8,10 +8,12 @@ before_remove() {
 <%=  script(:before_remove) %>
 <% end -%>
 
-<%# Removing the systemd service-%>
-<% if attributes[:deb_systemd] -%>
-systemctl stop <%= attributes[:deb_systemd] %> >/dev/null || true
-systemctl disable <%= attributes[:deb_systemd] %> >/dev/null || true
+<%# Stop and remove any systemd services that were installed-%>
+<% unless attributes[:deb_systemd].empty? -%>
+<% attributes[:deb_systemd].each do |service| -%>
+systemctl stop <%= service %> >/dev/null || true
+systemctl disable <%= service %> >/dev/null || true
+<% end -%>
 systemctl --system daemon-reload >/dev/null || true
 <% end -%>
 }

--- a/templates/deb/prerm_upgrade.sh.erb
+++ b/templates/deb/prerm_upgrade.sh.erb
@@ -9,9 +9,10 @@ before_remove() {
 <% end -%>
 
 <%# Stop and remove any systemd services that were installed-%>
-<% unless attributes[:deb_systemd].empty? -%>
+<% if attributes[:deb_systemd].any? -%>
+debsystemctl=$(command -v deb-systemd-invoke || echo systemctl)
 <% attributes[:deb_systemd].each do |service| -%>
-systemctl stop <%= service %> >/dev/null || true
+$debsystemctl stop <%= service %> >/dev/null || true
 systemctl disable <%= service %> >/dev/null || true
 <% end -%>
 systemctl --system daemon-reload >/dev/null || true


### PR DESCRIPTION
Hi, this PR adds in two new options to enable/disable and autostart systemd services

`--[no-]deb-systemd-enable` to enable the systemd service after install
`--[no-]deb-systemd-auto-start` to auto start the service after install

Additionally, any service start/stop/restart will use the `deb-systemd-invoke` wrapper if installed on the system

This should solve https://github.com/jordansissel/fpm/issues/1363 and https://github.com/jordansissel/fpm/issues/1284

Even though you can now disable a service from starting by default, I think its important to still allow for using [deb-systemd-invoke](http://manpages.ubuntu.com/manpages/trusty/man1/deb-systemd-invoke.1p.html) to keep in line with debian standards.

Let me know if you need anything changed! Thanks :)