### PR TITLE
JSON, REXML, and ruby 1.9.3 works again!

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -22,10 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 1.9.3'
 
-  # For parsing JSON (required for some Python support, etc)
-  # http://flori.github.com/json/doc/index.html
-  spec.add_dependency("json", ">= 1.7.7", "< 3.0") # license: Ruby License
-
   # For logging
   # https://github.com/jordansissel/ruby-cabin
   spec.add_dependency("cabin", ">= 0.6.0") # license: Apache 2

--- a/lib/fpm/package/osxpkg.rb
+++ b/lib/fpm/package/osxpkg.rb
@@ -4,7 +4,6 @@ require "fileutils"
 require "fpm/package/dir"
 require 'tempfile'  # stdlib
 require 'pathname'  # stdlib
-require 'rexml/document'  # stdlib
 
 # Use an OS X pkg built with pkgbuild.
 #
@@ -103,6 +102,7 @@ class FPM::Package::OSXpkg < FPM::Package
 
   # Extract name and version from PackageInfo XML
   def extract_info(package)
+    require 'rexml/document'
     build_path("expand").tap do |path|
       doc = REXML::Document.new File.open(File.join(path, "PackageInfo"))
       pkginfo_elem = doc.elements["pkg-info"]

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -421,7 +421,11 @@ module FPM::Util
     # to invoke ERB.new correctly and without printed warnings.
     # References: https://github.com/jordansissel/fpm/issues/1894
     # Honestly, I'm not sure if Gem::Version is correct to use in this situation, but it works.
-    if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("3.1.0")
+    
+    # on older versions of Ruby, RUBY_VERSION is a frozen string, and
+    # Gem::Version.new calls String#strip! which throws an exception.
+    # so we have to call String#dup to get an unfrozen copy.
+    if Gem::Version.new(RUBY_VERSION.dup) < Gem::Version.new("3.1.0")
       # Ruby 3.0.x and older
       return ERB.new(template_code, nil, "-")
     else


### PR DESCRIPTION
This change allows at least some of fpm to work under Ruby 1.9.3. I can produce rpms and debs using Ruby 1.9.3 and this patch! 

The `osxpkg` format doesn't seem to work for me on Ruby 1.9.3 because REXML seems to crash with an error.

This is accomplished by:
* removing the `json` dependency which has been included in Ruby by default since Ruby 1.9.1
* delaying rexml loading so that only uses that require xml parsing will load that library, such as osxpkg parsing.
* working around a frozen string modification error in `rubygems` under Ruby 1.9.3

You, reader, may be asking, "Why?"

In #1949, we discuss raising the minimum version of ruby required by fpm. At time of writing, the minimum version is set to '>= 1.9.3', and I'm somewhat slow to raise it without good cause.

Historically, there's been a race for some Ruby libraries to abandon older versions of ruby. However, as a sysadmin, I'm keenly aware that many folks may not have the authority to upgrade Ruby on their systems, so it feels natural to continue keep fpm compatible with older versions of Ruby.

I've tried to be consistent in this strategy:
* https://github.com/jordansissel/fpm/issues/1264#issuecomment-269422985

Related issues:
* rexml: #1798
* rexml: #1800 
* rexml: #1784
* json: https://github.com/jordansissel/fpm/issues/1741
* json: #1264 