### PR TITLE
add 'brew install rpm' as a prerequisite in the OSX/macOS section

### DIFF
--- a/docs/installing.rst
+++ b/docs/installing.rst
@@ -18,6 +18,8 @@ like OSX, come with Ruby already, but some do not. Depending on your operating s
 On OSX/macOS::
 
     brew install gnu-tar
+    
+    brew install rpm
 
 On Red Hat systems (Fedora 22 or older, CentOS, etc)::
 


### PR DESCRIPTION
add 'brew install rpm' as a prerequisite in the OSX/macOS section