### PR TITLE
FreeBSD package: Fix missing leading `/` in archive

### DIFF
--- a/lib/fpm/package/freebsd.rb
+++ b/lib/fpm/package/freebsd.rb
@@ -86,9 +86,7 @@ class FPM::Package::FreeBSD < FPM::Package
     # We use --files-from here to keep the tar entries from having `./` as the prefix.
     # This is done as a best effor to mimic what FreeBSD packages do, having everything at the top-level as
     # file names, like "+MANIFEST" instead of "./+MANIFEST"
-    # Note: This will include top-level files like "/usr/bin/foo" listed in the tar as "usr/bin/fo" without
-    # a leading slash. I don't know if this has any negative impact on freebsd packages.
-    safesystem("tar", "-Jcf", output_path, "-C", staging_path, "--files-from", build_path("file_list"))
+    safesystem("tar", "-Jcf", output_path, "-C", staging_path, "--files-from", build_path("file_list"), "--transform", 's|^\([^+]\)|/\1|')
   end # def output
 
   # Handle architecture naming conversion:


### PR DESCRIPTION
This is a simple workaround, which transforms the filenames inside the
tar archive so that they start with `/`. This happens only in case
the filename doesn't begin with `+`, which is expected (or at least is
very likely) to be a metadata file.

```
$ tar --list -f test-package-0.0.1.txz
+COMPACT_MANIFEST
+MANIFEST
/etc/config
/usr/bin/script

$ pkg install -y test-package-0.0.1.txz && echo OK
Updating FreeBSD repository catalogue...
FreeBSD repository is up to date.
All repositories are up to date.
Checking integrity... done (0 conflicting)
The following 1 package(s) will be affected (of 0 checked):

New packages to be INSTALLED:
	test-package: 0.0.1

Number of packages to be installed: 1
[1/1] Installing test-package-0.0.1...
Extracting test-package-0.0.1: 100%
OK
```

Fixes #1811

Signed-off-by: Vlastimil Holer <vholer@opennebula.io>