### PR TITLE
Fix flags for default BSD tar

### DIFF
--- a/lib/fpm/package/freebsd.rb
+++ b/lib/fpm/package/freebsd.rb
@@ -86,7 +86,7 @@ class FPM::Package::FreeBSD < FPM::Package
     # We use --files-from here to keep the tar entries from having `./` as the prefix.
     # This is done as a best effor to mimic what FreeBSD packages do, having everything at the top-level as
     # file names, like "+MANIFEST" instead of "./+MANIFEST"
-    safesystem("tar", "-Jcf", output_path, "-C", staging_path, "--files-from", build_path("file_list"), "--transform", 's|^\([^+]\)|/\1|')
+    safesystem("tar", "-Jcf", output_path, "-C", staging_path, "--files-from", build_path("file_list"), "-s", '/^\([^+]\)/\1/')
   end # def output
 
   # Handle architecture naming conversion:


### PR DESCRIPTION
Hi!

I work on FreeBSD 13.1 and use FPM to prepare a package for this system.
After running FPM, I get the above error:

```
pid 1174 exit 1
{:timestamp=>"2022-08-17T16:19:18.544663+0000", :message=>"Process failed: tar failed (exit code 1). Full command was:[\"tar\", \"-Jcf\", \"agent-1.5.0.220817161918.txz\", \"-C\", \"/tmp/package-dir-staging-a0d814f5e1ccf2cabe9af71505cb99a908f64a5efb531063253090cf7412\", \"--files-from\", \"/tmp/package-freebsd-build-36dcccb637b7ab270f329f125a8a0fc2650e2ae00778dbb78edb24955b6b1/file_list\", \"--transform\", \"s|^\\\\([^+]\\\\)|/\\\\1|\"]", :level=>:error)
```

I recognized that the problem is caused by the `--transform` flag that isn't supported by the default FreeBSD tar.

```
bsdtar 3.6.0 - libarchive 3.6.0 zlib/1.2.12 liblzma/5.2.5 bz2lib/1.0.8 libzstd/1.4.8
```

In this MR, I provided a patch that replaces the `--transform` flag with the `-s' flag that has the same meaning on FreeBSD tar but uses a little different pattern format.

Only workaround I found is to remove the default `tar` executable and replace it with the `gtar` (GNU tar), e.g.:

```
pkg install gtar
mv /usr/bin/tar /usr/bin/bsdtar
mv /usr/local/bin/gtar /usr/bin/tar
```

But it is an ugly hack and shouldn't be used in a production environment.