### PR TITLE
Support for source based packages

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -191,12 +191,12 @@ class FPM::Package
   end # def type
 
   # Convert this package to a new package type
-  def convert(klass)
+  def convert(klass, recipe_file)
     logger.info("Converting #{self.type} to #{klass.type}")
 
     exclude
 
-    pkg = klass.new
+    pkg = recipe_file ? klass.new(recipe_file) : klass.new
     pkg.cleanup_staging # purge any directories that may have been created by klass.new
 
     # copy other bits
@@ -414,7 +414,9 @@ class FPM::Package
     # Lets us track all known FPM::Package subclasses
     def inherited(klass)
       @subclasses ||= {}
-      @subclasses[klass.name.gsub(/.*:/, "").downcase] = klass
+      unless klass.name == 'FPM::SourcePackage'
+        @subclasses[klass.name.gsub(/.*:/, "").downcase] = klass
+      end
     end # def self.inherited
 
     # Get a list of all known package subclasses

--- a/lib/fpm/package/srpm.rb
+++ b/lib/fpm/package/srpm.rb
@@ -1,0 +1,64 @@
+require "fpm/source_package"
+require "fileutils"
+
+class FPM::Package::SRPM < FPM::SourcePackage
+
+  def output(output_path)
+    output_check(output_path)
+
+    %w(BUILD RPMS SRPMS SOURCES SPECS).each { |d| FileUtils.mkdir_p(build_path(d)) }
+
+    spec_file = staging_path("#{name}.spec")
+    # puts "spec_file = #{spec_file}"
+
+    File.open(spec_file, "w+") do |file|
+
+      if name = name()
+        file.write("Name: #{name}\n")
+      end
+
+      if version = version()
+        file.write("Version: #{version}\n")
+      end
+
+      if license = license()
+        file.write("License: #{license}\n")
+      end
+
+      if release = iteration()
+        file.write("Release: #{release}\n")
+      else
+        file.write("Release: 1\n")
+      end
+
+      if download_url = recipe.download
+        download_source(download_url.chomp, build_path("SOURCES"))
+        file.write("Url: #{download_url}\n")
+        file.write("Source0: #{download_url}\n")
+      end
+
+      if summary = description()
+        file.write("Summary: #{summary}\n")
+        file.write("%description\n#{summary}\n\n")
+      end
+
+      if prebuild_instructions = recipe.prebuild
+        file.write("%prep\n#{prebuild_instructions}\n\n")
+      end
+
+      if build_instructions = recipe.build
+        file.write("%build\n#{build_instructions}\n\n")
+      end
+
+      if install_instructions = recipe.install
+        file.write("%install\n#{install_instructions}\n\n")
+      end
+    end
+
+    safesystem("rpmbuild", "-bs", "--define", "_topdir #{build_path}", spec_file)
+
+    ::Dir["#{build_path}/SRPMS/*.src.rpm"].each do |srpm|
+      FileUtils.cp(srpm, output_path)
+    end
+  end
+end

--- a/lib/fpm/recipe.rb
+++ b/lib/fpm/recipe.rb
@@ -1,0 +1,50 @@
+require "fpm/util"
+
+class FPM::Recipe
+
+  RECIPE_SECTIONS = [ :download,
+                      :prebuild,
+                      :build,
+                      :install,
+                    ]
+
+  attr_accessor(*RECIPE_SECTIONS)
+
+  def initialize(recipe_file)
+    recipe_file = File.expand_path(recipe_file)
+
+    unless File.file?(recipe_file)
+      STDERR.puts "recipe file #{recipe_file} does not exist"
+      exit 1
+    end
+
+    # parse recipe_file
+    cur_section = nil
+    cur_val = nil
+    File.foreach(recipe_file) do |line|
+      line.chomp!.gsub!(/ *#.*| +$/, '')
+      next if line =~ /^$/
+      if section_name = section_tag?(line)
+        if !cur_section # this is the first section tag we have seen.
+          cur_section = section_name
+          cur_val = ""
+        else
+          instance_variable_set("@#{cur_section}", cur_val)
+          cur_section = section_name
+          cur_val = ""
+        end
+      else # this line is not a section
+        cur_val += line
+      end
+    end
+    if cur_section and cur_val
+      self.instance_variable_set("@#{cur_section}", cur_val)
+    end
+  end
+
+  private
+  def section_tag?(line)
+    # Note that no trimming of +line+ happens here
+    line[/^\[(#{RECIPE_SECTIONS.join("|")})\]$/, 1]
+  end
+end

--- a/lib/fpm/recipe.rb
+++ b/lib/fpm/recipe.rb
@@ -22,7 +22,7 @@ class FPM::Recipe
     cur_section = nil
     cur_val = nil
     File.foreach(recipe_file) do |line|
-      line.chomp!.gsub!(/ *#.*| +$/, '')
+      line.gsub!(/ *#.*| +$/, '')
       next if line =~ /^$/
       if section_name = section_tag?(line)
         if !cur_section # this is the first section tag we have seen.

--- a/lib/fpm/source_package.rb
+++ b/lib/fpm/source_package.rb
@@ -1,0 +1,29 @@
+require "fpm/package"
+require "fpm/recipe"
+
+# This class is the parent of all source based packages.
+# If you want to implement a source based FPM package type, you'll inherit from
+# this.
+class FPM::SourcePackage < FPM::Package
+  attr_reader :recipe
+
+  def initialize(recipe_file)
+    super()
+    @recipe = FPM::Recipe.new(recipe_file)
+  end
+
+  def download_source(url, dir)
+    safesystem("wget", "-P", dir, url)
+  end
+
+  class << self
+    def inherited(klass)
+      @subclasses ||= {}
+      @subclasses[klass.name.gsub(/.*:/, "").downcase] = klass
+    end
+
+    def types
+      return @subclasses
+    end
+  end
+end


### PR DESCRIPTION
This PR is not meant to be merged!

This a prototype showing that FPM can support source based packages (#1954) with the purpose of furthering the discussion. This PR almost certainly contains bugs and is not feature complete in terms of producing SRPM's.

Given the following recipe:

```
[download]
https://cpan.metacpan.org/authors/id/E/ET/ETHER/File-Temp-0.2311.tar.gz

[build]
perl Makefile.pl
make
make test

[install]
make install
```
If we run the command:
```
bundle exec fpm --workdir $WORKDIR -t srpm -s cpan -r $RECIPE_DIR/recipe File::Temp
```
We get a SRPM with the following spec file:

```
Name: perl-File-Temp
Version: 0.2311
License: perl_5
Release: 1
Url: https://cpan.metacpan.org/authors/id/E/ET/ETHER/File-Temp-0.2311.tar.gz

Source0: https://cpan.metacpan.org/authors/id/E/ET/ETHER/File-Temp-0.2311.tar.gz

Summary: return name and handle of a temporary file safely

%description
return name and handle of a temporary file safely

%build
perl Makefile.pl
make
make test

%install
make install
```