### PR TITLE
Fix broken postinst script

### DIFF
--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -20,6 +20,7 @@ debsystemctl=$(command -v deb-systemd-invoke || echo systemctl)
 <% attributes[:deb_systemd].each do |service| -%>
 if ! systemctl is-enabled <%= service %> >/dev/null 
 then
+    :
 <% if attributes[:deb_systemd_enable?]-%>
     systemctl enable <%= service %> >/dev/null || true
 <% end -%>


### PR DESCRIPTION
`:` is required to make sure the final postinst-script is legal. Otherwise, it will be looks as below, sometimes,

```sh
if ! systemctl is-enabled <%= service %> >/dev/null 
then   # <--- broken here
else
    $debsystemctl restart <%= service %> >/dev/null || true
fi
```