### PR TITLE
Use pkgbuild's --install-location flag when fpm's --prefix is given.

### DIFF
--- a/lib/fpm/package/osxpkg.rb
+++ b/lib/fpm/package/osxpkg.rb
@@ -148,6 +148,11 @@ class FPM::Package::OSXpkg < FPM::Package
       write_scripts
       args += ["--scripts", scripts_path]
     end
+
+    if attributes[:prefix]
+      args += ["--install-location", attributes[:prefix]]
+    end
+
     args << output_path
 
     safesystem("pkgbuild", *args)


### PR DESCRIPTION
A user reported that on macOS Catalina, the default pkgbuild install
location may result in a .pkg file which cannot be installed.

This change makes fpm's `--prefix` option pass through to `pkgbuild`'s
`--install-location` flag

> With macOS Catalina, you can no longer store files or data in the read-only system volume, nor can you write to the "root" directory ( / ) from the command line, such as with Terminal.

References:
* macOS Catalina's new read-only root filesystem: https://support.apple.com/en-us/HT210650

Fixes #1908