### PR TITLE
Perl CPAN Support, Broken tar --strip-components Command, Fix

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -116,6 +116,8 @@ class FPM::Package::CPAN < FPM::Package
     self.vendor = case metadata["author"]
       when String; metadata["author"]
       when Array; metadata["author"].join(", ")
+      # for Class::Data::Inheritable and others with blank 'author' field, fix "Invalid package configuration: Unexpected CPAN 'author' field type: NilClass. This is a bug."
+      when NilClass; "No Vendor Or Author Provided"
       else
         raise FPM::InvalidPackageConfiguration, "Unexpected CPAN 'author' field type: #{metadata["author"].class}. This is a bug."
     end if metadata.include?("author")

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -54,9 +54,13 @@ class FPM::Package::CPAN < FPM::Package
       moduledir = package
       result = {}
     else
+      logger.info("[[[ DEBUG CHECKPOINT 010 ]]]")
       result = search(package)
+      logger.info("[[[ DEBUG CHECKPOINT 011 ]]]")
       tarball = download(result, version)
+      logger.info("[[[ DEBUG CHECKPOINT 012 ]]]")
       moduledir = unpack(tarball)
+      logger.info("[[[ DEBUG CHECKPOINT 013 ]]]")
     end
 
     # Read package metadata (name, version, etc)
@@ -142,7 +146,11 @@ class FPM::Package::CPAN < FPM::Package
     cpanm_flags += ["--force"] if attributes[:cpan_cpanm_force?]
     cpanm_flags += ["--verbose"] if attributes[:cpan_verbose?]
 
-    safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
+    logger.info("[[[ DEBUG CHECKPOINT 060 ]]]")
+    # Run cpanm with stdin enabled so that ExtUtils::MakeMaker does not prompt user for input
+#    safesystem(attributes[:cpan_cpanm_bin], *cpanm_flags)
+    safesystemin("", attributes[:cpan_cpanm_bin], *cpanm_flags)
+    logger.info("[[[ DEBUG CHECKPOINT 061 ]]]")
 
     if !attributes[:no_auto_depends?]
      found_dependencies = {}
@@ -167,14 +175,19 @@ class FPM::Package::CPAN < FPM::Package
             self.dependencies << "#{dep_name} >= #{version}"
             next
           end
+          logger.info("[[[ DEBUG CHECKPOINT 020 ]]]")
           dep = search(dep_name)
+          logger.info("[[[ DEBUG CHECKPOINT 021 ]]]")
 
           name = cap_name(dep_name)
+          logger.info("[[[ DEBUG CHECKPOINT 022 ]]]")
 
           if version.to_s == "0"
+            logger.info("[[[ DEBUG CHECKPOINT 023 ]]]")
             # Assume 'Foo = 0' means any version?
             self.dependencies << "#{name}"
           else
+            logger.info("[[[ DEBUG CHECKPOINT 024 ]]]")
             # The 'version' string can be something complex like:
             #   ">= 0, != 1.0, != 1.2"
             # If it is not specified explicitly, require the given
@@ -191,64 +204,94 @@ class FPM::Package::CPAN < FPM::Package
               self.dependencies << "#{name} >= #{version}"
             end
           end
+          logger.info("[[[ DEBUG CHECKPOINT 025 ]]]")
         end
+        logger.info("[[[ DEBUG CHECKPOINT 026 ]]]")
       end
+       logger.info("[[[ DEBUG CHECKPOINT 027 ]]]")
     end #no_auto_depends
+    logger.info("[[[ DEBUG CHECKPOINT 028 ]]]")
 
     ::Dir.chdir(moduledir) do
       # TODO(sissel): install build and config dependencies to resolve
       # build/configure requirements.
       # META.yml calls it 'configure_requires' and 'build_requires'
       # META.json calls it prereqs/build and prereqs/configure
+      logger.info("[[[ DEBUG CHECKPOINT 030 ]]]")
 
       prefix = attributes[:prefix] || "/usr/local"
       # TODO(sissel): Set default INSTALL path?
+      logger.info("[[[ DEBUG CHECKPOINT 031 ]]]")
 
       # Try Makefile.PL, Build.PL
       #
       if File.exist?("Build.PL")
+        logger.info("[[[ DEBUG CHECKPOINT 040 ]]]")
         # Module::Build is in use here; different actions required.
