### PR TITLE
This improves the Oracle Linux install docs 

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -27,9 +27,9 @@ On Fedora 23 or newer::
 
     dnf install ruby-devel gcc make rpm-build libffi-devel
 
-On Oracle Enterprise 7.x systems::
+On Oracle Linux 7.x systems::
 
-    yum-config-manager --add-repo=https://yum.oracle.com/repo/OracleLinux/OL7/optional/developer/x86_64
+    yum-config-manager --enable ol7_optional_latest
     yum install ruby-devel gcc make rpm-build rubygems
 
 On Debian-derived systems (Debian, Ubuntu, etc)::


### PR DESCRIPTION
Remove the additional repo that was added (because it's for developer previews aka betas for Oracle Linux and is unsupported) and enable the `ol7_optional_latest` repo instead (which is the fully supported repo for this stuff).  This ensures that supported packages are installed, including the `ruby-devel` package.

This also corrects the product name.

Signed-off-by: Avi Miller <avi.miller@oracle.com>