### PR TITLE
A few changes for SRPM support 

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -452,7 +452,7 @@ class FPM::Package::RPM < FPM::Package
 
   def output(output_path)
     output_check(output_path)
-    %w(BUILD RPMS SRPMS SOURCES SPECS).each { |d| FileUtils.mkdir_p(build_path(d)) }
+    %w(BUILD BUILDROOT RPMS SRPMS SOURCES SPECS).each { |d| FileUtils.mkdir_p(build_path(d)) }
     args = ["rpmbuild", "-ba"]
 
     if %x{uname -m}.chomp != self.architecture

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -567,6 +567,17 @@ describe FPM::Package::RPM do
     end
 
     it "should permit brackets in filenames (issue #202)" do
+      on_linux = false
+      begin
+        if %x{uname -a} =~ /linux/i
+          on_linux = true
+        end
+      rescue
+        #noop
+      end
+
+      skip('This test only works on Linux systems') unless on_linux
+
       File.write(subject.staging_path("file[with]bracket"), "Hello")
 
       # This will raise an exception if rpmbuild fails.

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -111,8 +111,8 @@ Obsoletes: <%= repl %>
 
 %install
 <% if defined?(sources) && !sources.nil? && !sources.empty? -%>
-mkdir -p %{buildroot}%{prefix}
-cp -r * %{buildroot}%{prefix}
+mkdir -p %{buildroot}
+cp -r * %{buildroot}
 <% end -%>
 
 %clean

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -7,27 +7,20 @@
 #   https://github.com/jordansissel/fpm/issues
 # ------------------------------------------------------------------------
 
-# Disable the stupid stuff rpm distros include in the build process by default:
-<% %w(prep build install clean).each do |step| -%>
-<%# These definitions have to be non-empty... I guess... -%>
-#   Disable any <%= step %> shell actions. replace them with simply 'true'
-%define __spec_<%= step %>_post true
-%define __spec_<%= step %>_pre true
-<% end -%>
-# Disable checking for unpackaged files ?
-#%undefine __check_files
+# Never build debug packages
+%define debug_package %{nil}
 
 # Allow building noarch packages that contain binaries
 %define _binaries_in_noarch_packages_terminate_build 0
 
-# Use <%= attributes[:rpm_digest] %> file digest method. 
+# Use <%= attributes[:rpm_digest] %> file digest method.
 # The first macro is the one used in RPM v4.9.1.1
 %define _binary_filedigest_algorithm <%= digest_algorithm %>
 # This is the macro I find on OSX when Homebrew provides rpmbuild (rpm v5.4.14)
 %define _build_binary_file_digest_algo <%= digest_algorithm %>
 
 # Use <%= attributes[:rpm_compression] %> payload compression
-%define _binary_payload <%= payload_compression %> 
+%define _binary_payload <%= payload_compression %>
 
 <% (attributes[:rpm_filter_from_requires] or []).each do |reqfilter| -%>
 %filter_from_requires <%= reqfilter %>
@@ -60,13 +53,18 @@ AutoProv: yes
 <% end -%>
 # Seems specifying BuildRoot is required on older rpmbuild (like on CentOS 5)
 # fpm passes '--define buildroot ...' on the commandline, so just reuse that.
-BuildRoot: %buildroot
-<% if !prefix.nil? and !prefix.empty? %>
+#BuildRoot: buildroot
+<% if !prefix.nil? and !prefix.empty? -%>
 Prefix: <%= prefix %>
+<% end -%>
+<% if defined?(sources) && !sources.nil? && !sources.empty? -%>
+<%   sources.each_with_index do |src, i| -%>
+Source<%= i %>: <%= src %>
+<%   end -%>
 <% end -%>
 
 Group: <%= category %>
-<%# Sometimes the 'license' field has multiple lines... Hack around it. 
+<%# Sometimes the 'license' field has multiple lines... Hack around it.
   # While technically yes this means we are 'modifying' the license,
   # since the job of FPM is to get shit done and that this is  only
   # modifying whitespace, it should be reasonably OK. -%>
@@ -105,16 +103,21 @@ Obsoletes: <%= repl %>
 <%= description.gsub(/^\s*$/, " .") %>
 
 %prep
-# noop
+<% if defined?(sources) && !sources.nil? && !sources.empty? -%>
+%setup -qc
+<% end %>
 
 %build
 # noop
 
 %install
-# noop
+<% if defined?(sources) && !sources.nil? && !sources.empty? -%>
+mkdir -p %{buildroot}%{prefix}
+cp -r * %{buildroot}%{prefix}
+<% end -%>
 
 %clean
-# noop
+[ "%{buildroot}" != "/" ] && rm -rf "%{buildroot}"
 
 <%# This next section puts any %pre, %post, %preun, %postun, %verifyscript, %pretrans or %posttrans scripts %>
 <%
