### PR TITLE
support building python modules from a git source

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -293,6 +293,14 @@ class FPM::Package
     end
   end # def cleanup_build
 
+  def download_from_git(download_dir, url, branch)
+    logger.debug("Git cloning in directory #{download_dir}")
+    safesystem("git", "-C", download_dir, "clone", url, ".")
+    if branch
+      safesystem("git", "-C", download_dir, "checkout", branch)
+    end
+  end
+
   # List all files in the staging_path
   #
   # The paths will all be relative to staging_path and will not include that

--- a/lib/fpm/package/gem.rb
+++ b/lib/fpm/package/gem.rb
@@ -104,11 +104,7 @@ class FPM::Package::Gem < FPM::Package
     FileUtils.mkdir(download_dir) unless File.directory?(download_dir)
 
     if attributes[:gem_git_repo]
-      logger.debug("Git cloning in directory #{download_dir}")
-      safesystem("git", "-C", download_dir, "clone", attributes[:gem_git_repo], ".")
-      if attributes[:gem_git_branch]
-        safesystem("git", "-C", download_dir, "checkout", attributes[:gem_git_branch])
-      end
+      download_from_git(download_dir, attributes[:gem_git_repo], attributes[:gem_git_branch])
 
       gem_build = [ "#{attributes[:gem_gem]}", "build", "#{download_dir}/#{gem_name}.gemspec"]
       ::Dir.chdir(download_dir) do |dir|


### PR DESCRIPTION
The makes the building of python modules support a git repo URL (and optional branch) the same way as currently done for ruby gems.

Example to build an old version of the `requests` module on AlmaLinux 8:
```
bin/fpm --verbose -s python -t rpm -f --architecture noarch --rpm-auto-add-directories --python-bin python3.6 --python-package-name-prefix python3 --python-pip /usr/bin/pip3.6  --python-git-repo https://github.com/psf/requests.git --python-git-branch v2.5.0 requests
```

Thanks,
Corey