### PR TITLE
chore: relax 'clamp' version pin

### DIFF
--- a/fpm.gemspec
+++ b/fpm.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec|
 
   # For command-line flag support
   # https://github.com/mdub/clamp/blob/master/README.markdown
-  spec.add_dependency("clamp", "~> 1.0.0") # license: MIT
+  spec.add_dependency("clamp", ">= 1.0.0") # license: MIT
 
   # For sourcing from pleaserun
   spec.add_dependency("pleaserun", "~> 0.0.29") # license: Apache 2


### PR DESCRIPTION
Ubuntu 22.04 LTS comes with ruby-clamp 1.1.1 which seems to work just
fine with fpm 1.15.1

Relaxing the version pin seems to be the right thing to do.
