### PR TITLE
Reject invalid Debian version values.

### DIFF
--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -127,9 +127,28 @@ describe FPM::Package::Deb do
   end
 
   context "when validating the version field" do
-    pending "it should reject invalid versions"
-    pending "it should convert v-prefixed-but-otherwise-valid versions"
-    pending "it should accept valid versions"
+    [ "_", "1_2", "abc def", "%", "1^a"].each do |v|
+      it "should reject as invalid, '#{v}'" do
+        subject.version = v
+        insist { subject.version }.raises FPM::InvalidPackageConfiguration
+      end
+    end
+
+    [ "1", "1.2", "1.2.3", "20200101", "1~beta", "1whatever"].each do |v|
+      it "should accept '#{v}'" do
+        subject.version = v
+
+        # should not raise exception
+        insist { subject.version } == v
+      end
+
+      it "should remove a leading 'v' from v#{v} and still accept it" do
+        subject.version = "v#{v}"
+
+        # should not raise exception
+        insist { subject.version } == v
+      end
+    end
   end
 
   describe "#output" do

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -126,6 +126,12 @@ describe FPM::Package::Deb do
     end
   end
 
+  context "when validating the version field" do
+    pending "it should reject invalid versions"
+    pending "it should convert v-prefixed-but-otherwise-valid versions"
+    pending "it should accept valid versions"
+  end
+
   describe "#output" do
     let(:original) { FPM::Package::Deb.new }
     let(:input) { FPM::Package::Deb.new }


### PR DESCRIPTION
This fixes #1847 by adding an actionable error message when someone provides a version value that Debian's policy and tools will reject.

Includes test coverage :)