### PR TITLE
[deb] The regex for valid package names in relationships does not allow names including "." (and is missing a couple of constraints)

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -33,12 +33,17 @@ class FPM::Package::Deb < FPM::Package
   # Example value with version relationship: libc6 (>= 2.2.1)
   # Example value: libc6
 
+  # Package name docs here: https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source
+  # Package names (both source and binary, see Package) must consist only of lower case letters (a-z),
+  # digits (0-9), plus (+) and minus (-) signs, and periods (.).
+  # They must be at least two characters long and must start with an alphanumeric character.
+
   # Version string docs here: https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-version
   # The format is: [epoch:]upstream_version[-debian_revision].
   # epoch - This is a single (generally small) unsigned integer
   # upstream_version - must contain only alphanumerics 6 and the characters . + - ~
   # debian_revision - only alphanumerics and the characters + . ~
-  RELATIONSHIP_FIELD_PATTERN = /^(?<name>[A-z0-9_-]+)(?: *\((?<relation>[<>=]+) *(?<version>(?:[0-9]+:)?[0-9A-Za-z+~.-]+(?:-[0-9A-Za-z+~.]+)?)\))?$/
+  RELATIONSHIP_FIELD_PATTERN = /^(?<name>[A-z0-9][A-z0-9_.-]+)(?: *\((?<relation>[<>=]+) *(?<version>(?:[0-9]+:)?[0-9A-Za-z+~.-]+(?:-[0-9A-Za-z+~.]+)?)\))?$/
 
   option "--ignore-iteration-in-dependencies", :flag,
             "For '=' (equal) dependencies, allow iterations on the specified " \


### PR DESCRIPTION
Debian policy is that package names may include a period, and this is used for a number of default packages (for instance, `ruby2.7`).

Binary package documentation points to the Source package docs:
https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-package
Source package documentation includes ".":
https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-source

Current text: 

> Package names (both source and binary, see Package) must consist only of lower case letters (a-z), digits (0-9), plus (+) and minus (-) signs, and periods (.). They must be at least two characters long and must start with an alphanumeric character.

The regex in https://github.com/jordansissel/fpm/blob/788170598572ab2a9cb4d844575e3a9dab2ab467/lib/fpm/package/deb.rb#L41 
does not correctly apply the rules, as it does not allow "." or apply the alphanumeric and minimum-two-character limits.
