### PR TITLE
CPAN support - Fix broken tar command

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -305,7 +305,7 @@ class FPM::Package::CPAN < FPM::Package
     directory = build_path("module")
     ::Dir.mkdir(directory)
     args = [ "-C", directory, "-zxf", tarball,
-      "--strip-components", "1" ]
+             %q{--transform=s,[./]*[^/]*/,,} ]
     safesystem("tar", *args)
     return directory
   end

--- a/spec/fpm/package/cpan_spec.rb
+++ b/spec/fpm/package/cpan_spec.rb
@@ -37,6 +37,14 @@ describe FPM::Package::CPAN do
     # TODO(sissel): Check dependencies
   end
 
+  it "should package Alien::astyle" do
+    pending("Disabled on travis-ci because it always fails, and there is no way to debug it?") if is_travis
+
+    subject.instance_variable_set(:@version, "0.010000");
+    subject.input("Alien::astyle")
+    insist { subject.name } == "perl-Alien-astyle"
+  end
+
   it "should package File::Spec" do
     pending("Disabled on travis-ci because it always fails, and there is no way to debug it?") if is_travis
     subject.input("File::Spec")


### PR DESCRIPTION
This PR fixes issue #1517 using the fix provided by #1518.

For handling CPAN tarballs with leading "./Foo/" directory structures, we must employ a tar `--transform` regex instead of a tar `--strip-components` command.

This bug can be reproduced by running the following command on the main branch:
```
fpm --no-cpan-test --cpan-verbose --verbose --debug-workspace --workdir $HOME/tmp -t rpm -s cpan -v 0.010000 Alien::astyle
```
I also added a test to `cpan_spec.rb` that ensures Alien::astyle version 0.010000 can be built, but it should be noted that (on my machine) this tests causes the test suite to take about 4 minutes to run versus only about 30 seconds without this test.