### PR TITLE
Parse ~= operator according to PEP440 rules (compatible versions allowed)

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -162,7 +162,7 @@ class FPM::Package::Python < FPM::Package
         target,
         want_pkg,
       ]
-      
+
       safesystem(*setup_cmd)
     end
 
@@ -267,9 +267,41 @@ class FPM::Package::Python < FPM::Package
         next if attributes[:python_disable_dependency].include?(name)
 
         # convert == to =
-        if cmp == "==" or cmp == "~="
+        if cmp == "=="
           logger.info("Converting == dependency requirement to =", :dependency => dep )
           cmp = "="
+        elsif cmp == "~="
+          logger.info("Converting ~= dependency requirement to <,>=", :dependency => dep )
+          cmp = ">="
+
+          # PEP 440 - https://www.python.org/dev/peps/pep-0440/#compatible-release
+          # Note: rpm and deb packages do not allow wildcard dependency versions like 2.*
+          # Therefore we use >= 2.2, < 3.0 as the closest correct interpretation of the proposed >= 2.2, == 2.*
+          # Other examples:
+          # ~= 2.2
+          # >= 2.2, < 3.0
+          #
+          # ~= 1.4.5
+          # >= 1.4.5, < 1.5.0
+          #
+          # ~= 2.2.post3
+          # >= 2.2.post3, < 3.0
+          #
+          # ~= 1.4.5a4
+          # >= 1.4.5a4, < 1.5.0
+          #
+          # ~= 2.2.0
+          # >= 2.2.0, < 2.3.0
+          version_arr = version.split(".")
+          version_last = version_arr.pop  # drop last number (make it 0)
+          while /[a-z]/.match(version_last)  # drop post, pre, and dev release numbers
+            version_last = version_arr.pop
+          end
+          version_last = version_arr.pop  # get successor of next-to-last number
+          version_arr << (version_last.to_i + 1).to_s
+          version_arr << "0"
+          nextversion = version_arr.join(".")
+          self.dependencies << "#{name} < #{nextversion}"
         end
 
         # dependency name prefixing is optional, if enabled, a name 'foo' will


### PR DESCRIPTION
Currently python dependency versions using `~=` are converted to `=`
This changes that to a version range using `>=` and `<` according to the rules specified in PEP440 (https://www.python.org/dev/peps/pep-0440/#compatible-release)

Note that PEP440 actually specifies using `>= <major>.<minor>` and `== <major>.*`.
However at least .deb packages do not allow wildcards, so ie. instead of `== 2.*` I opted for `< 3.0`, which together with the `>= 2.2` would have the same effect and which would work as expected in any package type.