-        safesystem(attributes[:cpan_perl_bin],
+#        safesystem(attributes[:cpan_perl_bin],  # hangs on interactive build, waiting for user input
+        safesystemin("", attributes[:cpan_perl_bin],
                    "-Mlocal::lib=#{build_path("cpan")}",
                    "Build.PL")
-        safesystem(attributes[:cpan_perl_bin],
+        logger.info("[[[ DEBUG CHECKPOINT 041 ]]]")
+#        safesystem(attributes[:cpan_perl_bin],  # hangs on interactive build, waiting for user input
+        safesystemin("", attributes[:cpan_perl_bin],
                    "-Mlocal::lib=#{build_path("cpan")}",
                    "./Build")
+        logger.info("[[[ DEBUG CHECKPOINT 042 ]]]")
 
         if attributes[:cpan_test?]
-          safesystem(attributes[:cpan_perl_bin],
+#        safesystem(attributes[:cpan_perl_bin],  # hangs on interactive build, waiting for user input
+          safesystemin("", attributes[:cpan_perl_bin],
                    "-Mlocal::lib=#{build_path("cpan")}",
                    "./Build", "test")
+        logger.info("[[[ DEBUG CHECKPOINT 043 ]]]")
         end
         if attributes[:cpan_perl_lib_path]
+          logger.info("[[[ DEBUG CHECKPOINT 044 ]]]")
           perl_lib_path = attributes[:cpan_perl_lib_path]
           safesystem("./Build install --install_path lib=#{perl_lib_path} \
                      --destdir #{staging_path} --prefix #{prefix} --destdir #{staging_path}")
+          logger.info("[[[ DEBUG CHECKPOINT 045 ]]]")
         else
+          logger.info("[[[ DEBUG CHECKPOINT 046 ]]]")
            safesystem("./Build", "install",
                      "--prefix", prefix, "--destdir", staging_path,
                      # Empty install_base to avoid local::lib being used.
                      "--install_base", "")
+          logger.info("[[[ DEBUG CHECKPOINT 047 ]]]")
         end
       elsif File.exist?("Makefile.PL")
+        logger.info("[[[ DEBUG CHECKPOINT 050 ]]]")
         if attributes[:cpan_perl_lib_path]
+          logger.info("[[[ DEBUG CHECKPOINT 051 ]]]")
           perl_lib_path = attributes[:cpan_perl_lib_path]
-          safesystem(attributes[:cpan_perl_bin],
+          logger.info("[[[ DEBUG CHECKPOINT 052 ]]]")
+#          safesystem(attributes[:cpan_perl_bin],  # hangs on interactive build, waiting for user input
+          safesystemin("", attributes[:cpan_perl_bin],
                      "-Mlocal::lib=#{build_path("cpan")}",
                      "Makefile.PL", "PREFIX=#{prefix}", "LIB=#{perl_lib_path}",
                      # Empty install_base to avoid local::lib being used.
                      "INSTALL_BASE=")
+          logger.info("[[[ DEBUG CHECKPOINT 053 ]]]")
         else
-          safesystem(attributes[:cpan_perl_bin],
+          logger.info("[[[ DEBUG CHECKPOINT 054 ]]]")
+#          safesystem(attributes[:cpan_perl_bin],  # hangs on interactive build, waiting for user input
+          safesystemin("", attributes[:cpan_perl_bin],
                      "-Mlocal::lib=#{build_path("cpan")}",
                      "Makefile.PL", "PREFIX=#{prefix}",
                      # Empty install_base to avoid local::lib being used.
                      "INSTALL_BASE=")
+          logger.info("[[[ DEBUG CHECKPOINT 055 ]]]")
         end
+        logger.info("[[[ DEBUG CHECKPOINT 060 ]]]")
         make = [ "env", "PERL5LIB=#{build_path("cpan/lib/perl5")}", "make" ]
+        logger.info("[[[ DEBUG CHECKPOINT 061 ]]]")
         safesystem(*make)
+        logger.info("[[[ DEBUG CHECKPOINT 062 ]]]")
         safesystem(*(make + ["test"])) if attributes[:cpan_test?]
+        logger.info("[[[ DEBUG CHECKPOINT 063 ]]]")
         safesystem(*(make + ["DESTDIR=#{staging_path}", "install"]))
+        logger.info("[[[ DEBUG CHECKPOINT 064 ]]]")
 
 
       else
@@ -353,7 +396,7 @@ class FPM::Package::CPAN < FPM::Package
       response = httpfetch(url)
     rescue Net::HTTPServerException => e
       #logger.error("Download failed", :error => response.status_line,
-                    #:url => url)
+                    ##:url => url)
       logger.error("Download failed", :error => e, :url => url)
       raise FPM::InvalidPackageConfiguration, "metacpan query failed"
     end
@@ -368,21 +411,31 @@ class FPM::Package::CPAN < FPM::Package
   def search(package)
     logger.info("Asking metacpan about a module", :module => package)
     metacpan_url = "https://fastapi.metacpan.org/v1/module/" + package
+    logger.info("[[[ DEBUG CHECKPOINT 000 ]]]")
     begin
+      logger.info("[[[ DEBUG CHECKPOINT 001 ]]]")
       response = httpfetch(metacpan_url)
+      logger.info("[[[ DEBUG CHECKPOINT 002 ]]]")
     rescue Net::HTTPServerException => e
+      logger.info("[[[ DEBUG CHECKPOINT 003 ]]]")
       #logger.error("metacpan query failed.", :error => response.status_line,
-                    #:module => package, :url => metacpan_url)
+                    ##:module => package, :url => metacpan_url)
       logger.error("metacpan query failed.", :error => e.message,
                     :module => package, :url => metacpan_url)
+      logger.info("[[[ DEBUG CHECKPOINT 004 ]]]")
       raise FPM::InvalidPackageConfiguration, "metacpan query failed"
+      logger.info("[[[ DEBUG CHECKPOINT 005 ]]]")
     end
+    logger.info("[[[ DEBUG CHECKPOINT 006 ]]]")
 
     #data = ""
     #response.read_body { |c| p c; data << c }
     data = response.body
+    logger.info("[[[ DEBUG CHECKPOINT 007 ]]]")
     metadata = JSON.parse(data)
+    logger.info("[[[ DEBUG CHECKPOINT 008 ]]]")
     return metadata
+    logger.info("[[[ DEBUG CHECKPOINT 009 ]]]")
   end # def metadata
 
   def cap_name(name)

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -304,7 +304,8 @@ class FPM::Package::CPAN < FPM::Package
     directory = build_path("module")
     ::Dir.mkdir(directory)
     args = [ "-C", directory, "-zxf", tarball,
-      "--strip-components", "1" ]
+#      "--strip-components", "1" ]       # fails    on removing leading ./Foo/ in tarball paths
+      %q{--transform=s,[./]*[^/]*/,,} ]  # succeeds on removing leading ./Foo/ or /Foo/ or Foo/
     safesystem("tar", *args)
     return directory
   end

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -30,6 +30,10 @@ class FPM::Package::RPM < FPM::Package
     "bzip2" => "w9.bzdio"
   } unless defined?(COMPRESSION_MAP)
 
+  option "--ba", :flag, "Pass --ba to rpmbuild; build both source and binary packages."
+  option "--bb", :flag, "Pass --bb to rpmbuild; build binary package, not source package."
+  option "--bs", :flag, "Pass --bs to rpmbuild; build source package, not binary package."
+
   option "--use-file-permissions", :flag,
       "Use existing file permissions when defining ownership and modes."
 
@@ -419,7 +423,42 @@ class FPM::Package::RPM < FPM::Package
   def output(output_path)
     output_check(output_path)
     %w(BUILD RPMS SRPMS SOURCES SPECS).each { |d| FileUtils.mkdir_p(build_path(d)) }
-    args = ["rpmbuild", "-bb"]
+
+
+
+# THEN START HERE: use option to determine args below
+# THEN START HERE: use option to determine args below
+# THEN START HERE: use option to determine args below
+
+
+    logger.info("[[[ DEBUG ]]] have :rpm_ba", :rpm_ba => attributes[:rpm_ba?])
+    logger.info("[[[ DEBUG ]]] have :rpm_bb", :rpm_bb => attributes[:rpm_bb?])
+    logger.info("[[[ DEBUG ]]] have :rpm_bs", :rpm_bs => attributes[:rpm_bs?])
+
+#    args = ["rpmbuild", "-bb"]  # NEED REMOVE, ORIGINAL
+    args = ["rpmbuild"]
+
+    if attributes[:rpm_ba?]
+      if attributes[:rpm_bb?]
+        raise "RPM build options --rpm-ba and --rpm-bb both provided, must choose only one"
+      elsif attributes[:rpm_bs?]
+        raise "RPM build options --rpm-ba and --rpm-bs both provided, must choose only one"
+      end
+      args += ["--ba"] 
+    elsif attributes[:rpm_bb?]
+      if attributes[:rpm_bs?]
+        raise "RPM build options --rpm-bb and --rpm-bs both provided, must choose only one"
+      end
+      args += ["--bb"] 
+    elsif attributes[:rpm_bs?]
+      args += ["--bs"] 
+    else
+      # default to --bb, build binary packages only
+      args += ["--bb"] 
+    end
+
+
+
 
     if %x{uname -m}.chomp != self.architecture
       rpm_target = self.architecture

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -203,7 +203,7 @@ module FPM::Util
 
     if !success
       raise ProcessFailed.new("#{program} failed (exit code #{exit_code})" \
-                              ". Full command was:#{args.inspect}")
+                              ". Full command was:\n" + args.join(" "))
     end
     return success
   end # def safesystem

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -163,17 +163,19 @@ module FPM::Util
     stdout_w.close; stderr_w.close
     logger.info("Process is running", :pid => process.pid)
     if block_given?
+#    if false  # allows output & cures gcc/as hang, but re-introduces Inline::CPP interactive build hang
       args3 = []
       args3.push(process)           if opts[:process]
       args3.push(process.io.stdin)  if opts[:stdin]
-      args3.push(stdout_r)          if opts[:stdout]
-      args3.push(stderr_r)          if opts[:stderr]
+#      args3.push(stdout_r)          if opts[:stdout]
+#      args3.push(stderr_r)          if opts[:stderr]
 
       yield(*args3)
 
-      process.io.stdin.close        if opts[:stdin] and not process.io.stdin.closed?
-      stdout_r.close                unless stdout_r.closed?
-      stderr_r.close                unless stderr_r.closed?
+#      process.io.stdin.close        if opts[:stdin] and not process.io.stdin.closed?
+#      stdout_r.close                unless stdout_r.closed?
+#      stderr_r.close                unless stderr_r.closed?
+      logger.pipe(stdout_r => :info, stderr_r => :info)
     else
       # Log both stdout and stderr as 'info' because nobody uses stderr for
       # actually reporting errors and as a result 'stderr' is a misnomer.
@@ -249,9 +251,9 @@ module FPM::Util
         logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 122 ]]]")
         stdin.close
         logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 123 ]]]")
