### PR TITLE
Ensure an if-then-else doesn't have an empty if block

### DIFF
--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -20,6 +20,7 @@ debsystemctl=$(command -v deb-systemd-invoke || echo systemctl)
 <% attributes[:deb_systemd].each do |service| -%>
 if ! systemctl is-enabled <%= service %> >/dev/null 
 then
+  : # Ensure this if-clause is not empty. If it were empty, and we had an 'else', then it is an error in shell syntax
 <% if attributes[:deb_systemd_enable?]-%>
     systemctl enable <%= service %> >/dev/null || true
 <% end -%>


### PR DESCRIPTION
Issue #1749

This should help prevent errors like this during deb package installation:

```
/var/lib/dpkg/info/jagos.postinst: 71: /var/lib/dpkg/info/jagos.postinst: Syntax error: \"else\" unexpected
dpkg: error processing package jagos (--install):
installed jagos package post-installation script subprocess returned error exit status 2
```