@@ -231,7 +234,7 @@ fi
     :after_install => "in",
     :before_uninstall => "un",
     :after_target_uninstall => "postun"
-  } 
+  }
   triggermap.each do |name, rpmtype|
     (attributes["rpm_trigger_#{name}".to_sym] or []).each do |trigger_name, trigger_script, trigger_scriptprog| -%>
 %trigger<%= rpmtype -%> <%= trigger_scriptprog -%> -- <%= trigger_name %>

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -51,8 +51,10 @@ AutoReq: yes
 <% if attributes[:rpm_autoprov?] -%>
 AutoProv: yes
 <% end -%>
-<% if !prefix.nil? and !prefix.empty? -%>
+<% if !prefix.nil?  -%>
 Prefix: <%= prefix %>
+<% else -%>
+Prefix: /
 <% end -%>
 <% if defined?(sources) && !sources.nil? && !sources.empty? -%>
 <%   sources.each_with_index do |src, i| -%>

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -51,9 +51,6 @@ AutoReq: yes
 <% if attributes[:rpm_autoprov?] -%>
 AutoProv: yes
 <% end -%>
-# Seems specifying BuildRoot is required on older rpmbuild (like on CentOS 5)
-# fpm passes '--define buildroot ...' on the commandline, so just reuse that.
-#BuildRoot: buildroot
 <% if !prefix.nil? and !prefix.empty? -%>
 Prefix: <%= prefix %>
 <% end -%>


### PR DESCRIPTION
Let's try a PR within a PR! I can't remember the last time I did this 😅

My branch is rebased off of the latest `main` branch of fpm, so I think there's some merge conflicts until your `srpm-support` branch is rebased.

I'm open to however you'd like to handle this. We can discuss here or if you prefer back over on the fpm PR you filed.

Changes:
* Sets `%_target_cpu` to match what fpm's `--architecture` flag is set to. This allows `rpmbuild --rebuild` to be used *without* a `--target` flag which is kinda nice.
* Minor rewrite of the source tarball creation to be less lines of code.
* Unrelated to your PR: Removes an old change that copies files from fpm's staging_path to the expected default rpmbuild `_builddir`. Instead, fpm now sets the `_builddir` rpmbuild setting directly to fpm's staging path. This skips some file copies which hopefully is nice?

The fpm test suite for rpm passes ✅

```
% bundle exec rspec spec/fpm/package/rpm_spec.rb
...................................................................

Finished in 8.8 seconds (files took 0.20296 seconds to load)
67 examples, 0 failures
```

Testing expectations, I would expect fpm and `rpmbuild --rebuild` to produce roughly the same rpm  -- with exception that the build time and other external variables might be different.

Testing this:

```
% bundle exec bin/fpm -s gem -t rpm insist
Created package {:path=>"rubygem-insist-1.0.0-1.noarch.rpm"}

% rpmbuild --rebuild rubygem-insist-1.0.0-1.src.rpm
Installing rubygem-insist-1.0.0-1.src.rpm
...
Wrote: /home/jls/rpmbuild/RPMS/noarch/rubygem-insist-1.0.0-1.noarch.rpm
...
```

Cool. So far so good. Both filenames are the same and `rpmbuild` used the same target cpu (`noarch`). Let's check metadata:

```
% rpm -qip  /home/jls/rpmbuild/RPMS/noarch/rubygem-insist-1.0.0-1.noarch.rpm | grep -v 'Build Date' | md5sum
2569eb460def6afe12fec24da2047923  -

% rpm -qip rubygem-insist-1.0.0-1.noarch.rpm | grep -v 'Build Date' | md5sum
2569eb460def6afe12fec24da2047923  -
```

Checksums for both rpms match (if we exclude 'Build Date'). Nice!

Checking file lists:

```
% rpm -qlp rubygem-insist-1.0.0-1.noarch.rpm |md5sum
4c51f7d593cfab693b0c9b424a48ff6c  -
% rpm -qlp /home/jls/rpmbuild/RPMS/noarch/rubygem-insist-1.0.0-1.noarch.rpm |md5sum
4c51f7d593cfab693b0c9b424a48ff6c  -
```

File names listing are identical

There's timestamp differences on the files, but that might also be due to external clock aka build time variables.

```
% rpm -qvlp /home/jls/rpmbuild/RPMS/noarch/rubygem-insist-1.0.0-1.noarch.rpm | head -1
drwxr-xr-x    2 root     root                        0 Nov  3 23:29 /home/jls/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/build_info

% rpm -qvlp rubygem-insist-1.0.0-1.noarch.rpm | head -1
drwxr-xr-x    2 root     root                        0 Nov  3 23:28 /home/jls/.rbenv/versions/3.1.0/lib/ruby/gems/3.1.0/build_info
```