### PR TITLE
Fixed parameter to gem install

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -41,7 +41,7 @@ Installing FPM
 
 You can install fpm with the `gem` tool::
 
-    gem install --no-ri --no-rdoc fpm
+    gem install --no-document fpm
 
 .. note::
   `gem` is a command provided by a the Ruby packaging system called `rubygems`_. This allows you to install, and later upgrade, fpm.


### PR DESCRIPTION
The two options that were there before do no longer work.
The new option is called '--no-document'