### PR TITLE
Update outdated "gem install" command

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -41,7 +41,7 @@ Installing FPM
 
 You can install fpm with the `gem` tool::
 
-    gem install --no-ri --no-rdoc fpm
+    gem install --no-document fpm
 
 .. note::
   `gem` is a command provided by a the Ruby packaging system called `rubygems`_. This allows you to install, and later upgrade, fpm.


### PR DESCRIPTION
The --no-ri and --no-rdoc switches have now been superseded by --no-document per https://guides.rubygems.org/command-reference/#gem_install