### PR TITLE
Fix https://github.com/jordansissel/fpm/pull/1668

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -785,16 +785,16 @@ class FPM::Package::Deb < FPM::Package
     # Tar up the staging_path into control.tar.{compression type}
     case self.attributes[:deb_compression]
       when "gz", nil
-        controltar = build_path("control.tar.gz")
+        controltar_file = 'control.tar.gz'
         compression = "-z"
       when "bzip2"
-        controltar = build_path("control.tar.bz2")
+        controltar_file = 'control.tar.bz2'
         compression = "-j"
       when "xz"
-        controltar = build_path("control.tar.xz")
+        controltar_file = 'control.tar.xz'
         compression = "-J"
       when "none"
-        controltar = build_path("control.tar")
+        controltar_file = 'control.tar'
         compression = ""
       else
         raise FPM::InvalidPackageConfiguration,
@@ -802,7 +802,7 @@ class FPM::Package::Deb < FPM::Package
     end
 
     # Make the control.tar.gz
-    build_path(controltar).tap do |controltar|
+    build_path(controltar_file).tap do |controltar|
       logger.info("Creating", :path => controltar, :from => control_path)
 
       args = [ tar_cmd, "-C", control_path, compression, "-cf", controltar,


### PR DESCRIPTION
This change created a double path and that causes tar to exit with 2, thus fail...
“/tmp/package-deb-build-010438296705d36edd37559060f917dc7c605c826408d3a142a3bb685358/tmp/package-deb-build-010438296705d36edd37559060f917dc7c605c826408d3a142a3bb685358/control.tar.gz”

`
Writing control file {:path=>"/tmp/package-deb-build-010438296705d36edd37559060f917dc7c605c826408d3a142a3bb685358/control/control", :level=>:debug, :file=>"fpm/package/deb.rb", :line=>"854", :method=>"block in write_control"}
Creating {:path=>"/tmp/package-deb-build-010438296705d36edd37559060f917dc7c605c826408d3a142a3bb685358/tmp/package-deb-build-010438296705d36edd37559060f917dc7c605c826408d3a142a3bb685358/control.tar.gz", :from=>"/tmp/package-deb-build-010438296705d36edd37559060f917dc7c605c826408d3a142a3bb685358/control", :level=>:info, :file=>"fpm/package/deb.rb", :line=>"807", :method=>"block in write_control_tarball"}
`