### PR TITLE
added support for RPM ghost files

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -155,6 +155,14 @@ class FPM::Package::RPM < FPM::Package
     File.expand_path(val) # Get the full path to the script
   end # --posttrans
 
+  rpm_ghost_files = []
+  option "--ghost-file", "FILE",
+    "Adds a ghost file directive under %files in the spec file." \
+    "Example: --rpm-ghost-file '/var/log/blather.log'" do |add_ghost_file|
+      rpm_ghost_files << add_ghost_file
+    next rpm_ghost_files
+  end
+
   ["before-install","after-install","before-uninstall","after-target-uninstall"].each do |trigger_type|
      rpm_trigger = []
      option "--trigger-#{trigger_type}", "'[OPT]PACKAGE: FILEPATH'", "Adds a rpm trigger script located in FILEPATH, " \

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -258,6 +258,9 @@ fi
 <%   next if directories.include?(path)-%>
 <%= rpm_file_entry(path) %>
 <% end -%>
+<% (attributes[:rpm_ghost_file] or []).each do |ghost| -%>
+<%= "%ghost #{ghost}" %>
+<% end -%>
 
 %changelog
 <%= attributes[:rpm_changelog] %>


### PR DESCRIPTION
Moin !
I needed fpm to be able to add ghost files in RPMs. See: [this link](http://ftp.rpm.org/max-rpm/s1-rpm-inside-files-list-directives.html).
Did not had to change a lot. I basically copied the "--rpm-tags" - code.

Regards,
Rüdiger