### PR TITLE
deb: Fixes gem pessimistic version constrains for single component versions

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -715,8 +715,13 @@ class FPM::Package::Deb < FPM::Package
       name, version = dep.gsub(/[()~>]/, "").split(/ +/)[0..1]
       nextversion = version.split(".").collect { |v| v.to_i }
       l = nextversion.length
-      nextversion[l-2] += 1
-      nextversion[l-1] = 0
+      if l > 1
+        nextversion[l-2] += 1
+        nextversion[l-1] = 0
+      else
+        # Single component versions ~> 1
+        nextversion[l-1] += 1
+      end
       nextversion = nextversion.join(".")
       return ["#{name} (>= #{version})", "#{name} (<< #{nextversion})"]
     elsif (m = dep.match(/(\S+)\s+\(!= (.+)\)/))


### PR DESCRIPTION
If gem had a version constraint with just major version (e.g., ~>1),
the Debian packages were generated with wrong zero upper limit
(e.g., >= 1 and << 0). This results in unresolvable dependencies.