### PR TITLE
Fix filename mangling for RPM targets

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -192,17 +192,26 @@ class FPM::Package::RPM < FPM::Package
   # Replace * with [*] to make rpm not use globs
   # Replace ? with [?] to make rpm not use globs
   # Replace % with [%] to make rpm not expand macros
+  # Replace whitespace with ? to make rpm not split the filename
+  # If and only if any of the above are done, then also replace ' with \', " with \", and \ with \\\\
+  #   to accommodate escape and quote processing that rpm will perform in that case (but not otherwise)
   def rpm_fix_name(name)
-    name = name.gsub(/(\ |\[|\]|\*|\?|\%|\$|')/, {
-      ' ' => '?',
-      '%' => '[%]',
-      '$' => '[$]',
-      '?' => '[?]',
-      '*' => '[*]',
-      '[' => '[\[]',
-      ']' => '[\]]',
-      "'" => "\\'",
-    })
+    if name.match?(/[ \t*?%$\[\]]/)
+      name = name.gsub(/(\ |\t|\[|\]|\*|\?|\%|\$|'|"|\\)/, {
+        ' '  => '?',
+        "\t" => '?',
+        '%'  => '[%]',
+        '$'  => '[$]',
+        '?'  => '[?]',
+        '*'  => '[*]',
+        '['  => '[\[]',
+        ']'  => '[\]]',
+        '"'  => '\\"',
+        "'"  => "\\'",
+        '\\' => '\\\\\\\\',
+      })
+    end
+    name
   end
 
   def rpm_file_entry(file)


### PR DESCRIPTION
Fixes the mangling FPM performs on the contents of RPM %files lists
to better match RPM's idiosyncratic filename handling.  FPM now
recognizes more cases that require special handling, and it
correctly distinguishes between the glob and non-glob cases,
which RPM itself treates differently.

Fixes #1385