### PR TITLE
Allow versions in `Provides` field for Debian packages

### DIFF
--- a/spec/conversion/gem_to_deb.rb
+++ b/spec/conversion/gem_to_deb.rb
@@ -1,0 +1,36 @@
+require "spec_setup"
+require "fpm/command" # local
+require "fpm/package/deb" # local
+require "fpm/package/gem" # local
+require "stud/temporary"
+
+describe "-s gem -t deb" do
+  # dpkg-deb lets us query deb package files.
+  # Comes with debian and ubuntu systems.
+  have_dpkg_deb = program_exists?("dpkg-deb")
+  if !have_dpkg_deb
+    Cabin::Channel.get("rspec") \
+      .warn("Skipping some deb tests because 'dpkg-deb' isn't in your PATH")
+  end
+
+  let(:fpm) { FPM::Command.new("fpm") }
+
+  let(:target) { Stud::Temporary.pathname + ".deb" }
+
+  after do
+    File.unlink(target) if File.exist?(target)
+  end
+
+  before do
+    insist { fpm.run(["-s", "gem", "-t", "deb", "-p", target, "rails"]) } == 0
+  end
+
+  it "should have a correctly formatted Provides field" do
+    deb = FPM::Package::Deb.new
+    deb.input(target)
+
+    # Converting gem->deb should format the deb Provides field as "rubygem-rails (= version)"
+    insist { deb.provides.first } =~ /^rubygem-rails \(= \d+\.\d+\.\d+\)$/
+  end
+
+end # describe "-s gem -t deb"

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -143,7 +143,7 @@ describe FPM::Package::Deb do
       original.architecture = "all"
       original.dependencies << "something > 10"
       original.dependencies << "hello >= 20"
-      original.provides << "#{original.name} = #{original.version}"
+      original.provides << "#{original.name} (= #{original.version})"
 
       # Test to cover PR#591 (fix provides names)
       original.provides << "Some-SILLY_name"
@@ -234,11 +234,6 @@ describe FPM::Package::Deb do
         original.dependencies.each do |dep|
           insist { input.dependencies }.include?(dep)
         end
-      end
-
-      it "should ignore versions and conditions in 'provides' (#280)" do
-        # Provides is an array because rpm supports multiple 'provides'
-        insist { input.provides }.include?(original.name)
       end
 
       it "should fix capitalization and underscores-to-dashes (#591)" do

--- a/spec/fpm/package/osxpkg_spec.rb
+++ b/spec/fpm/package/osxpkg_spec.rb
@@ -60,8 +60,8 @@ describe FPM::Package::OSXpkg do
     end
 
     after :all do
-      @original.cleanup
-      @input.cleanup
+      @original.cleanup if @original
+      @input.cleanup if @input
     end # after
 
     context "package attributes" do

--- a/templates/deb.erb
+++ b/templates/deb.erb
@@ -25,7 +25,7 @@ Build-Depends: <%= attributes[:deb_build_depends].collect { |d| fix_dependency(d
 <% if !provides.empty? -%>
 <%# Turn each provides from 'foo = 123' to simply 'foo' because Debian :\ -%>
 <%#  http://www.debian.org/doc/debian-policy/ch-relationships.html -%>
-Provides: <%= provides.map {|p| p.split(" ").first}.join ", " %>
+Provides: <%= provides.join ", " %>
 <% end -%>
 <% if !replaces.empty? -%>
 Replaces: <%= replaces.collect { |d| fix_dependency(d) }.flatten.join(", ") %>


### PR DESCRIPTION
(more history/research for this PR available in the parent issue #1788)

---

This fixes #1788. This also reverts #280. For #280, at the time, this
change to ignore versions was correct. Two years after #280, Debian
began allowing `Provides` field to have versions.

This change also fixes bug in gem-to-deb conversion where previously an
incorrect Provides syntax would be generated (but thanks to #280,
removed), so this bug was only noticed after #280 was undone!

Computers are hard sometimes.

Added tests for gem-to-deb conversion specifically for the Provides
field.

Tested manually with Docker on Ubuntu 14.04 and 18.04 and results meet
expectations.

The history here is follows:
* In 2012, fpm was patched to remove version specifiers in Provides
  field because Debian didn't support it.
* In 2014, Debian dpkg[1] added support for versions in Provides field
* Somewhere between 2015-2018, Debian and Ubuntu included this new
  version of dpkg.
* Debian packaging policy docs (v4.4.0) was updated to allow versions
  in the Provides field.

Expected impacts:
* Older versions of dpkg/etc should _ignore_ the presence of a version
  specifier. Testing on Ubuntu 14.04 confirmed this.
* Newer versions of dpkg/etc should respect the presence of a version
  specifier. Testing on Ubuntu 18.04 confirmed this.

[1] https://launchpad.net/debian/+source/dpkg/1.17.11
