### PR TITLE
Replace deprecated {File,Dir}.exists? with {File,Dir}.exist?

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -298,7 +298,7 @@ class FPM::Command < Clamp::Command
       args << "."
     end
 
-    if !File.exists?(workdir)
+    if !File.exist?(workdir)
       logger.fatal("Given --workdir=#{workdir} is not a path that exists.")
       raise FPM::Package::InvalidArgument, "The given workdir '#{workdir}' does not exist."
     end
@@ -371,7 +371,7 @@ class FPM::Command < Clamp::Command
 
     # If --inputs was specified, read it as a file.
     if !inputs.nil?
-      if !File.exists?(inputs)
+      if !File.exist?(inputs)
         logger.fatal("File given for --inputs does not exist (#{inputs})")
         return 1
       end
@@ -386,7 +386,7 @@ class FPM::Command < Clamp::Command
     # If --exclude-file was specified, read it as a file and append to
     # the exclude pattern list.
     if !exclude_file.nil?
-      if !File.exists?(exclude_file)
+      if !File.exist?(exclude_file)
         logger.fatal("File given for --exclude-file does not exist (#{exclude_file})")
         return 1
       end
@@ -451,7 +451,7 @@ class FPM::Command < Clamp::Command
       # Skip scripts not set
       next if path.nil?
 
-      if !File.exists?(path)
+      if !File.exist?(path)
         logger.error("No such file (for #{scriptname.to_s}): #{path.inspect}")
         script_errors << path
       end

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -591,7 +591,7 @@ class FPM::Package::Deb < FPM::Package
       end # No need to close, GzipWriter#close will close it.
     end
 
-    if File.exists?(dest_changelog) and not File.exists?(dest_upstream_changelog)
+    if File.exist?(dest_changelog) and not File.exist?(dest_upstream_changelog)
       # see https://www.debian.org/doc/debian-policy/ch-docs.html#s-changelogs
       File.rename(dest_changelog, dest_upstream_changelog)
     end
@@ -747,7 +747,7 @@ class FPM::Package::Deb < FPM::Package
 
     if origin == FPM::Package::Deb
       changelog_path = staging_path("usr/share/doc/#{name}/changelog.Debian.gz")
-      if File.exists?(changelog_path)
+      if File.exist?(changelog_path)
         logger.debug("Found a deb changelog file, using it.", :path => changelog_path)
         attributes[:deb_changelog] = build_path("deb_changelog")
         File.open(attributes[:deb_changelog], "w") do |deb_changelog|
@@ -761,7 +761,7 @@ class FPM::Package::Deb < FPM::Package
 
     if origin == FPM::Package::Deb
       changelog_path = staging_path("usr/share/doc/#{name}/changelog.gz")
-      if File.exists?(changelog_path)
+      if File.exist?(changelog_path)
         logger.debug("Found an upstream changelog file, using it.", :path => changelog_path)
         attributes[:deb_upstream_changelog] = build_path("deb_upstream_changelog")
         File.open(attributes[:deb_upstream_changelog], "w") do |deb_upstream_changelog|
@@ -1038,7 +1038,7 @@ class FPM::Package::Deb < FPM::Package
     etcfiles = []
     # Add everything in /etc
     begin
-      if !attributes[:deb_no_default_config_files?] && File.exists?(staging_path("/etc"))
+      if !attributes[:deb_no_default_config_files?] && File.exist?(staging_path("/etc"))
         logger.warn("Debian packaging tools generally labels all files in /etc as config files, " \
                     "as mandated by policy, so fpm defaults to this behavior for deb packages. " \
                     "You can disable this default behavior with --deb-no-default-config-files flag")

--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -43,7 +43,7 @@ class FPM::Package::Dir < FPM::Package
     # This mapping should work the same way 'rsync -a' does
     #   Meaning 'rsync -a source dest'
     #   and 'source=dest' in fpm work the same as the above rsync
-    if path =~ /.=./ && !File.exists?(chdir == '.' ? path : File.join(chdir, path))
+    if path =~ /.=./ && !File.exist?(chdir == '.' ? path : File.join(chdir, path))
       origin, destination = path.split("=", 2)
 
       if File.directory?(origin) && origin[-1,1] == "/"

--- a/lib/fpm/package/puppet.rb
+++ b/lib/fpm/package/puppet.rb
@@ -60,7 +60,7 @@ class FPM::Package::Puppet < FPM::Package
       end # case name
     end # self.scripts.each
 
