### PR TITLE
virtualenv.rst: fix heading level

### DIFF
--- a/docs/source/virtualenv.rst
+++ b/docs/source/virtualenv.rst
@@ -15,7 +15,7 @@ python dependencies separate from system python that you can then distribute.
    `pip install virtualenv virtualenv-tools`.
 
 Example uses:
-=============
+-------------
 
 Build an rpm package for ansible::
 


### PR DESCRIPTION
This makes the "Example uses" heading a subsection of the virtualenv section.