### PR TITLE
Upgrades to cpan_spec.rb

### DIFF
--- a/spec/fpm/package/cpan_spec.rb
+++ b/spec/fpm/package/cpan_spec.rb
@@ -6,10 +6,8 @@ require "fpm/package/cpan" # local
 have_cpanm = program_exists?("cpanm")
 if !have_cpanm
   Cabin::Channel.get("rspec") \
-    .warn("Skipping CPAN#input tests because 'cpanm' isn't in your PATH")
+    .warn("Skipping CPAN tests because 'cpanm' isn't in your PATH")
 end
-
-is_travis = ENV["TRAVIS_OS_NAME"] && !ENV["TRAVIS_OS_NAME"].empty?
 
 describe FPM::Package::CPAN do
   before do
@@ -22,8 +20,44 @@ describe FPM::Package::CPAN do
     subject.cleanup
   end
 
+  it "should prepend package name prefix" do
+    subject.attributes[:cpan_package_name_prefix] = "prefix"
+    insist { subject.instance_eval { fix_name("Foo::Bar") } } == "prefix-Foo-Bar"
+  end
+
+  it "should wrap name in perl()" do
+    insist { subject.instance_eval { cap_name("Foo::Bar") } } == "perl(Foo::Bar)"
+  end
+
+  it "should return successful HTTP resonse" do
+    response = subject.instance_eval { httpfetch("https://fastapi.metacpan.org/v1/module/File::Temp") }
+    insist { response.class } == Net::HTTPOK
+  end
+
+  it "should return successful HTTP resonse" do
+    response = subject.instance_eval {httppost(
+      "https://fastapi.metacpan.org/v1/release/_search",
+      "{\"fields\":[\"download_url\"],\"filter\":{\"term\":{\"name\":\"File-Temp-0.2310\"}}}"
+    )}
+    insist { response.class } == Net::HTTPOK
+  end
+
+  it "should return metadata hash" do
+    metadata = subject.instance_eval { search("File::Temp") }
+    insist { metadata.class } == Hash
+    insist { metadata["name"] } == "Temp.pm"
+    insist { metadata["distribution"] } == "File-Temp"
+  end
+
+  it "should download precise version" do
+    metadata = subject.instance_eval { search("File::Temp") }
+    insist { File.basename(subject.instance_eval { download(metadata, "0.2310")}) } == "File-Temp-0.2310.tar.gz"
+  end
+
   it "should package Digest::MD5" do
-    pending("Disabled on travis-ci because it always fails, and there is no way to debug it?") if is_travis
+    # Set the version explicitly because we default to installing the newest
+    # version, and a new version could be released that breaks the test.
+    subject.instance_variable_set(:@version, "2.58");
 
     # Disable testing because we don't really need to run the cpan tests. The
     # goal is to see the parsed result (name, module description, etc)
@@ -31,15 +65,15 @@ describe FPM::Package::CPAN do
     # to not finding `Test.pm`, and it seems like a flakey test if we keep this
     # enabled.
     subject.attributes[:cpan_test?] = false
+
     subject.input("Digest::MD5")
     insist { subject.name } == "perl-Digest-MD5"
     insist { subject.description } == "Perl interface to the MD-5 algorithm"
     insist { subject.vendor } == "Gisle Aas <gisle@activestate.com>"
-    # TODO(sissel): Check dependencies
+    insist { subject.dependencies.sort } == ["perl >= 5.006", "perl(Digest::base) >= 1.00", "perl(XSLoader)"]
   end
 
   it "should unpack tarball containing ./ leading paths" do
-    pending("Disabled on travis-ci because it always fails, and there is no way to debug it?") if is_travis
 
     Dir.mktmpdir do |tmpdir|
       # Create tarball containing a file './foo/bar.txt'
@@ -55,7 +89,9 @@ describe FPM::Package::CPAN do
   end
 
   it "should package File::Spec" do
-    pending("Disabled on travis-ci because it always fails, and there is no way to debug it?") if is_travis
+    subject.instance_variable_set(:@version, "3.75");
+    subject.attributes[:cpan_test?] = false
+
     subject.input("File::Spec")
 
     # the File::Spec module comes from the PathTools CPAN distribution
@@ -63,21 +99,21 @@ describe FPM::Package::CPAN do
   end
 
   it "should package Class::Data::Inheritable" do
-    pending("Disabled on travis-ci because it always fails, and there is no way to debug it?") if is_travis
-
     # Class::Data::Inheritable version 0.08 has a blank author field in its
     # META.yml file.
     subject.instance_variable_set(:@version, "0.08");
+
+    subject.attributes[:cpan_test?] = false
+
     subject.input("Class::Data::Inheritable")
     insist { subject.vendor } == "No Vendor Or Author Provided"
   end
 
   context "given a distribution without a META.* file" do
     it "should package IPC::Session" do
-      pending("Disabled on travis-ci because it always fails, and there is no way to debug it?") if is_travis
-
-      # IPC::Session fails 'make test'
+      subject.instance_variable_set(:@version, "0.05");
       subject.attributes[:cpan_test?] = false
+      # IPC::Session fails 'make test'
       subject.input("IPC::Session")
     end
   end

--- a/spec/spec_setup.rb
+++ b/spec/spec_setup.rb
@@ -5,6 +5,9 @@ require "tmpdir" # stdlib
 require "tempfile" # stdlib
 require "fileutils" # stdlib
 require "date" # stdlib
+require "net/http" # stdlib
+require "json" # stdlib
+require "yaml" # stdlib
 
 # put "lib" in RUBYLIB
 $: << File.join(File.dirname(File.dirname(__FILE__)), "lib")


### PR DESCRIPTION
I upgraded `cpan_spec.rb` so every method defined in `cpan.rb` has its own test.

I upgraded the existing tests to explicitly set package versions to avoid the scenario that a new version of a CPAN distribution is released that breaks the test.

I also removed the stuff related to Travis CI as FPM now uses GitHub Actions.

On my machine these changes make the test suite take 5 seconds longer to run.

Let me know what you think!