### PR TITLE
Remove `git` gem dependency.

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -44,9 +44,6 @@ Gem::Specification.new do |spec|
   # For sourcing from pleaserun
   spec.add_dependency("pleaserun", "~> 0.0.29") # license: Apache 2
 
-  # For sourcing from git repos
-  spec.add_dependency("git", ">= 1.3.0", "< 2.0") # license: MIT
-
   spec.add_dependency("stud")
 
   # In Ruby 3.0, rexml was moved to a bundled gem instead of a default one,


### PR DESCRIPTION
Folks are reporting that fpm cannot be installed easily (or at all) on older systems because a transitive dependency(1) rejects ruby versions older than 2.6.

(1) rubygem git depends on addressable which depends on public_suffix

Since the `git` dependency is only used in the `gem` source when using a git repo as a installation source, and that usage seems pretty simple -- clone a repo, checkout a branch, etc -- it feels safe to remove this dependency while still keeping the same functionality.

Fixes #1923