### PR TITLE
Execmd: prevent prompting for input

### DIFF
--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -158,6 +158,9 @@ module FPM::Util
       stdout_r.close                unless stdout_r.closed?
       stderr_r.close                unless stderr_r.closed?
     else
+      # If no block given (not interactive) we should close stdin_w because we
+      # won't be able to give input which may cause a hang.
+      stdin_w.close
       # Log both stdout and stderr as 'info' because nobody uses stderr for
       # actually reporting errors and as a result 'stderr' is a misnomer.
       logger.pipe(stdout_r => :info, stderr_r => :info)
@@ -421,7 +424,7 @@ module FPM::Util
     # to invoke ERB.new correctly and without printed warnings.
     # References: https://github.com/jordansissel/fpm/issues/1894
     # Honestly, I'm not sure if Gem::Version is correct to use in this situation, but it works.
-    
+
     # on older versions of Ruby, RUBY_VERSION is a frozen string, and
     # Gem::Version.new calls String#strip! which throws an exception.
     # so we have to call String#dup to get an unfrozen copy.

--- a/spec/fpm/util_spec.rb
+++ b/spec/fpm/util_spec.rb
@@ -98,6 +98,14 @@ describe FPM::Util do
         subject.safesystem("true")
       end
     end
+
+    it "should not prompt for input" do
+      expect {
+        Timeout::timeout(3) do
+          subject.safesystem("sh", "-c", "read foo || true")
+        end
+      }.not_to raise_error
+    end
   end
 
   describe "#expand_pessimistic_constraints" do

--- a/spec/fpm/util_spec.rb
+++ b/spec/fpm/util_spec.rb
@@ -2,6 +2,7 @@ require "spec_setup"
 require "fpm" # local
 require "fpm/util" # local
 require "stud/temporary"
+require "timeout"
 
 
 describe FPM::Util do
@@ -105,6 +106,12 @@ describe FPM::Util do
           subject.safesystem("sh", "-c", "read foo || true")
         end
       }.not_to raise_error
+    end
+
+    it "should pipe command output to logger" do
+      logger = Cabin::Channel.get
+      expect(logger).to receive(:pipe)
+      subject.safesystem("true")
     end
   end
 


### PR DESCRIPTION
This PR fixes issue https://github.com/jordansissel/fpm/issues/1519 and https://github.com/jordansissel/fpm/issues/1522.

I based my fix off [this commit](https://github.com/jordansissel/fpm/pull/1610/commits/ae9594eb098f74c55166729d317d86af83e3b3f9) from https://github.com/jordansissel/fpm/pull/1610 that was never merged.

Because Inline::CPP version 0.80 has an interactive Makefile.PL, the bug can be reproduced by running the following command on the main branch (this command will hang):
```
fpm --no-cpan-test --cpan-verbose --verbose --debug-workspace --workdir $HOME/tmp -t rpm -s cpan -v 0.80 Inline::CPP
```
Part of the issue in #1522 is that @wbraswell could not see the output from cpanminus, however this problem was fixed at some point. I added a test to `util_spec.rb` to ensure that the loggers `pipe` method is invoked during execution of `safesystem`. I would have liked to say `expect(logger).to receive(:pipe).with(instance_of(IO) => :info, instance_of(IO) => :info)`, but rspec does not allow you to use the `instance_of` matcher on the keys of a hash argument. Due to this limitation I am not able to ensure that `pipe` is called with the correct arguments, but this test should still be good enough.