### PR TITLE
Allow FPM to be loaded from a environment variable. 

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -524,7 +524,7 @@ class FPM::Command < Clamp::Command
   def run(run_args)
     logger.subscribe(STDOUT)
 
-    # Short circuit for a `fpm --version` or `fpm -v` short invocation that 
+    # Short circuit for a `fpm --version` or `fpm -v` short invocation that
     # is the user asking us for the version of fpm.
     if run_args == [ "-v" ] || run_args == [ "--version" ]
       puts FPM::VERSION
@@ -536,6 +536,7 @@ class FPM::Command < Clamp::Command
     # directory
     rc_files = [ ".fpm" ]
     rc_files << File.join(ENV["HOME"], ".fpm") if ENV["HOME"]
+    rc_files << File.join(ENV["FPMRC"], ".fpm") if ENV["FPMRC"]
 
     rc_args = []
 


### PR DESCRIPTION
I have a use case where I want to do a monorepo and have separate subdirectories. 

An example:
a/.fpm
b/.fpm
.fpm

I want to be able to have a global .fpm for my monorepo and have each service specify there own .fpms to be added.  

I expect the run to look like `FPMRC=a fpm ...`

Hopefully, this will resolve that. Let me know what else needs to be done. 