### PR TITLE
Prepending pyfpm to PYTHONPATH instead of replacing

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -183,7 +183,7 @@ class FPM::Package::Python < FPM::Package
 
     output = ::Dir.chdir(setup_dir) do
       tmp = build_path("metadata.json")
-      setup_cmd = "env PYTHONPATH=#{pylib} #{attributes[:python_bin]} " \
+      setup_cmd = "env PYTHONPATH=#{pylib}:$PYTHONPATH #{attributes[:python_bin]} " \
         "setup.py --command-packages=pyfpm get_metadata --output=#{tmp}"
 
       if attributes[:python_obey_requirements_txt?]


### PR DESCRIPTION
fixes #1710 