### PR TITLE
rpm: add option to enable install-time macro expansion in scripts

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -142,6 +142,10 @@ class FPM::Package::RPM < FPM::Package
            "names in rpm requires instead of the redhat style " \
            "rubygem(foo).", :default => false
 
+  option "--macro-expansion", :flag,
+           "install-time macro expansion in %pre %post %preun %postun scripts " \
+           "(see: https://rpm.org/user_doc/scriptlet_expansion.html)", :default => false
+
   option "--verifyscript", "FILE",
     "a script to be run on verification" do |val|
     File.expand_path(val) # Get the full path to the script

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -126,7 +126,7 @@ Obsoletes: <%= repl %>
 -%>
 <% if script?(:before_upgrade) or script?(:after_upgrade) -%>
 <%   if script?(:before_upgrade) or script?(:before_install) -%>
-%pre
+%pre <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %> <% end -%>
 upgrade() {
 <%# Making sure that at least one command is in the function -%>
 <%# avoids a lot of potential errors, including the case that -%>
@@ -156,7 +156,7 @@ then
 fi
 <%   end -%>
 <%   if script?(:after_upgrade) or script?(:after_install) -%>
-%post
+%post <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %>  <% end -%>
 upgrade() {
 <%# Making sure that at least one command is in the function -%>
 <%# avoids a lot of potential errors, including the case that -%>
@@ -186,7 +186,7 @@ then
 fi
 <%   end -%>
 <%   if script?(:before_remove) -%>
-%preun
+%preun <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %>  <% end -%>
 if [ "${1}" -eq 0 ]
 then
 <%# Making sure that at least one command is in the function -%>
@@ -197,7 +197,7 @@ then
 fi
 <%   end -%>
 <%   if script?(:after_remove) -%>
-%postun
+%postun <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %>  <% end -%>
 if [ "${1}" -eq 0 ]
 then
 <%# Making sure that at least one command is in the function -%>
@@ -219,7 +219,7 @@ fi
 -%>
 <% scriptmap.each do |name, rpmname| -%>
 <%   if script?(name) -%>
-%<%=   rpmname %>
+%<%=   rpmname -%> <%= ' -e' if attributes[:rpm_macro_expansion?] %>
 <%=    script(name) %>
 <%   end -%>
 <% end -%>


### PR DESCRIPTION
 - spec file sections affected: %pre %post %preun %postun