### PR TITLE
By default, use pip for fetching and installing python packages.

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -81,7 +81,7 @@ class FPM::Package::Python < FPM::Package
     :multivalued => true, :attribute_name => :python_setup_py_arguments,
     :default => [] 
   option "--internal-pip", :flag,
-    "Use the pip module within python to install modules",
+    "Use the pip module within python to install modules - aka 'python -m pip'. This is the recommended usage since Python 3.4 (2014) instead of invoking the 'pip' script",
     :attribute_name => :python_internal_pip,
     :default => true
 

--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -150,8 +150,8 @@ class FPM::Package::Python < FPM::Package
         "download",
         "--no-clean",
         "--no-deps",
-        "--no-binary",
-        ":all:",
+        "--no-binary", ":all:",
+        "-d", build_path,
         "-i", attributes[:python_pypi],
       ]
 

--- a/spec/fixtures/python/setup.py
+++ b/spec/fixtures/python/setup.py
@@ -10,6 +10,9 @@ setup(name="Example",
       package_dir={},
       install_requires=[
           "Dependency1", "dependency2",
+          # XXX: I don't know what these python_version-dependent deps mean
+          # needs investigation
+          # Reference: PEP-0508
            'rtxt-dep3; python_version == "2.0"',
            'rtxt-dep4; python_version > "2.0"',
            ],

--- a/spec/fpm/package/python_spec.rb
+++ b/spec/fpm/package/python_spec.rb
@@ -4,7 +4,7 @@ require "fpm/package/python" # local
 require "find" # stdlib
 
 def python_usable?
-  return program_exists?("python") && program_exists?("easy_install")
+  return program_exists?("python")
 end
 
 if !python_usable?
@@ -124,7 +124,8 @@ describe FPM::Package::Python do
 
     it "it should include the dependencies from setup.py" do
       subject.input(example_dir)
-      insist { subject.dependencies.sort } == ["python-dependency1  ","python-dependency2  "]
+      # XXX: Why is there extra whitespace in these strings?
+      insist { subject.dependencies.sort } == ["python-dependency1  ","python-dependency2  ", "python-rtxt-dep4  "]
     end
 
     context "and :python_disable_dependency is set" do
@@ -134,7 +135,7 @@ describe FPM::Package::Python do
 
       it "it should exclude the dependency" do
         subject.input(example_dir)
-        insist { subject.dependencies.sort } == ["python-dependency2  "]
+        insist { subject.dependencies.sort } == ["python-dependency2  ", "python-rtxt-dep4  "]
       end
     end
   end

--- a/spec/fpm/package/python_spec.rb
+++ b/spec/fpm/package/python_spec.rb
@@ -3,13 +3,19 @@ require "fpm" # local
 require "fpm/package/python" # local
 require "find" # stdlib
 
+def find_python
+  [ "python", "python3", "python2" ].each do |i|
+    return i if program_exists?(i)
+  end
+  return nil
+end
+
 def python_usable?
-  return program_exists?("python")
+  return find_python
 end
 
 if !python_usable?
-  Cabin::Channel.get("rspec").warn("Skipping Python#input tests because " \
-    "'python' and/or 'easy_install' isn't in your PATH")
+  Cabin::Channel.get("rspec").warn("Skipping Python#input tests because 'python' wasn't found in $PATH")
 end
 
 is_travis = ENV["TRAVIS_OS_NAME"] && !ENV["TRAVIS_OS_NAME"].empty?
@@ -28,7 +34,8 @@ end
 
 describe FPM::Package::Python do
   before do
-    skip("Python and/or easy_install not found") unless python_usable?
+    skip("Python program not found") unless python_usable?
+    subject.attributes[:python_bin] = find_python
   end
 
   let (:example_dir) do


### PR DESCRIPTION
This adds a new flag, --python-internal-pip, which is enabled by default.

"internal pip" means using 'python -m pip' to invoke pip. Ideally this will make fpm more correctly use pip.

Tested on python 2.7.17 and 3.6.9 on Ubuntu 18.04

All python tests passing 👍👍

Fixes #1820