### PR TITLE
Work in progress: Remove FFI as a dependency

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -46,11 +46,6 @@ Gem::Specification.new do |spec|
   # Ref: https://github.com/jordansissel/fpm/issues/1592
   spec.add_dependency("childprocess", "< 1.0.0") # license: ???
 
-  # For calling functions in dynamic libraries
-  # This is pinned because 1.13.0 requires Ruby 2.3 or later
-  # Ref: https://github.com/jordansissel/fpm/issues/1708
-  spec.add_dependency("ffi", "~> 1.12.0") # license: GPL3/LGPL3
-
   spec.add_development_dependency("rake", "~> 10") # license: MIT
 
   # For creating FreeBSD package archives (xz-compressed tars)

--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -41,11 +41,6 @@ Gem::Specification.new do |spec|
   # https://github.com/mdub/clamp/blob/master/README.markdown
   spec.add_dependency("clamp", "~> 1.0.0") # license: MIT
 
-  # For starting external processes across various ruby interpreters
-  # Note: This is pinned because v1.0.0 fails to install for multiple users.
-  # Ref: https://github.com/jordansissel/fpm/issues/1592
-  spec.add_dependency("childprocess", "< 1.0.0") # license: ???
-
   spec.add_development_dependency("rake", "~> 10") # license: MIT
 
   # For creating FreeBSD package archives (xz-compressed tars)

--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -43,9 +43,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency("rake", "~> 10") # license: MIT
 
-  # For creating FreeBSD package archives (xz-compressed tars)
-  spec.add_dependency("ruby-xz", "~> 0.2.3") # license: MIT
-
   # For sourcing from pleaserun
   spec.add_dependency("pleaserun", "~> 0.0.29") # license: Apache 2
 

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -1,5 +1,4 @@
 require "fpm/namespace"
-require "childprocess"
 require "fileutils"
 
 # Some utility functions

--- a/spec/fpm/package/cpan_spec.rb
+++ b/spec/fpm/package/cpan_spec.rb
@@ -10,7 +10,11 @@ end
 
 is_travis = ENV["TRAVIS_OS_NAME"] && !ENV["TRAVIS_OS_NAME"].empty?
 
-describe FPM::Package::CPAN, :if => have_cpanm do
+describe FPM::Package::CPAN do
+  before do
+    skip("Missing cpanm program") unless have_cpanm
+  end
+
   subject { FPM::Package::CPAN.new }
 
   after :each do

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -247,7 +247,11 @@ describe FPM::Package::Deb do
     end # package attributes
 
     # This section mainly just verifies that 'dpkg-deb' can parse the package.
-    context "when read with dpkg", :if => have_dpkg_deb do
+    context "when read with dpkg" do
+      before do
+        skip("Missing dpkg-deb program") unless have_dpkg_deb
+      end
+
       def dpkg_field(field)
         return `dpkg-deb -f #{target} #{field}`.chomp
       end # def dpkg_field
@@ -380,7 +384,11 @@ describe FPM::Package::Deb do
       FileUtils.rm_r staging_path if File.exist? staging_path
     end # after
 
