### PR TITLE
Add support for zstd compression for deb packages.

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -27,7 +27,7 @@ class FPM::Package::Deb < FPM::Package
   } unless defined?(SCRIPT_MAP)
 
   # The list of supported compression types. Default is gz (gzip)
-  COMPRESSION_TYPES = [ "gz", "bzip2", "xz", "none" ]
+  COMPRESSION_TYPES = [ "gz", "bzip2", "xz", "zst", "none" ]
 
   # https://www.debian.org/doc/debian-policy/ch-relationships.html#syntax-of-relationship-fields
   # Example value with version relationship: libc6 (>= 2.2.1)
@@ -332,6 +332,9 @@ class FPM::Package::Deb < FPM::Package
       when "xz"
         controltar = "control.tar.xz"
         compression = "-J"
+      when "zst"
+        controltar = "control.tar.zst"
+        compression = "-I zstd"
       when 'tar'
         controltar = "control.tar"
         compression = ""
@@ -344,7 +347,7 @@ class FPM::Package::Deb < FPM::Package
 
     build_path("control").tap do |path|
       FileUtils.mkdir(path) if !File.directory?(path)
-      # unpack the control.tar.{,gz,bz2,xz} from the deb package into staging_path
+      # unpack the control.tar.{,gz,bz2,xz,zst} from the deb package into staging_path
       # Unpack the control tarball
       safesystem(ar_cmd[0] + " p #{package} #{controltar} | tar #{compression} -xf - -C #{path}")
 
@@ -454,6 +457,9 @@ class FPM::Package::Deb < FPM::Package
       when "xz"
         datatar = "data.tar.xz"
         compression = "-J"
+      when "zst"
+        datatar = "data.tar.zst"
+        compression = "-I zstd"
       when 'tar'
         datatar = "data.tar"
         compression = ""
@@ -650,6 +656,10 @@ class FPM::Package::Deb < FPM::Package
         datatar = build_path("data.tar.xz")
         controltar = build_path("control.tar.xz")
         compression_flags = ["-J"]
+      when "zst"
+        datatar = build_path("data.tar.zst")
+        controltar = build_path("control.tar.zst")
+        compression_flags = ["-I zstd"]
       when "none"
         datatar = build_path("data.tar")
         controltar = build_path("control.tar")
@@ -721,7 +731,7 @@ class FPM::Package::Deb < FPM::Package
         else
           # Also replace '::' in the perl module name with '-'
           modulename = m["name"].gsub("::", "-")
-         
+
           # Fix any upper-casing or other naming concerns Debian has about packages
           name = "#{attributes[:cpan_package_name_prefix]}-#{modulename}"
 
@@ -937,6 +947,9 @@ class FPM::Package::Deb < FPM::Package
       when "xz"
         controltar = "control.tar.xz"
         compression_flags = ["-J"]
+      when "zst"
+        controltar = "control.tar.zst"
+        compression_flags = ["-I zstd"]
       when "none"
         controltar = "control.tar"
         compression_flags = []

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -413,7 +413,7 @@ describe FPM::Package::Deb do
 
     context "when run against lintian" do
       before do
-        skip("Missing lintian program") unless have_lintian 
+        skip("Missing lintian program") unless have_lintian
       end
 
       lintian_errors_to_ignore = [
@@ -535,7 +535,8 @@ describe FPM::Package::Deb do
     {
       "bzip2" => "bz2",
       "xz" => "xz",
-      "gz" => "gz"
+      "gz" => "gz",
+      "zst" => "zst"
     }.each do |flag,suffix|
       context "when --deb-compression is #{flag}" do
         let(:target) { Stud::Temporary.pathname + ".deb" }


### PR DESCRIPTION
This PR adds what it says on the tin to make fpm compatible with recent Debian and derivatives which implement zstd compression for their packages.

Fixes https://github.com/jordansissel/fpm/issues/2007.