### PR TITLE
Enable --[no]-virtualenv-pip-upgrade flag. Fixes #1615

### DIFF
--- a/docs/source/virtualenv.rst
+++ b/docs/source/virtualenv.rst
@@ -23,6 +23,10 @@ Build an rpm package for ansible::
   yum install virtualenv-ansible*.rpm
   which ansible # /usr/share/python/ansible/bin/ansible
 
+Build an rpm package for ansible without upgrading pip::
+
+  fpm -s virtualenv -t rpm --no-virtualenv-pip-upgrade ansible
+
 Create a debian package for your project's python dependencies under `/opt`::
 
   echo 'glade' >> requirements.txt
@@ -37,3 +41,4 @@ pypi repository, along with it's external dependencies::
   fpm -s virtualenv -t deb \
     --virtualenv-pypi-extra-url=https://office-pypi.lan/ \
     proprietary-magic=0.9
+

--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -46,6 +46,9 @@ class FPM::Package::Virtualenv < FPM::Package
     :multivalued => true, :attribute_name => :virtualenv_find_links_urls,
     :default => nil
 
+  option "--pip-upgrade", :flag, "Should we perform pip upgrade?",
+    :default => true
+
   private
 
   # Input a package.
@@ -108,10 +111,12 @@ class FPM::Package::Virtualenv < FPM::Package
     pip_exe = File.join(virtualenv_build_folder, "bin", "pip")
     python_exe = File.join(virtualenv_build_folder, "bin", "python")
 
-    # Why is this hack here? It looks important, so I'll keep it in.
-    safesystem(python_exe, pip_exe, "install", "-U", "-i",
-               attributes[:virtualenv_pypi],
-               "pip")
+    if self.attributes[:virtualenv_pip_upgrade?]
+        logger.info("Performing pip upgrade")
+        safesystem(python_exe, pip_exe, "install", "-U", "-i",
+                   attributes[:virtualenv_pypi],
+                   "pip")
+    end
 
     extra_index_url_args = []
     if attributes[:virtualenv_pypi_extra_index_urls]


### PR DESCRIPTION
## Problem Statement

According to #1615, there is no available option to disable pip upgrade when we use `virtualenv` as source package.

## Proposal

Introduce `--[no]-virtualenv-pip-upgrade` to provide a flag to disable pip upgrade.

In view of backward compatibility, it is defaulted to `true` for this flag.