### PR TITLE
Update virtualenv documentation for Python3

### DIFF
--- a/docs/source/virtualenv.rst
+++ b/docs/source/virtualenv.rst
@@ -11,8 +11,9 @@ python dependencies separate from system python that you can then distribute.
 
 .. note::
    `virtualenv` support requires that you have `virtualenv` and  the
-   `virtualenv-tools` binary on your path.  This can usually be achieved with
-   `pip install virtualenv virtualenv-tools`.
+   `virtualenv-tools` binary on your path.  
+    - For python2 virtual environments, this can usually be achieved with `pip install virtualenv virtualenv-tools`. 
+    - For python3 virtual environments, use `pip install virtualenv-tools3` instead. 
 
 Example uses:
 =============


### PR DESCRIPTION
Original `virtualenv-tools` causes issues when building Python3 virtual environments. Previously reported in #1491.