### PR TITLE
Apply fix for readthedocs building errors.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,6 @@
+# https://blog.readthedocs.com/build-errors-docutils-0-18/
+version: 2
+
+python:
+  install:
+  - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+# https://blog.readthedocs.com/build-errors-docutils-0-18/
+docutils<0.18


### PR DESCRIPTION
https://blog.readthedocs.com/build-errors-docutils-0-18/

For #1848

Hoping this fixes it. Readthedocs emails me whenever doc build fails, and
for the past week or two, it has said the following:

```
Running Sphinx v1.8.5
loading translations [en]... done
making output directory...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 37 source files that are out of date
updating environment: 37 added, 0 changed, 0 removed
reading sources... [  2%] changelog
reading sources... [  5%] changelog_links
reading sources... [  8%] cli-reference

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/fpm/envs/latest/lib/python2.7/site-packages/sphinx/cmd/build.py", line 304, in build_main
    app.build(args.force_all, filenames)
[ ... cut for brevity ... ]
  File "/home/docs/checkouts/readthedocs.org/user_builds/fpm/envs/latest/lib/python2.7/site-packages/sphinx/util/nodes.py", line 94, in apply_source_workaround
    for classifier in reversed(node.parent.traverse(nodes.classifier)):
TypeError: argument to reversed() must be a sequence
```