### PR TITLE
fixed lintian issue for changelog #1575

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -535,7 +535,9 @@ class FPM::Package::Deb < FPM::Package
 
     if File.exists?(dest_changelog) and not File.exists?(dest_upstream_changelog)
       # see https://www.debian.org/doc/debian-policy/ch-docs.html#s-changelogs
-      File.rename(dest_changelog, dest_upstream_changelog)
+      # to solve Lintian rule debian-changelog-file-missing-or-wrong-name the file
+      # is copied and not renamed
+      FileUtils.cp(dest_changelog, dest_upstream_changelog)
     end
 
     attributes.fetch(:deb_init_list, []).each do |init|


### PR DESCRIPTION
Although
https://www.debian.org/doc/debian-policy/ch-docs.html#s-changelogs
states that changelog.Debian.gz should be renamed to changelog.gz when
no upstream-changelog exists lintian complains with
debian-changelog-file-missing-or-wrong-name when doing that.
That's why this change does not rename but copies the changelog file.

Signed-off-by: Andreas Ulm <andreas.ulm@root360.de>