### PR TITLE
Fix hyperlink on installation docs

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -7,7 +7,7 @@ Installing FPM
 --------------
 
 .. note::
-	You must have ruby installed on your machine before installing fpm. `Here` are instructions to install Ruby on your machine.
+	You must have ruby installed on your machine before installing fpm. `Here`_ are instructions to install Ruby on your machine.
 
 .. _Here: https://www.ruby-lang.org/en/documentation/installation/
 


### PR DESCRIPTION
Fixing a typo on the installation page, the `Here` should have an underscore right after for it to be a hyperlink :+1: 