### PR TITLE
add --cpan-deps-name-prefix option

### DIFF
--- a/docs/source/perl.rst
+++ b/docs/source/perl.rst
@@ -32,6 +32,7 @@ A full list of available options for CPAN are listed here::
     --cpan-mirror CPAN_MIRROR     (cpan only) The CPAN mirror to use instead of the default.
     --[no-]cpan-mirror-only       (cpan only) Only use the specified mirror for metadata. (default: false)
     --cpan-package-name-prefix NAME_PREFIX (cpan only) Name to prefix the package name with. (default: "perl")
+    --cpan-deps-name-prefix DEPS_PREFIX (cpan only) Name to prefix the package dependency names with. (default: "perl")
     --[no-]cpan-test              (cpan only) Run the tests before packaging? (default: true)
     --cpan-perl-lib-path PERL_LIB_PATH (cpan only) Path of target Perl Libraries
     --[no-]cpan-sandbox-non-core  (cpan only) Sandbox all non-core modules, even if they're already installed (default: true)

--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -22,6 +22,9 @@ class FPM::Package::CPAN < FPM::Package
   option "--package-name-prefix", "NAME_PREFIX",
     "Name to prefix the package name with.", :default => "perl"
 
+  option "--deps-name-prefix", "DEPS_PREFIX",
+    "Name to prefix the package dependency names with.", :default => "perl"
+
   option "--test", :flag,
     "Run the tests before packaging?", :default => true
 
@@ -385,7 +388,8 @@ class FPM::Package::CPAN < FPM::Package
   end # def metadata
 
   def cap_name(name)
-    return "perl(" + name.gsub("-", "::") + ")"
+    deps_name_prefix = attributes[:cpan_deps_name_prefix]
+    return "#{deps_name_prefix}(" + name.gsub("-", "::") + ")"
   end # def cap_name
 
   def fix_name(name)


### PR DESCRIPTION
I need to change path to Perl dependencies when using Perl from SCL (http://ftp.fau.de/centos/7/sclo/x86_64/rh/rh-perl524/) on CentOS. All packages are prefixed and also dependencies are prefixed. This pull request adds `--cpan-deps-name-prefix` option that will add a prefix to all perl dependencies.

Example of usage:

```
  fpm \
    -t rpm \
    -s cpan \
    --cpan-package-name-prefix rh-perl524-perl \
    --cpan-deps-name-prefix rh-perl524-perl \
    --cpan-perl-lib-path /opt/rh/rh-perl524/root/usr/local \
    Carton
```

Dependencies with a `rh-perl524-perl` prefix:

```
[root@0887e002fbf1 /]# rpm -qpR rh-perl524-perl-Carton-v1.0.34-1.noarch.rpm  | grep rh-perl524-perl
rh-perl524-perl(CPAN::Meta) >= 2.120921
rh-perl524-perl(CPAN::Meta::Requirements) >= 2.121
rh-perl524-perl(Class::Tiny) >= 1.001
rh-perl524-perl(Getopt::Long) >= 2.39
rh-perl524-perl(JSON::PP) >= 2.27300
rh-perl524-perl(Module::CPANfile) >= 0.9031
rh-perl524-perl(Module::CoreList)
rh-perl524-perl(Path::Tiny) >= 0.033
rh-perl524-perl(Try::Tiny) >= 0.09
rh-perl524-perl(parent) >= 0.223
```