### PR TITLE
Always treat perl dependency version as a string.

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -160,7 +160,7 @@ class FPM::Package::CPAN < FPM::Package
        found_dependencies.each do |dep_name, version|
           # Special case for representing perl core as a version.
           if dep_name == "perl"
-            m = version.match(/^(\d)\.(\d{3})(\d{3})$/)
+            m = version.to_s.match(/^(\d)\.(\d{3})(\d{3})$/)
             if m
                version = m[1] + '.' + m[2].sub(/^0*/, '') + '.' + m[3].sub(/^0*/, '')
             end


### PR DESCRIPTION
Perl modules have both META.json and META.yml. In the JSON, the perl
dependency appears as a string `"5.004"`, but in YAML it appears as a
number `5.004`! This may cause fpm to fail when trying to convert the
perl version into a dependency, so we now always treat the perl version
as a string.

Hopefully fixes #1514