-    context "when run against lintian", :if => have_lintian do
+    context "when run against lintian" do
+      before do
+        skip("Missing lintian program") unless have_lintian 
+      end
+
       lintian_errors_to_ignore = [
         "no-copyright-file",
         "script-in-etc-init.d-not-registered-via-update-rc.d"

--- a/spec/fpm/package/gem_spec.rb
+++ b/spec/fpm/package/gem_spec.rb
@@ -8,7 +8,11 @@ if !have_gem
     .warn("Skipping Gem#input tests because 'gem' isn't in your PATH")
 end
 
-describe FPM::Package::Gem, :if => have_gem do
+describe FPM::Package::Gem do
+  before do
+    skip("Missing program 'gem'") unless program_exists?("gem")
+  end
+
   let (:example_gem) do
     File.expand_path("../../fixtures/gem/example/example-1.0.gem", File.dirname(__FILE__))
   end

--- a/spec/fpm/package/npm_spec.rb
+++ b/spec/fpm/package/npm_spec.rb
@@ -13,7 +13,11 @@ describe FPM::Package::NPM do
     subject.cleanup
   end
 
-  describe "::default_prefix", :if => have_npm do
+  describe "::default_prefix" do
+    before do
+      skip("Missing npm program") unless have_npm
+    end
+
     it "should provide a valid default_prefix" do
       stat = File.stat(FPM::Package::NPM.default_prefix)
       insist { stat }.directory?

--- a/spec/fpm/package/osxpkg_spec.rb
+++ b/spec/fpm/package/osxpkg_spec.rb
@@ -34,8 +34,13 @@ describe FPM::Package::OSXpkg do
     end
   end
 
-  describe "#output", :if => platform_is_darwin do
+  describe "#output" do
+    before do
+      skip("Current platform is not darwin/osx") unless platform_is_darwin
+    end
+
     before :all do
+      skip("Current platform is not darwin/osx") unless platform_is_darwin
       # output a package, use it as the input, set the subject to that input
       # package. This helps ensure that we can write and read packages
       # properly.

--- a/spec/fpm/package/pacman_spec.rb
+++ b/spec/fpm/package/pacman_spec.rb
@@ -4,6 +4,25 @@ require "fpm" # local
 require "fpm/package/pacman" # local
 require "stud/temporary"
 
+
+if !program_exists?("bsdtar")
+  Cabin::Channel.get("rspec") \
+    .warn("Skipping Pacman tests because 'bsdtar' isn't in your PATH")
+end
+
+if !program_exists?("zstd")
+  Cabin::Channel.get("rspec") \
+    .warn("Skipping Pacman tests because 'zstd' isn't in your PATH")
+end
+
+def skip?
+  missing = []
+  missing << "bsdtar" unless program_exists?("bsdtar")
+  missing << "zstd" unless program_exists?("zstd")
+  return nil if missing.empty?
+  return "Missing programs: #{missing.join(", ")}"
+end
+
 describe FPM::Package::Pacman do
   let(:target) { Stud::Temporary.pathname + ".pkg.tar.zst" }
   after do
@@ -80,6 +99,7 @@ describe FPM::Package::Pacman do
 
     context "Test that empty epoch is tested properly" do
       before do
+        skip(skip?) if skip?
 
         original.name = "foo"
         original.version = "123"
@@ -90,18 +110,26 @@ describe FPM::Package::Pacman do
         input.input(target)
       end
       it "should have the correct name" do
+        skip("Missing bsdtar") unless program_exists?("bsdtar")
+        skip("Missing zstd") unless program_exists?("zstd")
         insist { input.name } == original.name
       end
 
       it "should have the correct version" do
+        skip("Missing bsdtar") unless program_exists?("bsdtar")
+        skip("Missing zstd") unless program_exists?("zstd")
         insist { input.version } == original.version
       end
 
       it "should have the correct iteration" do
+        skip("Missing bsdtar") unless program_exists?("bsdtar")
+        skip("Missing zstd") unless program_exists?("zstd")
         insist { input.iteration } == original.iteration
       end
 
       it "should have the correct epoch" do
+        skip("Missing bsdtar") unless program_exists?("bsdtar")
+        skip("Missing zstd") unless program_exists?("zstd")
         insist { input.epoch } == original.epoch
       end
     end
@@ -109,6 +137,8 @@ describe FPM::Package::Pacman do
 
     context "normal tests" do
       before do
+        skip(skip?) if skip?
+        
         # output a package, use it as the input, set the subject to that input
         # package. This helps ensure that we can write and read packages
         # properly.
@@ -184,6 +214,8 @@ describe FPM::Package::Pacman do
         [:before_install, :after_install, :before_remove, :after_remove,
          :before_upgrade, :after_upgrade].each do |script|
           it "should be the same both with input as with original for #{script.to_s}" do
+            skip("Missing bsdtar") unless program_exists?("bsdtar")
+            skip("Missing zstd") unless program_exists?("zstd")
             expect( \
                    (input.scripts[script] =~ \
                     /[\n :]+#{Regexp.quote(original.scripts[script])}/m \
@@ -208,6 +240,8 @@ describe FPM::Package::Pacman do
          "/var/lib" => 0755,
          "/var/lib/foo" => 0755}.each do |dir, perm|
            it "should preserve file permissions for #{dir}" do
+             skip("Missing bsdtar") unless program_exists?("bsdtar")
+             skip("Missing zstd") unless program_exists?("zstd")
              insist { File.stat(File.join(input.staging_path,
                                           dir)).mode & 07777 } == perm
            end
@@ -216,18 +250,26 @@ describe FPM::Package::Pacman do
 
       context "package attributes" do
         it "should have the correct name" do
+          skip("Missing bsdtar") unless program_exists?("bsdtar")
+          skip("Missing zstd") unless program_exists?("zstd")
           insist { input.name } == original.name
         end
 
         it "should have the correct version" do
+          skip("Missing bsdtar") unless program_exists?("bsdtar")
+          skip("Missing zstd") unless program_exists?("zstd")
           insist { input.version } == original.version
         end
 
         it "should have the correct iteration" do
+          skip("Missing bsdtar") unless program_exists?("bsdtar")
+          skip("Missing zstd") unless program_exists?("zstd")
           insist { input.iteration } == original.iteration
         end
 
         it "should have the correct epoch" do
+          skip("Missing bsdtar") unless program_exists?("bsdtar")
+          skip("Missing zstd") unless program_exists?("zstd")
           insist { input.epoch } == original.epoch
         end
 

--- a/spec/fpm/package/python_spec.rb
+++ b/spec/fpm/package/python_spec.rb
@@ -26,7 +26,11 @@ def easy_install_default(python_bin, option)
   return result
 end
 
-describe FPM::Package::Python, :if => python_usable? do
+describe FPM::Package::Python do
+  before do
+    skip("Python and/or easy_install not found") unless python_usable?
+  end
+
   let (:example_dir) do
     File.expand_path("../../fixtures/python/", File.dirname(__FILE__))
   end

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -140,7 +140,11 @@ describe FPM::Package::RPM do
     end # context
   end
 
-  describe "#output", :if => program_exists?("rpmbuild") do
+  describe "#output" do
+    before do
+      skip("Missing rpmbuild program") unless program_exists?("rpmbuild")
+    end
+
     context "architecture" do
       it "can be basically anything" do
         subject.name = "example"
@@ -484,7 +488,11 @@ describe FPM::Package::RPM do
     end
   end
 
-  describe "regressions should not occur", :if => program_exists?("rpmbuild") do
+  describe "regressions should not occur" do
+    before do
+      skip("Missing rpmbuild program") unless program_exists?("rpmbuild")
+    end
+
     before :each do
       @tempfile_handle =
       @target = Stud::Temporary.pathname
@@ -582,7 +590,11 @@ describe FPM::Package::RPM do
     end
   end # regression stuff
 
-  describe "input validation stuff", :if => program_exists?("rpmbuild") do
+  describe "input validation stuff" do
+    before do
+      skip("Missing rpmbuild program") unless program_exists?("rpmbuild")
+    end
+
     before :each do
       @tempfile_handle =
       @target = Stud::Temporary.pathname
@@ -705,14 +717,16 @@ describe FPM::Package::RPM do
       File.delete(target) rescue nil
     end
 
-    it "should respect file user and group ownership", :if => program_exists?("rpmbuild") do
+    it "should respect file user and group ownership" do
+      skip("Missing rpmbuild program") unless program_exists?("rpmbuild")
       subject.attributes[:rpm_use_file_permissions?] = true
       subject.output(target)
       insist { rpm.tags[:fileusername].first } == Etc.getpwuid(path_stat.uid).name
       insist { rpm.tags[:filegroupname].first } == Etc.getgrgid(path_stat.gid).name
     end
 
-    it "rpm_group should override rpm_use_file_permissions-derived owner", :if => program_exists?("rpmbuild") do
+    it "rpm_group should override rpm_use_file_permissions-derived owner" do
+      skip("Missing rpmbuild program") unless program_exists?("rpmbuild")
       subject.attributes[:rpm_use_file_permissions?] = true
       subject.attributes[:rpm_user] = "hello"
       subject.attributes[:rpm_group] = "world"
@@ -722,7 +736,11 @@ describe FPM::Package::RPM do
     end
   end
 
-  describe "#output with digest and compression settings", :if => program_exists?("rpmbuild") do
+  describe "#output with digest and compression settings" do
+    before do
+      skip("Missing rpmbuild program") unless program_exists?("rpmbuild")
+    end
+
     context "bzip2/sha1" do
       before :each do
         @target = Stud::Temporary.pathname

--- a/spec/fpm/package/sh_spec.rb
+++ b/spec/fpm/package/sh_spec.rb
@@ -9,7 +9,11 @@ if !shell_is_bash
 end
 
 describe FPM::Package::Sh do
-  describe "#output", :if => shell_is_bash do
+  describe "#output" do
+    before do
+      skip("Shell (SHELL env) is not bash") unless shell_is_bash
+    end
+
     def make_sh_package
       # output a package, use it as the input, set the subject to that input
       # package. This helps ensure that we can write and read packages

--- a/spec/fpm/package/virtualenv_spec.rb
+++ b/spec/fpm/package/virtualenv_spec.rb
@@ -12,7 +12,10 @@ if !virtualenv_usable?
     "no virtualenv/tools bin on your path")
 end
 
-describe FPM::Package::Virtualenv, :if => virtualenv_usable? do
+describe FPM::Package::Virtualenv do
+  before do
+    skip("virtualenv and/or virtualenv-tools programs not found") unless virtualenv_usable?
+  end
 
   after :each do
     subject.cleanup


### PR DESCRIPTION
In this PR, the following changes shall occur:

* [X] Replace ChildProcess library with Ruby standard `Process.spawn`
* [X] Replace FFI providing `mknod` syscall with Ruby standard methods, where possible.
* [x] Replace FreeBSD package support `xz` library with external `xz` program.

Acceptance criteria: fpm can be installed without any `ffi` gem dependency.

Expected outcomes, all of the following:
* Ruby 2.0-2.2 shall be supported again? (Needs more research)
* New Apple M1 Macs shall be able to use fpm successfully.
* Newer Arch systems which ship only Ruby FFI 1.15 shall be able to use fpm successfully

This PR aims to address issues listed in #1795 