### PR TITLE
Fix bug in deb.rb outputting erroneous conffiles file when specifying upstart config

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -1090,7 +1090,7 @@ class FPM::Package::Deb < FPM::Package
       end
       upstarts.each do |upstart|
         name = File.basename(upstart, ".upstart")
-        upstartscript = "etc/init/#{name}.conf"
+        upstartscript = "/etc/init/#{name}.conf"
         logger.debug("Add conf file declaration for upstart script", :script => upstartscript)
         allconfigs << upstartscript[1..-1]
       end


### PR DESCRIPTION
This PR fixes a bug in `deb.rb` where adding an upstart configuration file via the `--deb-upstart` flag, causes FPM to output a deb package with an erroneous `conffiles` file.

Steps to reproduce:

```
$ cd $FPM_ROOT
$ touch /tmp/foo.upstart
$ bundle exec fpm -t deb -s cpan --deb-upstart /tmp/foo.upstart -p /tmp/perl-file-temp_VERSION_all.deb --log error File::Temp
Created package {:path=>"/tmp/perl-file-temp_0.2311_all.deb"}
$ cd /tmp
$ ar x perl-file-temp_0.2311_all.deb
$ tar -xf control.tar.gz
$ cat conffiles
/etc/init/foo.conf
/tc/init/foo.conf
```

This example shows that the `conffiles` file erroneously constains the value `/tc/init/foo.conf`.

With the fix from this PR the `conffiles` file contains only `/etc/init/foo.conf`.