### PR TITLE
FIX: Proper indentation for changes

### DIFF
--- a/templates/deb/deb.changes.erb
+++ b/templates/deb/deb.changes.erb
@@ -14,9 +14,8 @@ Description: <%= firstline %>
 <%= remainder.collect { |l| l =~ /^ *$/ ? " ." : " #{l}" }.join("\n") %>
 <% end -%>
 Changes:
-<%= name %> (<%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>) whatever; urgency=medium
- .
-   * Package created with FPM.
+ <%= name %> (<%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>) whatever; urgency=medium
+  * Package created with FPM.
 Checksums-Sha1:
 <% changes_files.each do |file| -%>
  <%= file[:sha1sum] %> <%= file[:size] %> <%= file[:name] %>


### PR DESCRIPTION
Set the expected indentation format in changes according to the documentation: https://www.debian.org/doc/debian-policy/ch-source.html#s-dpkgchangelog