### PR TITLE
backports and pacman errors fixed

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -4,7 +4,7 @@ require "pathname" # stdlib
 require "find"
 require "tmpdir" # stdlib
 require "ostruct"
-require "backports/2.0.0/stdlib/ostruct"
+require "backports/latest"
 require "socket" # stdlib, for Socket.gethostname
 require "shellwords" # stdlib, for Shellwords.escape
 require "erb" # stdlib, for template processing
@@ -316,7 +316,7 @@ class FPM::Package
     # the path before returning.
     #
     # Wrapping Find.find in an Enumerator is required for sane operation in ruby 1.8.7,
-    # but requires the 'backports' gem (which is used in other places in fpm)
+    # but requires the 'backports/latest' gem (which is used in other places in fpm)
     return Enumerator.new { |y| Find.find(staging_path) { |path| y << path } } \
       .select { |path| path != staging_path } \
       .select { |path| is_leaf.call(path) } \

--- a/lib/fpm/package/apk.rb
+++ b/lib/fpm/package/apk.rb
@@ -3,7 +3,7 @@ require "fpm/namespace"
 require "fpm/package"
 require "fpm/errors"
 require "fpm/util"
-require "backports"
+require "backports/latest"
 require "fileutils"
 require "digest"
 require 'digest/sha1'

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -3,7 +3,7 @@ require "fpm/namespace"
 require "fpm/package"
 require "fpm/errors"
 require "fpm/util"
-require "backports"
+require "backports/latest"
 require "fileutils"
 require "digest"
 

--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -1,6 +1,6 @@
 require "fpm/package"
 require "fpm/util"
-require "backports"
+require "backports/latest"
 require "fileutils"
 require "find"
 require "socket"

--- a/lib/fpm/package/empty.rb
+++ b/lib/fpm/package/empty.rb
@@ -1,5 +1,5 @@
 require "fpm/package"
-require "backports"
+require "backports/latest"
 
 # Empty Package type. For strict/meta/virtual package creation
 

--- a/lib/fpm/package/freebsd.rb
+++ b/lib/fpm/package/freebsd.rb
@@ -1,4 +1,4 @@
-require "backports" # gem backports
+require "backports/latest" # gem backports/latest
 require "fpm/package"
 require "fpm/util"
 require "digest"

--- a/lib/fpm/package/pacman.rb
+++ b/lib/fpm/package/pacman.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require "fpm/package"
 require "fpm/util"
-require "backports"
+require "backports/latest"
 require "fileutils"
 require "find"
 

--- a/lib/fpm/package/pacman.rb
+++ b/lib/fpm/package/pacman.rb
@@ -257,6 +257,7 @@ class FPM::Package::Pacman < FPM::Package
         copy_entry(path, dst, preserve=true, remove_destination=true)
       rescue
         copy_entry(path, dst, preserve=false, remove_destination=true)
+      end
       copy_metadata(path, dst)
     end
 

--- a/lib/fpm/package/pacman.rb
+++ b/lib/fpm/package/pacman.rb
@@ -18,10 +18,10 @@ class FPM::Package::Pacman < FPM::Package
   option "--group", "GROUP", "The group owner of files in this package", :default => 'root'
 
   # The list of supported compression types. Default is xz (LZMA2)
-  COMPRESSION_TYPES = [ "gz", "bzip2", "xz", "none" ]
+  COMPRESSION_TYPES = [ "gz", "bzip2", "xz", "zstd", "none" ]
 
   option "--compression", "COMPRESSION", "The compression type to use, must " \
-    "be one of #{COMPRESSION_TYPES.join(", ")}.", :default => "xz" do |value|
+    "be one of #{COMPRESSION_TYPES.join(", ")}.", :default => "zstd" do |value|
     if !COMPRESSION_TYPES.include?(value)
       raise ArgumentError, "Pacman compression value of '#{value}' is invalid. " \
         "Must be one of #{COMPRESSION_TYPES.join(", ")}"
@@ -215,6 +215,8 @@ class FPM::Package::Pacman < FPM::Package
         return ""
       when "gz"
         return "-z"
+      when "xz"
+        return "--xz"
       when "bzip2"
         return "-j"
       when "zstd"
@@ -232,6 +234,8 @@ class FPM::Package::Pacman < FPM::Package
         return ""
       when "gz"
         return ".gz"
+      when "zx"
+        return ".xz"
       when "bzip2"
         return ".bz2"
       when "zstd"

--- a/lib/fpm/package/pacman.rb
+++ b/lib/fpm/package/pacman.rb
@@ -253,7 +253,10 @@ class FPM::Package::Pacman < FPM::Package
     Find.find(staging_path) do |path|
       src = path.gsub(/^#{staging_path}/, '')
       dst = build_path(src)
-      copy_entry(path, dst, preserve=true, remove_destination=true)
+      begin
+        copy_entry(path, dst, preserve=true, remove_destination=true)
+      rescue
+        copy_entry(path, dst, preserve=false, remove_destination=true)
       copy_metadata(path, dst)
     end
 

--- a/lib/fpm/package/pacman.rb
+++ b/lib/fpm/package/pacman.rb
@@ -69,6 +69,8 @@ class FPM::Package::Pacman < FPM::Package
                   :removed_dependencies => bogus_dependencies,
                   :fixed_dependencies => @dependencies)
     end
