### PR TITLE
Use bash in deb templates

### DIFF
--- a/templates/deb/ldconfig.sh.erb
+++ b/templates/deb/ldconfig.sh.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 # This script is automatically added by fpm when you specify
 # conditions that usually require running ldconfig upon
 # package installation and removal.

--- a/templates/deb/postinst_upgrade.sh.erb
+++ b/templates/deb/postinst_upgrade.sh.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 <% if attributes[:deb_maintainerscripts_force_errorchecks?] -%>
 set -e

--- a/templates/deb/postrm_upgrade.sh.erb
+++ b/templates/deb/postrm_upgrade.sh.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 <% if attributes[:deb_maintainerscripts_force_errorchecks?] -%>
 set -e

--- a/templates/deb/preinst_upgrade.sh.erb
+++ b/templates/deb/preinst_upgrade.sh.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 <% if attributes[:deb_maintainerscripts_force_errorchecks?] -%>
 set -e

--- a/templates/deb/prerm_upgrade.sh.erb
+++ b/templates/deb/prerm_upgrade.sh.erb
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 <% if attributes[:deb_maintainerscripts_force_errorchecks?] -%>
 set -e


### PR DESCRIPTION
Currently, fpm has a bug where if I use #!bash for an --after-install
script that uses bash specific features, it works, but if I add an
--after-upgrade script, the previously working --after-install script
now fails, because the script is now run with sh.

If this change is too opinionated, maybe an alternative fix would be to respect the shebang in the `--after-install` script?