### PR TITLE
Add rexml as dependency

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -64,6 +64,10 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("stud")
 
+  # In Ruby 3.0, rexml was moved to a bundled gem instead of a default one,
+  # so I think this needs to be added explicitly?
+  spec.add_dependency("rexml")
+
   spec.add_development_dependency("rspec", "~> 3.0.0") # license: MIT (according to wikipedia)
   spec.add_development_dependency("insist", "~> 1.0.0") # license: Apache 2
   spec.add_development_dependency("pry")


### PR DESCRIPTION
Previously, rexml was included standard in Ruby. However, in 3.0.0, ruby
moved this library to be a "bundled gem", per the release notes:

https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/

> The following default gems are now bundled gems.
> * rexml

Tested on Ruby 2.7.0 and 3.0.1 w/ bundler and it works.

```
% (rbenv shell 3.0.1; bundle install; bundle exec bin/fpm -s empty -t empty -n example)
% (rbenv shell 2.7.0; bundle install; bundle exec bin/fpm -s empty -t empty -n example)
```

Fixes #1793