### PR TITLE
Fix a few CPAN issues

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -112,6 +112,8 @@ class FPM::Package::CPAN < FPM::Package
     self.vendor = case metadata["author"]
       when String; metadata["author"]
       when Array; metadata["author"].join(", ")
+      # for Class::Data::Inheritable and others with blank 'author' field, fix "Invalid package configuration: Unexpected CPAN 'author' field type: NilClass. This is a bug."
+      when NilClass; "No Vendor Or Author Provided"
       else
         raise FPM::InvalidPackageConfiguration, "Unexpected CPAN 'author' field type: #{metadata["author"].class}. This is a bug."
     end if metadata.include?("author")

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -304,7 +304,8 @@ class FPM::Package::CPAN < FPM::Package
     directory = build_path("module")
     ::Dir.mkdir(directory)
     args = [ "-C", directory, "-zxf", tarball,
-      "--strip-components", "1" ]
+     #      "--strip-components", "1" ]       # fails    on removing leading ./Foo/ in tarball paths
+            %q{--transform=s,[./]*[^/]*/,,} ]  # succeeds on removing leading ./Foo/ or /Foo/ or Foo/
     safesystem("tar", *args)
     return directory
   end


### PR DESCRIPTION
This builds off of the excellent work done by @wbraswell in #1528.

This PR should fix:
* #1519, #1522 (`fpm -s cpan -t rpm Inline::CPP` hangs on stdin)
* #1517 (Alien::astyle fails due to a bug in FPM's `tar` invocation)
* #1523 (Allow blank author field in CPAN metadata)

Because there are known test failures on master, testing on master vs this PR locally shows:
* master: 13 failures
* this pr: 13 failures

For this, I believe nothing broke in this PR, but the above issues should be fixed. When I test the known cases, they work for me; specifically, the following all fail on master but succeed on this PR.

* `bin/fpm --debug -s cpan -t rpm --no-cpan-test Inline::CPP`
* `bin/fpm --verbose --no-cpan-test -s cpan -t rpm Alien::astyle`
* `bin/fpm --verbose --no-cpan-test -s cpan -t rpm Class::Data::Inheritable`
