### PR TITLE
Prevent crash if CPAN distribution has blank author field

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -112,6 +112,7 @@ class FPM::Package::CPAN < FPM::Package
     self.vendor = case metadata["author"]
       when String; metadata["author"]
       when Array; metadata["author"].join(", ")
+      when NilClass; "No Vendor Or Author Provided"
       else
         raise FPM::InvalidPackageConfiguration, "Unexpected CPAN 'author' field type: #{metadata["author"].class}. This is a bug."
     end if metadata.include?("author")


### PR DESCRIPTION
This PR fixes issue #1523. 

Because [Class::Data::Inheritable](https://metacpan.org/release/TMTM/Class-Data-Inheritable-0.08) version 0.08 has a blank author field in its META.yml file, the bug can be reproduced with the following command:
```
fpm --no-cpan-test --cpan-verbose --verbose --debug-workspace --workdir $HOME/fpm_tmp/ -s cpan -t rpm -v 0.08 Class::Data::Inheritable
```