### PR TITLE
Fix frozen cpanm caused by interactive Makefile.PL

### DIFF
--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -158,6 +158,9 @@ module FPM::Util
       stdout_r.close                unless stdout_r.closed?
       stderr_r.close                unless stderr_r.closed?
     else
+      # If no block given (not interactive) we should close stdin_w because we
+      # won't be able to give input which may cause a hang.
+      stdin_w.close
       # Log both stdout and stderr as 'info' because nobody uses stderr for
       # actually reporting errors and as a result 'stderr' is a misnomer.
       logger.pipe(stdout_r => :info, stderr_r => :info)

--- a/spec/fpm/package/cpan_spec.rb
+++ b/spec/fpm/package/cpan_spec.rb
@@ -45,6 +45,16 @@ describe FPM::Package::CPAN do
     insist { subject.name } == "perl-PathTools"
   end
 
+  it "should package Inline::CPP" do
+    # Inline::CPP v0.80 has an interactive Makefile.PL which expects input from
+    # STDIN.
+    pending("Disabled on travis-ci because it always fails, and there is no way to debug it?") if is_travis
+    subject.instance_variable_set(:@version, "0.80");
+    subject.input("Inline::CPP")
+
+    insist { subject.name } == "perl-Inline-CPP"
+  end
+
   it "should package Class::Data::Inheritable" do
     pending("Disabled on travis-ci because it always fails, and there is no way to debug it?") if is_travis
 


### PR DESCRIPTION
This PR fixes issue #1519 and #1522. I also added a test to `cpan_spec.rb` that makes sure Inline::CPP version 0.80 can be built.

I based my fix off [this commit](https://github.com/jordansissel/fpm/pull/1610/commits/ae9594eb098f74c55166729d317d86af83e3b3f9) from #1610 that was never merged.

Because Inline::CPP version 0.80 has an interactive Makefile.PL, the bug can be reproduced by running the following command on the main branch (this command will hang):

```
fpm --no-cpan-test --cpan-verbose --verbose --debug-workspace --workdir $HOME/tmp -t rpm -s cpan -v 0.80 Inline::CPP
```