### PR TITLE
[rpm] Escape single quotes in file names listed in `%files`

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -190,14 +190,15 @@ class FPM::Package::RPM < FPM::Package
   # Replace ? with [?] to make rpm not use globs
   # Replace % with [%] to make rpm not expand macros
   def rpm_fix_name(name)
-    name = name.gsub(/(\ |\[|\]|\*|\?|\%|\$)/, {
+    name = name.gsub(/(\ |\[|\]|\*|\?|\%|\$|')/, {
       ' ' => '?',
       '%' => '[%]',
       '$' => '[$]',
       '?' => '[?]',
       '*' => '[*]',
       '[' => '[\[]',
-      ']' => '[\]]'
+      ']' => '[\]]',
+      "'" => "\\'",
     })
   end
 


### PR DESCRIPTION
Fixes #1773