-        stdout_r_str = stdout.read
+#        stdout_r_str = stdout.read
         logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 124 ]]]")
-        stderr_r_str = stderr.read
+#        stderr_r_str = stderr.read
         logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 125 ]]]")
       end
       logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 126 ]]]")

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -101,6 +101,7 @@ module FPM::Util
   #   :stderr  (default: true)  -- pass stderr object of the child process to the block for reading,
   #
   def execmd(*args)
+    logger.info("[[[ DEBUG CHECKPOINT, execmd(), 700 ]]]")
     i = 0
     if i < args.size
       if args[i].kind_of?(Hash)
@@ -142,7 +143,7 @@ module FPM::Util
       raise ExecutableNotFound.new(program)
     end
 
-    logger.debug("Running command", :args => args2)
+    logger.info("Running command: " + args2.join(" "))
 
     stdout_r, stdout_w = IO.pipe
     stderr_r, stderr_w = IO.pipe
@@ -160,7 +161,7 @@ module FPM::Util
     process.start
 
     stdout_w.close; stderr_w.close
-    logger.debug("Process is running", :pid => process.pid)
+    logger.info("Process is running", :pid => process.pid)
     if block_given?
       args3 = []
       args3.push(process)           if opts[:process]
@@ -186,6 +187,7 @@ module FPM::Util
 
   # Run a command safely in a way that gets reports useful errors.
   def safesystem(*args)
