### PR TITLE
Fix failing test when run on arm64/aarch64 systems 

### DIFF
--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -53,7 +53,13 @@ describe FPM::Package::Deb do
 
     it "should default to native" do
       # Convert kernel name to debian name
-      expected = native == "x86_64" ? "amd64" : native
+      expected = if native == "x86_64"
+        "amd64"
+      elsif native == "aarch64"
+        "arm64"
+      else
+        native
+      end
       expect(subject.architecture).to(be == expected)
     end
   end


### PR DESCRIPTION
This was a bug in the test suite.

```
  1) FPM::Package::Deb#architecture should default to native
     Failure/Error: expect(subject.architecture).to(be == expected)
       expected: == "aarch64"
            got:    "arm64"
     # ./spec/fpm/package/deb_spec.rb:57:in `block (3 levels) in <top (required)>'
```