-    if File.exists?(params[:output])
+    if File.exist?(params[:output])
       # TODO(sissel): Allow folks to choose output?
       logger.error("Puppet module directory '#{params[:output]}' already " \
                     "exists. Delete it or choose another output (-p flag)")

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -345,7 +345,7 @@ module FPM::Util
     when 'characterSpecial', 'blockSpecial'
       raise  UnsupportedSpecialFile.new("File is device which fpm doesn't know how to copy (#{File.ftype(src)}): #{src}")
     when 'directory'
-      FileUtils.mkdir(dst) unless File.exists? dst
+      FileUtils.mkdir(dst) unless File.exist? dst
     else
       # if the file with the same dev and inode has been copied already -
       # hard link it's copy to `dst`, otherwise make an actual copy

--- a/spec/fpm/package/tar_spec.rb
+++ b/spec/fpm/package/tar_spec.rb
@@ -26,7 +26,7 @@ describe FPM::Package::Tar do
     end
 
     it "doesn't include a .scripts folder" do
-      insist { Dir.exists?(File.join(output_dir, '.scripts')) } == false
+      insist { Dir.exist?(File.join(output_dir, '.scripts')) } == false
     end
 
     after do

--- a/spec/fpm/package/virtualenv_spec.rb
+++ b/spec/fpm/package/virtualenv_spec.rb
@@ -38,7 +38,7 @@ describe FPM::Package::Virtualenv, :if => virtualenv_usable? do
 
       activate_path = File.join(subject.build_path, '/usr/share/python/pip/bin/activate')
 
-      expect(File.exists?(activate_path)).to(be_truthy)
+      expect(File.exist?(activate_path)).to(be_truthy)
     end
 
     it "can override the version specified on the input" do
@@ -85,7 +85,7 @@ describe FPM::Package::Virtualenv, :if => virtualenv_usable? do
       subject.input("pip==8.1.2")
 
       activate_path = File.join(subject.build_path, '/opt/foo/pip/bin/activate')
-      expect(File.exists?(activate_path)).to(be_truthy)
+      expect(File.exist?(activate_path)).to(be_truthy)
     end
   end
 
@@ -95,10 +95,10 @@ describe FPM::Package::Virtualenv, :if => virtualenv_usable? do
       subject.input("pip==8.1.2")
 
       activate_path = File.join(subject.build_path, '/usr/share/python/pip/bin/activate')
-      expect(File.exists?(activate_path)).to(be_truthy)
+      expect(File.exist?(activate_path)).to(be_truthy)
 
       egg_path =  File.join(subject.build_path, '/setup.py')
-      expect(File.exists?(egg_path)).to(be_truthy)
+      expect(File.exist?(egg_path)).to(be_truthy)
     end
   end
 
@@ -118,7 +118,7 @@ describe FPM::Package::Virtualenv, :if => virtualenv_usable? do
         subject.input(File.join(fixtures_dir, 'requirements.txt'))
 
         activate_path = File.join(subject.build_path, '/usr/share/python/virtualenv/bin/activate')
-        expect(File.exists?(activate_path)).to(be_truthy)
+        expect(File.exist?(activate_path)).to(be_truthy)
         expect(subject.name).to eq("virtualenv-virtualenv")
       end
     end
@@ -129,7 +129,7 @@ describe FPM::Package::Virtualenv, :if => virtualenv_usable? do
         subject.input(File.join(fixtures_dir, 'requirements.txt'))
         activate_path = File.join(subject.build_path, '/usr/share/python/virtualenv/bin/activate')
 
-        expect(File.exists?(activate_path)).to(be_truthy)
+        expect(File.exist?(activate_path)).to(be_truthy)
 
         expect(subject.name).to eq("virtualenv-foo")
       end
@@ -143,7 +143,7 @@ describe FPM::Package::Virtualenv, :if => virtualenv_usable? do
 
       activate_path = File.join(subject.staging_path, '/opt/foo/bin/activate')
 
-      expect(File.exists?(activate_path)).to(be_truthy)
+      expect(File.exist?(activate_path)).to(be_truthy)
     end
 
     it "takes precedence over other folder options" do
@@ -153,7 +153,7 @@ describe FPM::Package::Virtualenv, :if => virtualenv_usable? do
 
       activate_path = File.join(subject.staging_path, '/opt/foo/bin/activate')
 
-      expect(File.exists?(activate_path)).to(be_truthy)
+      expect(File.exist?(activate_path)).to(be_truthy)
     end
   end
 end


### PR DESCRIPTION
Ruby 3.2.0 was just released, and the deprecated methods `File.exists?` and `Dir.exists?` were completely removed. These methods are used in FPM, so FPM is currently broken under Ruby 3.2.0. Instead we are supposed to use the `File.exist?` and `Dir.exist?` methods. This PR replaces all occurrence of these deprecated methods with their preferred counterpart.