### PR TITLE
relax json dependency

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   # For parsing JSON (required for some Python support, etc)
   # http://flori.github.com/json/doc/index.html
-  spec.add_dependency("json", ">= 1.7.7", "< 2.0") # license: Ruby License
+  spec.add_dependency("json", ">= 1.7.7", "< 3.0") # license: Ruby License
 
   # For logging
   # https://github.com/jordansissel/ruby-cabin


### PR DESCRIPTION
rubies >= 2.5 ship with JSON 2.x, so allowing bundler to resolve to newer
implementations eliminates conflicts with dependency trees that include JSON
2.x.

Breaking changes for JSON 2.x include removed support for older rubies [[1]],
so specifying in this manner ensures that older rubies can find 1.x, while
newer ones can resolve to 2.x

[1]: https://github.com/flori/json/blob/master/CHANGES.md#2015-09-11-200

Resolves: https://github.com/jordansissel/fpm/issues/1599