+    logger.info("[[[ DEBUG, FULL COMMAND ]]]  in safesystem(), received args =\n" + args.join(" "))
     # ChildProcess isn't smart enough to run a $SHELL if there's
     # spaces in the first arg and there's only 1 arg.
     if args.size == 1
@@ -210,6 +212,7 @@ module FPM::Util
 
   # Run a command safely in a way that pushes stdin to command
   def safesystemin(*args)
+    logger.info("[[[ DEBUG, FULL COMMAND ]]]  in safesystemin(), received args =\n" + args.join(" "))
     logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 100 ]]]")
     # Our first argument is our stdin
     safe_stdin = args.shift()
@@ -238,6 +241,8 @@ module FPM::Util
       logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 117 ]]]")
     else
       logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 120 ]]]")
+#      args.push(" | tee /tmp/execmd.out")   # NO, runs but does not create output file
+#      args.push(" > /tmp/execmd.out 2>&1 ") # NO, runs but does not create output file
       exit_code = execmd(args) do |stdin,stdout,stderr|
         logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 121 ]]]")
         stdin.write(safe_stdin)
@@ -260,7 +265,7 @@ module FPM::Util
     if !success
       logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 133 ]]]")
       raise ProcessFailed.new("#{program} failed (exit code #{exit_code})" \
-                              ". Full command was:#{args.inspect}")
+                              ". Full command was:\n" + args.join(" "))
     end
     logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 134 ]]]")
     return success
