### PR TITLE
Restore development_dependency on `rake`

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -57,6 +57,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("insist", "~> 1.0.0") # license: Apache 2
   spec.add_development_dependency("pry")
 
+  spec.add_development_dependency("rake") # For FPM::RakeTask, #1877, #756
+
   spec.files = files
   spec.require_paths << "lib"
   spec.bindir = "bin"


### PR DESCRIPTION
A prior commit removed `rake` as a development dependency on the
assumption that nothing in fpm's development process actually required
the use of `rake`.

However, I had forgotten about #756 (year 2014) which adds FPM::RakeTask
and some test coverage. FPM::RakeTask was added to allow folks to more
easily invoke FPM from within a Rake task.

At this time, I see no reason to remove FPM::RakeTask. Further, because
`rake` is typically (in my experience) used only in development
environments. Therefore, I believe the right solution is to restore
`rake` as a development_dependency in order to allow the test suite to
pass. For users of FPM::RakeTask, I would assume (hopefully correctly!)
that they already have `rake` installed as a dependency in their own
project, so the `fpm` gem has no need to specify `rake` as a general-use
dependency.

When studying newer versions of Rake, I found:
* Rake v13 requires Ruby 2.2 or newer
* Rake v12.xx and older are flagged as having security vulnerabilities.

In order to minimize chaos, this commit adds an unversioned dependency
on rake. This is to help fpm service more versions of Ruby and resist
efforts by any dependency to dictate which version of Ruby is used.

This reverts db9db670c39a84dccc92123eed4413bf09d89bc5.

Fixes #1877