### PR TITLE
Run `pip` without the `--build` flag

### DIFF
--- a/spec/fpm/package/python_spec.rb
+++ b/spec/fpm/package/python_spec.rb
@@ -204,7 +204,7 @@ describe FPM::Package::Python do
 
       # Hardcode /usr/local/bin here. On newer Python 3's I cannot figure out how to 
       # determine the script_dir at installation time. easy_install's method is gone.
-      path = subject.staging_path("/usr/local/bin/django-admin.py")
+      path = subject.staging_path("/usr/local/bin/django-admin")
 
       # Read the first line (the hashbang line) of the django-admin.py script
       fd = File.new(path, "r")


### PR DESCRIPTION
Previously, fpm would use `pip download ... --build ...` to instruct pip
to unpack a given python package to a specific directory for the purpose
of running something like `python setup.py` from it.

However, somewhere in 2021, pip removed this flag. First, I think, it
was deprecated and ignored, then finally removed. One reference to
this removal in the upstream pip project is this issue:
https://github.com/pypa/pip/issues/8333

Without `--build`, pip will place a single tarball in the destination
directory. Fpm cannot easily predict the name of this file because we
don't know the "real" name of the python package nor do we know the
version number being downloaded.

For example:

```
% python3 -m pip download --no-binary :all: --no-deps --no-clean django
...
Successfully downloaded django
% ls
Django-4.0.4.tar.gz
```

Best guess:
* we can expect exactly one file in the previously-empty target directory
* we can also expect that it is a .tar.gz

I don't know if these guesses are always correct, but it's a start.

As of this commit, the following command generates a Debian package:

`fpm -s python --python-bin python3 -t deb django`

Prior to this commit, with a newer version of pip, the command would
fail.

Fixes #1831