### PR TITLE
Introduce --virtualenv-requirement flag for virtualenv package

### DIFF
--- a/docs/source/virtualenv.rst
+++ b/docs/source/virtualenv.rst
@@ -10,8 +10,9 @@ single egg or from a `requirements.txt` file.  This lets you bundle up a set of
 python dependencies separate from system python that you can then distribute.
 
 .. note::
-   `virtualenv` support requires that you have `virtualenv` and  the
-   `virtualenv-tools` binary on your path.  This can usually be achieved with
+   `virtualenv` support requires that you have `virtualenv` and the
+   `virtualenv-tools` (or `virtualenv-tools3` if you using Python 3) binary on 
+   your path.  This can usually be achieved with
    `pip install virtualenv virtualenv-tools`.
 
 Example uses:
@@ -30,6 +31,15 @@ Create a debian package for your project's python dependencies under `/opt`::
   echo 'SQLAlchemy' >> requirements.txt
   fpm -s virtualenv -t deb --name myapp-python-libs \
     --prefix /opt/myapp/virtualenv requirements.txt
+
+If your requirements file is not name after `requirements.txt`,
+
+  echo 'glade' >> example-requirements.txt
+  echo 'paramiko' >> example-requirements.txt
+  echo 'SQLAlchemy' >> example-requirements.txt
+  fpm -s virtualenv -t deb --name myapp-python-libs \
+    --prefix /opt/myapp/virtualenv \
+    --virtualenv-requirement example-requirements.txt
 
 Create a debian package from a version 0.9 of an egg kept in your internal
 pypi repository, along with it's external dependencies::

--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -46,6 +46,9 @@ class FPM::Package::Virtualenv < FPM::Package
     :multivalued => true, :attribute_name => :virtualenv_find_links_urls,
     :default => nil
 
+  option "--requirement", :flag, "Indicate the included file is a "\
+    "requirements file"
+
   private
 
   # Input a package.
@@ -56,7 +59,8 @@ class FPM::Package::Virtualenv < FPM::Package
     m = /^([^=]+)==([^=]+)$/.match(package)
     package_version = nil
 
-    is_requirements_file = (File.basename(package) == "requirements.txt")
+    is_requirements_file = (File.basename(package) == "requirements.txt" or self.attributes[:virtualenv_requirement?])
+    logger.debug("Detecting requirements file", :is_requirements_file => is_requirements_file)
 
     if is_requirements_file
       if !File.file?(package)


### PR DESCRIPTION
## Problem Statement

It is possible for `requirements.txt` to be named in different file name.

For example, in the [example section of pip documentation](https://pip.pypa.io/en/stable/reference/pip_install/#example-requirements-file), `example-requirements.txt` was used.

Currently the `-r` flag is only applied if the file name is `requirements.txt`.

## Proposal

Introduce `--virtualenv-requirement` flag to indicate the file name provided is a valid requirements file, regardless of its file name.

The proposal above is made in view of backward compatibility of existing `fpm` users.