### PR TITLE
Fix docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,9 @@ RUN false
 # Base container is used for various release and test things
 FROM ubuntu:18.04 as minimal-base
 
+# This avoids 'pip' having decoding errors for UTF-8 paths.
+ENV LC_ALL=C.UTF-8
+
 # Runtime deps. Build deps go in the build or test containers
 RUN apt-get update \
 	&& apt-get -y dist-upgrade \

--- a/Dockerfile
+++ b/Dockerfile
@@ -66,9 +66,8 @@ RUN install -d -o fpm /origsrc
 COPY --chown=fpm . /origsrc
 ENV HOME=/origsrc
 ENV BUNDLE_PATH=/origsrc/.bundle
-# Install a specific version of bundler
 WORKDIR /origsrc
-RUN gem install -v "$(grep -A1 '^BUNDLED WITH' Gemfile.lock | tail -1)" bundler
+RUN gem install bundler
 USER fpm
 RUN bundle install
 CMD bundle exec rspec

--- a/Makefile
+++ b/Makefile
@@ -69,5 +69,5 @@ docker-test-%: .docker-test-%
 	docker run -v `pwd`:/src fpm-test-$*
 
 docker-release-%:
-	DOCKER_BUILDKIT=1 docker build -t fpm  --build-arg BASE_ENV=$* --build-arg TARGET=release --squash .
+	DOCKER_BUILDKIT=1 docker build -t fpm  --build-arg BASE_ENV=$* --build-arg TARGET=release .
 

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ SECONDARY: .docker-test-minimal .docker-test-everything
 	touch "$@"
 
 docker-test-%: .docker-test-%
-	docker run -v `pwd`:/src fpm-test-$*
+	docker run -v "`pwd`:/src" fpm-test-$*
 
 docker-release-%:
 	DOCKER_BUILDKIT=1 docker build -t fpm  --build-arg BASE_ENV=$* --build-arg TARGET=release .

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,7 @@ release-prep:
 # The dot file is a sentinal file that will built a docker image, and tag it.
 # The normal make target runs said image, mounting CWD against it.
 SECONDARY: .docker-test-minimal .docker-test-everything
-.docker-test-%: Gemfile.lock fpm.gemspec Dockerfile
+.docker-test-%: fpm.gemspec Dockerfile
 	DOCKER_BUILDKIT=1 docker build -t fpm-test-$*  --build-arg BASE_ENV=$* --build-arg TARGET=test .
 	touch "$@"
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -34,6 +34,14 @@ As a full example::
 Depending on your needs, you will have to adjust the volume mounts and
 relative paths to fit your particular situation.
 
+Developing using docker
+-----------------------
+The docker image can be useful for doing ad-hoc testing of changes made to the
+FPM source. To do this, build an image as described above, then run the `fpm`
+script from within the source directory. For example::
+
+    docker run -v "$(pwd):/src" --entrypoint /src/bin/fpm fpm --help
+
 Running rpsec inside docker
 ---------------------------
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -18,7 +18,7 @@ First, build a container will all the dependencies::
 Now, run it as you would the fpm command. Note that you will have to
 mount your source directly into the docker volume::
 
-   docker run -v $(pwd):/src fpm --help
+   docker run -v "$(pwd):/src" fpm --help
 
 As a full example::
 

--- a/docs/docker.rst
+++ b/docs/docker.rst
@@ -11,7 +11,7 @@ locally. And a developer can use docker to run the test suite.
 Running FPM inside docker
 -------------------------
 
-First, build a container will all the dependencies::
+First, build an image will all the dependencies::
 
    make docker-release-everything
 
@@ -46,7 +46,7 @@ Running rpsec inside docker
 ---------------------------
 
 The Makefile provides some targets for testing. They will build a
-docker container with the dependencies, and then invoked `rspec`
+docker image with the dependencies, and then invoke `rspec`
 inside it. The makefile uses a sentinel file to indicate that the
 docker image has been build, and can be reused.
 
@@ -58,7 +58,7 @@ How does this work
 ------------------
 
 The Dockerfile makes heavy use of multistage
-builds. This allows the various output containers to build on the same
+builds. This allows the various output images to build on the same
 earlier stages.
 
 There are two ``base`` images. A ``minimal`` image, which contains
@@ -73,6 +73,6 @@ unspecified, it defaults to ``everything``
 
 We want to use the same set of base images for both the ``rspec``
 testing, as well as the run time containerization. We do this by using
-the ``TARGET`` argument to select which container to build.
+the ``TARGET`` argument to select which image to build.
 
 The makefile encodes this logic with two pattern rules.


### PR DESCRIPTION
The recent docker setup looks very useful for testing and development, but I was unable to use it as currently provided and documented. This PR includes all the fixes I needed to be able to use docker to test things for #1806.

Note that many automated tests still do not run within docker because the ubuntu 18.04 image does not contain `zstd` (or have support for it in `tar`). Fixing this would probably require updating the base image to a later version; I tried doing that and got stuck, so I abandoned that effort.