+    print @dependencies
+    print "\n"
     return @dependencies
   end
 

--- a/lib/fpm/package/pacman.rb
+++ b/lib/fpm/package/pacman.rb
@@ -69,8 +69,6 @@ class FPM::Package::Pacman < FPM::Package
                   :removed_dependencies => bogus_dependencies,
                   :fixed_dependencies => @dependencies)
     end
-    print @dependencies
-    print "\n"
     return @dependencies
   end
 

--- a/lib/fpm/package/pacman.rb
+++ b/lib/fpm/package/pacman.rb
@@ -209,31 +209,35 @@ class FPM::Package::Pacman < FPM::Package
 
   def compression_option
     case self.attributes[:pacman_compression]
-      when nil, "xz"
-        return "--xz"
+      when nil, "zstd"
+        return "--zstd"
       when "none"
         return ""
       when "gz"
         return "-z"
       when "bzip2"
         return "-j"
+      when "zstd"
+        return "--zstd"
       else
-        return "--xz"
+        return "--zstd"
       end
   end
 
   def compression_ending
     case self.attributes[:pacman_compression]
-      when nil, "xz"
-        return ".xz"
+      when nil, "zstd"
+        return ".zst"
       when "none"
         return ""
       when "gz"
         return ".gz"
       when "bzip2"
         return ".bz2"
+      when "zstd"
+        return ".zst"
       else
-        return ".xz"
+        return ".zst"
       end
   end
 

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -1,5 +1,5 @@
 require "fpm/package"
-require "backports"
+require "backports/latest"
 require "fileutils"
 require "find"
 require "arr-pm/file" # gem 'arr-pm'

--- a/lib/fpm/package/sh.rb
+++ b/lib/fpm/package/sh.rb
@@ -3,7 +3,7 @@ require "fpm/namespace"
 require "fpm/package"
 require "fpm/errors"
 require "fpm/util"
-require "backports"
+require "backports/latest"
 require "fileutils"
 require "digest"
 

--- a/lib/fpm/package/tar.rb
+++ b/lib/fpm/package/tar.rb
@@ -1,4 +1,4 @@
-require "backports" # gem backports
+require "backports/latest" # gem backports/latest
 require "fpm/package"
 require "fpm/util"
 require "fileutils"

--- a/lib/fpm/package/zip.rb
+++ b/lib/fpm/package/zip.rb
@@ -1,4 +1,4 @@
-require "backports" # gem backports
+require "backports/latest" # gem backports/latest
 require "fpm/package"
 require "fpm/util"
 require "fileutils"

--- a/lib/fpm/util/tar_writer.rb
+++ b/lib/fpm/util/tar_writer.rb
@@ -29,7 +29,7 @@ end # module FPM
 
 module FPM; module Util; end; end
 
-# Like the ::Gem::Package::TarWriter but contains some backports and bug fixes
+# Like the ::Gem::Package::TarWriter but contains some backports/latest and bug fixes
 class FPM::Util::TarWriter < ::Gem::Package::TarWriter
   if FPM::Issues::TarWriter.has_issues_with_split_name?
     def split_name(name)

--- a/spec/fpm/package/pacman_spec.rb
+++ b/spec/fpm/package/pacman_spec.rb
@@ -5,7 +5,7 @@ require "fpm/package/pacman" # local
 require "stud/temporary"
 
 describe FPM::Package::Pacman do
-  let(:target) { Stud::Temporary.pathname + ".pkg.tar.xz" }
+  let(:target) { Stud::Temporary.pathname + ".pkg.tar.zst" }
   after do
     subject.cleanup
     File.unlink(target) if File.exist?(target)
@@ -59,7 +59,7 @@ describe FPM::Package::Pacman do
 
     it "should have a default output usable as a filename" do
       # This is the default filename I see commonly produced by debuild
-      insist { subject.to_s } == "name-123-100-any.pkg.tar.xz"
+      insist { subject.to_s } == "name-123-100-any.pkg.tar.zst"
     end
 
     context "when iteration is nil" do
@@ -69,7 +69,7 @@ describe FPM::Package::Pacman do
 
       it "should have an iteration of `1`" do
         # This is the default filename I see commonly produced by debuild
-        expect(subject.to_s).to(be == "name-123-1-any.pkg.tar.xz")
+        expect(subject.to_s).to(be == "name-123-1-any.pkg.tar.zst")
       end
     end
   end


### PR DESCRIPTION
Please consider this pull request. It fixes the backports error warning, as well as changes the compression standard for pacman to zsdt which is the current standard. The build still fails two test. One has to do with copy_entry preserve flag not working in Linux (at least on Arch). and the other has to do with python #! which I didn't mess with. 
Note I'm not all that familiar with ruby code so please take my edits with grain of salt.