### PR TITLE
deb: A local path copied with --config-files should still be included in the package's conffiles list (Fixes #1823)

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -1068,6 +1068,7 @@ class FPM::Package::Deb < FPM::Package
             logger.debug("Adding config file #{path} to Staging area #{staging_path}")
             FileUtils.mkdir_p(File.dirname(dcl))
             FileUtils.cp_r path, dcl
+            add_path(path, allconfigs)
           else
             logger.debug("Config file aready exists in staging area.")
           end


### PR DESCRIPTION
Fix #1823.