### PR TITLE
update for latest rubygems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ RUN apk add --no-cache \
         make \
         libc-dev \
         rpm \
-    && gem install --no-ri --no-rdoc fpm
+    && gem install --no-document fpm

--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -36,7 +36,7 @@ Installing FPM
 
 You can install fpm with the `gem` tool::
 
-    gem install --no-ri --no-rdoc fpm
+    gem install --no-document fpm
 
 .. note::
   `gem` is a command provided by a the Ruby packaging system called `rubygems`_. This allows you to install, and later upgrade, fpm.
@@ -45,7 +45,7 @@ You can install fpm with the `gem` tool::
 
 You should see output that looks like this::
 
-    % gem install --no-ri --no-rdoc fpm
+    % gem install --no-document fpm
     Fetching: cabin-0.9.0.gem (100%)
     Successfully installed cabin-0.9.0
     Fetching: backports-3.6.8.gem (100%)

--- a/docs/source/gem.rst
+++ b/docs/source/gem.rst
@@ -95,7 +95,7 @@ First we'll have to download the gem and its deps. The easiest way to do this
 is to stage the installation in a temporary directory, like this::
 
     % mkdir /tmp/gems
-    % gem install --no-ri --no-rdoc --install-dir /tmp/gems cucumber
+    % gem install --no-document --install-dir /tmp/gems cucumber
     <output trimmed>
 
     Successfully installed json-1.4.6

--- a/examples/fpm-with-system-ruby/Makefile
+++ b/examples/fpm-with-system-ruby/Makefile
@@ -35,7 +35,7 @@ $(CHECKOUT_DIR):
 	cd $(CHECKOUT_DIR) && git fetch && git checkout $(TAG_SPEC)
 
 $(BUNDLE_BIN):
-	$(GEM_CMD) install bundler --install-dir=$(GEM_PATH) --no-ri --no-rdoc
+	$(GEM_CMD) install bundler --install-dir=$(GEM_PATH) --no-document
 
 $(FPM_BIN):
 	mkdir --parents $(BIN_DIR)

--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -198,7 +198,7 @@ class FPM::Package::Gem < FPM::Package
 
     ::FileUtils.mkdir_p(installdir)
     # TODO(sissel): Allow setting gem tool path
-    args = [attributes[:gem_gem], "install", "--quiet", "--no-ri", "--no-rdoc",
+    args = [attributes[:gem_gem], "install", "--quiet", "--no-document",
        "--no-user-install", "--install-dir", installdir]
 
     if !attributes[:gem_embed_dependencies?]


### PR DESCRIPTION
This updates the flags to `gems` to use --no-document instead of
--no-ri and --no-rdoc which have been deprecated since the release of
Ruby 2.0.0.

Issue: https://github.com/jordansissel/fpm/issues/1582