### PR TITLE
Bump minimum required version to meet required dependencies

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     "management without wasting pointless hours debugging bad rpm specs!"
   spec.license = "MIT-like"
 
-  spec.required_ruby_version = '>= 1.9.3'
+  spec.required_ruby_version = '>= 2.6.2'
 
   # For parsing JSON (required for some Python support, etc)
   # http://flori.github.com/json/doc/index.html


### PR DESCRIPTION
While fpm may still stick to the conventions of Ruby 1.9, several of it's dependencies no longer support that release. I recently discovered this trying to build on an older ruby in a resource constrained system. The `json` gem requires ruby 2.3 or later and the `public_suffix` gem requires ruby 2.6 or later. So I'm proposing this PR to bump the minimum version requirement to 2.6.2 which seems to work without issue. Hopefully this will help someone in the future who is in the same boat I was in.

@jordansissel if you feel this is inappropriate, just let me know what you think would be a better approach. Happy to just make a PR to the README if that makes more sense.