### PR TITLE
Replace whatever in changelog.erb and deb.changes.erb

### DIFF
--- a/templates/deb/changelog.erb
+++ b/templates/deb/changelog.erb
@@ -1,4 +1,4 @@
-<%= name %> (<%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>) whatever; urgency=medium
+<%= name %> (<%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>) <%= distribution %>; urgency=medium
 
   * Package created with FPM.
 

--- a/templates/deb/deb.changes.erb
+++ b/templates/deb/deb.changes.erb
@@ -14,7 +14,7 @@ Description: <%= firstline %>
 <%= remainder.collect { |l| l =~ /^ *$/ ? " ." : " #{l}" }.join("\n") %>
 <% end -%>
 Changes:
-<%= name %> (<%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>) <%= distribution %>; urgency=medium
+ <%= name %> (<%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>) <%= distribution %>; urgency=medium
   * Package created with FPM.
 Checksums-Sha1:
 <% changes_files.each do |file| -%>

--- a/templates/deb/deb.changes.erb
+++ b/templates/deb/deb.changes.erb
@@ -14,7 +14,7 @@ Description: <%= firstline %>
 <%= remainder.collect { |l| l =~ /^ *$/ ? " ." : " #{l}" }.join("\n") %>
 <% end -%>
 Changes:
- <%= name %> (<%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>) whatever; urgency=medium
+<%= name %> (<%= "#{epoch}:" if epoch %><%= version %><%= "-" + iteration.to_s if iteration %>) <%= distribution %>; urgency=medium
   * Package created with FPM.
 Checksums-Sha1:
 <% changes_files.each do |file| -%>


### PR DESCRIPTION
In order to support packaging upload, the distribution must be set/aligned in changelog and changes files.
Required for example inside dput-ng repo upload app.