### PR TITLE
fix building of python modules that have tarballs named .tgz and .zip

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -171,13 +171,20 @@ class FPM::Package::Python < FPM::Package
       # behind a directory with the Python package extracted and ready to be used.
       # For example, `pip download ... Django` puts `Django-4.0.4.tar.tz` into the build_path directory.
       # If we expect `pip` to leave an unknown-named file in the `build_path` directory, let's check for
-      # a single file and unpack it.  I don't know if it will /always/ be a .tar.gz though.
-      files = ::Dir.glob(File.join(build_path, "*.tar.gz"))
-      if files.length != 1
+      # a single file and unpack it. Iterate over recognized file formats.
+      ::Dir.chdir(build_path) do
+        files = ::Dir.glob(["*.tar.gz", "*.tgz"])
+        if files.length == 1
+          safesystem("tar", "-zxf", files[0], "-C", target)
+          break
+        end
+        files = ::Dir.glob("*.zip")
+        if files.length == 1
+          safesystem("unzip", files[0], "-d", target)
+          break
+        end
         raise "Unexpected directory layout after `pip download ...`. This might be an fpm bug? The directory is #{build_path}"
       end
-
-      safesystem("tar", "-zxf", files[0], "-C", target)
     else
       # no pip, use easy_install
       logger.debug("no pip, defaulting to easy_install", :easy_install => attributes[:python_easyinstall])


### PR DESCRIPTION
This fixes building of (at least):
https://pypi.org/project/amqplib/1.0.2/
https://pypi.org/project/dnspython/1.15.0/

Wrap the operation within a Dir.chdir() to simplify the use of multiple globs (older ruby does not support the ':base' option to Dir.glob()).