### PR TITLE
Add missing requires to fix #1854 and fix breakage in 1.14.0 when using the fpm api.

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -8,6 +8,10 @@ require "fileutils"
 require "digest"
 require "zlib"
 
+# For handling conversion
+require "fpm/package/cpan"
+require "fpm/package/gem"
+
 # Support for debian packages (.deb files)
 #
 # This class supports both input and output of packages.

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -4,6 +4,9 @@ require "fileutils"
 require "find"
 require "arr-pm/file" # gem 'arr-pm'
 
+# For conversion handling
+require "fpm/package/gem"
+
 # RPM Package type.
 #
 # Build RPMs without having to waste hours reading Maximum-RPM.

--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -2,6 +2,8 @@ require "fpm/namespace"
 require "fpm/package"
 require "fpm/util"
 
+require "fpm/package/dir"
+
 # Support for python virtualenv packages.
 #
 # This supports input, but not output.


### PR DESCRIPTION
In #1854, it is reported that packaging fails. I think this happens because that specific use case invokes fpm via api and not via cli. When the cli is run, it loads all package type files. However, with the api, you `require()` your own files. 

I think files should require things they need, so this PR adds require() calls for places where  one package refers to another (like when converting things to deb). 

I used `grep FPM::Package:: lib/fpm/package/*.rb` to find cases where requires might be needed.

Test cases that failed without this PR:

```
% bundle exec ruby -r./lib/fpm/package/rpm.rb -e 'FPM::Package::RPM.new.tap { |x| x.name = "fancy" }.convert(FPM::Package::RPM)' 

% bundle exec ruby -r./lib/fpm/package/deb.rb -e 'FPM::Package::Deb.new.tap { |x| x.name = "fancy" }.convert(FPM::Package::Deb)' 
```

