### PR TITLE
Preserve build-time timestamps when building rpms [#1538]

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -516,10 +516,11 @@ class FPM::Package::RPM < FPM::Package
     end
 
     # copy all files from staging to BUILD dir
+    # [#1538] Be sure to preserve the original timestamps.
     Find.find(staging_path) do |path|
       src = path.gsub(/^#{staging_path}/, '')
       dst = File.join(build_path, build_sub_dir, src)
-      copy_entry(path, dst)
+      copy_entry(path, dst, preserve=true)
     end
 
     rpmspec = template("rpm.erb").result(binding)


### PR DESCRIPTION
.pyc files must be newer-than (not equal-in-time-to) the .py file they come from. The copy_entry is dropping in time-equivalent files, so the resulting rpm has equivalent-timestamp files.   This leads to a pyc recompile by the first script invocation that has write perms to the .pyc file (probably root).

This could have unintended side effects, but I'm not seeing a more granular way to apply timestamp love to just .pyc files.