### PR TITLE
fix RPM documentation links in docs and code

### DIFF
--- a/docs/cli-reference.rst
+++ b/docs/cli-reference.rst
@@ -532,7 +532,7 @@ General Options
     - (rpm only) Add FILEPATH as an init script
 
 * ``--[no-]rpm-macro-expansion``
-    - (rpm only) install-time macro expansion in %pre %post %preun %postun scripts (see: https://rpm.org/user_doc/scriptlet_expansion.html)
+    - (rpm only) install-time macro expansion in %pre %post %preun %postun scripts (see: https://rpm-software-management.github.io/rpm/manual/scriptlet_expansion.html)
 
 * ``--rpm-os OS``
     - (rpm only) The operating system to target this rpm for. You want to set this to 'linux' if you are using fpm on OS X, for example
@@ -556,16 +556,16 @@ General Options
     - (rpm only) Adds a custom tag in the spec file as is. Example: --rpm-tag 'Requires(post): /usr/sbin/alternatives'
 
 * ``--rpm-trigger-after-install '[OPT]PACKAGE: FILEPATH'``
-    - (rpm only) Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - (rpm only) Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 
 * ``--rpm-trigger-after-target-uninstall '[OPT]PACKAGE: FILEPATH'``
-    - (rpm only) Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - (rpm only) Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 
 * ``--rpm-trigger-before-install '[OPT]PACKAGE: FILEPATH'``
-    - (rpm only) Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - (rpm only) Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 
 * ``--rpm-trigger-before-uninstall '[OPT]PACKAGE: FILEPATH'``
-    - (rpm only) Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - (rpm only) Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 
 * ``--[no-]rpm-use-file-permissions``
     - (rpm only) Use existing file permissions when defining ownership and modes.
@@ -976,7 +976,7 @@ rpm
 * ``--rpm-init FILEPATH``
     - Add FILEPATH as an init script
 * ``--[no-]rpm-macro-expansion``
-    - install-time macro expansion in %pre %post %preun %postun scripts (see: https://rpm.org/user_doc/scriptlet_expansion.html)
+    - install-time macro expansion in %pre %post %preun %postun scripts (see: https://rpm-software-management.github.io/rpm/manual/scriptlet_expansion.html)
 * ``--rpm-os OS``
     - The operating system to target this rpm for. You want to set this to 'linux' if you are using fpm on OS X, for example
 * ``--rpm-posttrans FILE``
@@ -992,13 +992,13 @@ rpm
 * ``--rpm-tag TAG``
     - Adds a custom tag in the spec file as is. Example: --rpm-tag 'Requires(post): /usr/sbin/alternatives'
 * ``--rpm-trigger-after-install '[OPT]PACKAGE: FILEPATH'``
-    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 * ``--rpm-trigger-after-target-uninstall '[OPT]PACKAGE: FILEPATH'``
-    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 * ``--rpm-trigger-before-install '[OPT]PACKAGE: FILEPATH'``
-    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 * ``--rpm-trigger-before-uninstall '[OPT]PACKAGE: FILEPATH'``
-    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 * ``--[no-]rpm-use-file-permissions``
     - Use existing file permissions when defining ownership and modes.
 * ``--rpm-user USER``

--- a/docs/packages/cli/rpm.rst
+++ b/docs/packages/cli/rpm.rst
@@ -35,7 +35,7 @@
 * ``--rpm-init FILEPATH``
     - Add FILEPATH as an init script
 * ``--[no-]rpm-macro-expansion``
-    - install-time macro expansion in %pre %post %preun %postun scripts (see: https://rpm.org/user_doc/scriptlet_expansion.html)
+    - install-time macro expansion in %pre %post %preun %postun scripts (see: https://rpm-software-management.github.io/rpm/manual/scriptlet_expansion.html)
 * ``--rpm-os OS``
     - The operating system to target this rpm for. You want to set this to 'linux' if you are using fpm on OS X, for example
 * ``--rpm-posttrans FILE``
@@ -51,13 +51,13 @@
 * ``--rpm-tag TAG``
     - Adds a custom tag in the spec file as is. Example: --rpm-tag 'Requires(post): /usr/sbin/alternatives'
 * ``--rpm-trigger-after-install '[OPT]PACKAGE: FILEPATH'``
-    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 * ``--rpm-trigger-after-target-uninstall '[OPT]PACKAGE: FILEPATH'``
-    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 * ``--rpm-trigger-before-install '[OPT]PACKAGE: FILEPATH'``
-    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 * ``--rpm-trigger-before-uninstall '[OPT]PACKAGE: FILEPATH'``
-    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: http://rpm.org/api/4.4.2.2/triggers.html
+    - Adds a rpm trigger script located in FILEPATH, having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. See: https://rpm-software-management.github.io/rpm/manual/triggers.html
 * ``--[no-]rpm-use-file-permissions``
     - Use existing file permissions when defining ownership and modes.
 * ``--rpm-user USER``

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -156,7 +156,7 @@ class FPM::Package::RPM < FPM::Package
 
   option "--macro-expansion", :flag,
            "install-time macro expansion in %pre %post %preun %postun scripts " \
-           "(see: https://rpm.org/user_doc/scriptlet_expansion.html)", :default => false
+           "(see: https://rpm-software-management.github.io/rpm/manual/scriptlet_expansion.html)", :default => false
 
   option "--verifyscript", "FILE",
     "a script to be run on verification" do |val|
@@ -175,7 +175,7 @@ class FPM::Package::RPM < FPM::Package
      rpm_trigger = []
      option "--trigger-#{trigger_type}", "'[OPT]PACKAGE: FILEPATH'", "Adds a rpm trigger script located in FILEPATH, " \
             "having 'OPT' options and linking to 'PACKAGE'. PACKAGE can be a comma seperated list of packages. " \
-            "See: http://rpm.org/api/4.4.2.2/triggers.html" do |trigger|
+            "See: https://rpm-software-management.github.io/rpm/manual/triggers.html" do |trigger|
        match = trigger.match(/^(\[.*\]|)(.*): (.*)$/)
        @logger.fatal("Trigger '#{trigger_type}' definition can't be parsed ('#{trigger}')") unless match
        opt, pkg, file = match.captures


### PR DESCRIPTION
The previous versions where all returning 404. This change points to the new correct locations.