### PR TITLE
Allow virtualenv to use custom python interpreter

### DIFF
--- a/docs/source/virtualenv.rst
+++ b/docs/source/virtualenv.rst
@@ -23,6 +23,10 @@ Build an rpm package for ansible::
   yum install virtualenv-ansible*.rpm
   which ansible # /usr/share/python/ansible/bin/ansible
 
+Build an rpm package for ansible with custom python interpreter::
+
+  fpm -s virtualenv -t rpm --virtualenv-python /usr/local/bin/python3.6 ansible
+
 Create a debian package for your project's python dependencies under `/opt`::
 
   echo 'glade' >> requirements.txt

--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -46,6 +46,10 @@ class FPM::Package::Virtualenv < FPM::Package
     :multivalued => true, :attribute_name => :virtualenv_find_links_urls,
     :default => nil
 
+  option "--python", "PYTHON", "Set custom python interpreter to be used in"\
+    "virtualenv",
+    :default => nil
+
   private
 
   # Input a package.
@@ -98,12 +102,20 @@ class FPM::Package::Virtualenv < FPM::Package
 
     ::FileUtils.mkdir_p(virtualenv_build_folder)
 
+    
+    venv_args = Array.new
+    venv_args << "virtualenv"
     if self.attributes[:virtualenv_system_site_packages?]
-        logger.info("Creating virtualenv with --system-site-packages")
-        safesystem("virtualenv", "--system-site-packages", virtualenv_build_folder)
-    else
-        safesystem("virtualenv", virtualenv_build_folder)
+      logger.info("Creating virtualenv with --system-site-packages")
+      venv_args << "--system-site-packages"
     end
+    if self.attributes[:virtualenv_python]
+      logger.info("Creating virtualenv with --python")
+      venv_args << "-p" << self.attributes[:virtualenv_python]
+    end
+    venv_args << virtualenv_build_folder
+
+    safesystem(*venv_args.flatten)
 
     pip_exe = File.join(virtualenv_build_folder, "bin", "pip")
     python_exe = File.join(virtualenv_build_folder, "bin", "python")


### PR DESCRIPTION
## Problem Statement

There is a possibility the python interpreter is located at non-default location.

`virtualenv` provides `-p`/`--python` [option](https://virtualenv.pypa.io/en/latest/reference/#virtualenv-command) to define a custom python interpreter.

## Proposal

Introduce `--virtualenv-python` to define the custom python interpreter.