@@ -269,6 +274,7 @@ module FPM::Util
 
   # Run a command safely in a way that captures output and status.
   def safesystemout(*args)
+    logger.info("[[[ DEBUG, FULL COMMAND ]]]  in safesystemout(), received args =\n" + args.join(" "))
     if args.size == 1
       args = [ ENV["SHELL"], "-c", args[0] ]
     end
@@ -286,7 +292,7 @@ module FPM::Util
 
     if !success
       raise ProcessFailed.new("#{program} failed (exit code #{exit_code})" \
-                              ". Full command was:#{args.inspect}")
+                              ". Full command was:\n" + args.join(" "))
     end
     return stdout_r_str
   end # def safesystemout

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -208,6 +208,65 @@ module FPM::Util
     return success
   end # def safesystem
 
+  # Run a command safely in a way that pushes stdin to command
+  def safesystemin(*args)
+    logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 100 ]]]")
+    # Our first argument is our stdin
+    safe_stdin = args.shift()
+    logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 101 ]]]")
+
+    if args.size == 1
+      logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 102 ]]]")
+      args = [ default_shell, "-c", args[0] ]
+    end
+
+    if args[0].kind_of?(Hash)
+      logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 110 ]]]")
+      env = args.shift()
+      logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 111 ]]]")
+      exit_code = execmd(env, args) do |stdin,stdout,stderr|
+        logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 112 ]]]")
+        stdin.write(safe_stdin)
+        logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 113 ]]]")
+        stdin.close
+        logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 114 ]]]")
+        stdout_r_str = stdout.read
+        logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 115 ]]]")
+        stderr_r_str = stderr.read  
+        logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 116 ]]]")
+      end
+      logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 117 ]]]")
+    else
+      logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 120 ]]]")
+      exit_code = execmd(args) do |stdin,stdout,stderr|
+        logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 121 ]]]")
+        stdin.write(safe_stdin)
+        logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 122 ]]]")
+        stdin.close
+        logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 123 ]]]")
+        stdout_r_str = stdout.read
+        logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 124 ]]]")
+        stderr_r_str = stderr.read
+        logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 125 ]]]")
+      end
+      logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 126 ]]]")
+    end
+    logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 130 ]]]")
+    program = args[0]
+    logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 131 ]]]")
+    success = (exit_code == 0)
+
+    logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 132 ]]]")
+    if !success
+      logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 133 ]]]")
+      raise ProcessFailed.new("#{program} failed (exit code #{exit_code})" \
+                              ". Full command was:#{args.inspect}")
+    end
+    logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 134 ]]]")
+    return success
+    logger.info("[[[ DEBUG CHECKPOINT, safesystemin(), 135 ]]]")
+  end # def safesystemin
+
   # Run a command safely in a way that captures output and status.
   def safesystemout(*args)
     if args.size == 1


### PR DESCRIPTION
For handling CPAN tarballs with leading "./Foo/" directory structures, we must employ a `tar --transform` regex instead of a `tar --strip-components` command.

I also edited the output format of the failed commands in util.rb safesystem so developers can actually copy/paste the commands for debugging.  (Feel free to do the same to safesystemout if you like.)