### PR TITLE
rpm: Replace dash with underscore.

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -254,6 +254,12 @@ class FPM::Package::RPM < FPM::Package
 
   # This method ensures a default value for iteration if none is provided.
   def iteration
+    if @iteration.kind_of?(String) and @iteration.include?("-")
+      logger.warn("Package iteration '#{@iteration}' includes dashes, converting" \
+                   " to underscores. rpmbuild does not allow the dashes in the package iteration (called 'Release' in rpm)")
+      @iteration = @iteration.gsub(/-/, "_")
+    end
+
     return @iteration ? @iteration : 1
   end # def iteration
 

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -162,6 +162,22 @@ describe FPM::Package::RPM do
         File.unlink(target)
       end
     end
+
+    context "with slight corrections" do
+      context "on the version attribute" do
+        it "should replace dash(-) with underscore(_)" do
+          subject.version = "123-456"
+          insist { subject.version } == "123_456"
+        end
+      end
+      context "on the iteration attribute" do
+        # Found in https://github.com/electron-userland/electron-builder/issues/5976
+        it "should replace dash(-) with underscore(_)" do
+          subject.iteration = "123-456"
+          insist { subject.iteration } == "123_456"
+        end
+      end
+    end
     context "package attributes" do
       before :each do
         @target = Stud::Temporary.pathname


### PR DESCRIPTION
(note: fpm calls 'iteration' what rpm calls 'release')

rpmbuild will reject the `Release` tag containing a dash with the
following error (via fpm --verbose):

```
error: line 41: Illegal char '-' (0x2d) in: Release: 1-1 {:level=>:info}
Process failed: rpmbuild failed (exit code 1).
```

This patch copies the dash-to-underscore operation that is already
applied to the version field.

Adds tests for both iteration and version field.

Fixes: #1833