### PR TITLE
Change default Debian package priority to optional

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -93,7 +93,7 @@ class FPM::Package::Deb < FPM::Package
   end
 
   option "--priority", "PRIORITY",
-    "The debian package 'priority' value.", :default => "extra"
+    "The debian package 'priority' value.", :default => "optional"
 
   option "--use-file-permissions", :flag,
     "Use existing file permissions when defining ownership and modes"
@@ -216,7 +216,7 @@ class FPM::Package::Deb < FPM::Package
 
   def initialize(*args)
     super(*args)
-    attributes[:deb_priority] = "extra"
+    attributes[:deb_priority] = "optional"
   end # def initialize
 
   private

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -71,8 +71,8 @@ describe FPM::Package::Deb do
   end
 
   describe "priority" do
-    it "should default to 'extra'" do
-      expect(subject.attributes[:deb_priority]).to(be == "extra")
+    it "should default to 'optional'" do
+      expect(subject.attributes[:deb_priority]).to(be == "optional")
     end
   end
 


### PR DESCRIPTION
Since Debian Policy version 4.0.1, the "extra" priority has been deprecated and replaced with "optional"; this triggers Lintian warnings for Debian packages built by FPM. Make this the new default for Debian package outputs when no value of `--deb-priority` is given.

Fixes #1398.