### PR TITLE
Call safesystem() with a list

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -163,7 +163,7 @@ class FPM::Package::Python < FPM::Package
         want_pkg,
       ]
       
-      safesystem(setup_cmd*" ")
+      safesystem(*setup_cmd)
     end
 
     # easy_install will put stuff in @tmpdir/packagename/, so find that:


### PR DESCRIPTION
instead of a space-separated argument string

Tested with this command:

    bundle exec bin/fpm --debug -s python -t deb --python-pip =pip django

And verified that safesystem() to invoke pip is given a list.

Mentioned this here:
https://github.com/jordansissel/fpm/pull/1737#discussion_r560474705