### PR TITLE
Add back newlines after sections with macro expansion

### DIFF
--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -126,7 +126,7 @@ Obsoletes: <%= repl %>
 -%>
 <% if script?(:before_upgrade) or script?(:after_upgrade) -%>
 <%   if script?(:before_upgrade) or script?(:before_install) -%>
-%pre <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %> <% end -%>
+%pre <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %> <% end %>
 upgrade() {
 <%# Making sure that at least one command is in the function -%>
 <%# avoids a lot of potential errors, including the case that -%>
@@ -156,7 +156,7 @@ then
 fi
 <%   end -%>
 <%   if script?(:after_upgrade) or script?(:after_install) -%>
-%post <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %>  <% end -%>
+%post <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %>  <% end %>
 upgrade() {
 <%# Making sure that at least one command is in the function -%>
 <%# avoids a lot of potential errors, including the case that -%>
@@ -186,7 +186,7 @@ then
 fi
 <%   end -%>
 <%   if script?(:before_remove) -%>
-%preun <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %>  <% end -%>
+%preun <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %>  <% end %>
 if [ "${1}" -eq 0 ]
 then
 <%# Making sure that at least one command is in the function -%>
@@ -197,7 +197,7 @@ then
 fi
 <%   end -%>
 <%   if script?(:after_remove) -%>
-%postun <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %>  <% end -%>
+%postun <% if attributes[:rpm_macro_expansion?] -%><%= " -e " %>  <% end %>
 if [ "${1}" -eq 0 ]
 then
 <%# Making sure that at least one command is in the function -%>


### PR DESCRIPTION
The previous commit eats too much whitespace after the section headers
(`%pre`, `%post` etc.). There should remain a newline.

Correct versions (for `%pre`):

```
%pre
ugrade () {
```

and

```
%pre -e
upgrade() {
```

Without this patch, we get these (wrong):

```
%pre ugrade () {
```

and

```
%pre -e upgrade() {
```

(exact number of spaces can be different, but should not be relevant)

Fixes #1750

Signed-off-by: Jo Vandeginste <Jo.Vandeginste@kuleuven.be>