### PR TITLE
rpm: generate changelog if none is provided

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -275,6 +275,24 @@ class FPM::Package::RPM < FPM::Package
     return @iteration ? @iteration : 1
   end # def iteration
 
+  # Generate a generic changelog or return an existing definition
+  def changelog
+    if attributes[:rpm_changelog]
+      return attributes[:rpm_changelog]
+    end
+
+    reldate = if attributes[:source_date_epoch].nil?
+                Time.now()
+              else
+                Time.at(attributes[:source_date_epoch].to_i)
+              end
+    changed = reldate.strftime("%a %b %_e %Y")
+    changev = "#{version}-#{iteration}"
+    changev += "%{?dist}" if attributes[:rpm_dist]
+
+    "* #{changed}  #{maintainer} - #{changev}\n- Package created with FPM\n"
+  end
+
   # See FPM::Package#converted_from
   def converted_from(origin)
     if origin == FPM::Package::Gem

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -484,6 +484,45 @@ describe FPM::Package::RPM do
         File.unlink(@target)
       end
     end # dist
+
+    context "changelog" do
+      it "should generate a changelog in the release" do
+        subject.name = "example"
+        subject.attributes[:rpm_dist] = 'rhel'
+        subject.version = "1.2.3"
+        subject.maintainer = "Spec Test <spec.test@example.com>"
+        @target = Stud::Temporary.pathname
+
+        # Write RPM
+        subject.output(@target)
+
+        @rpm = ::RPM::File.new(@target)
+        insist { @rpm.tags[:changelogname] } == [ "Spec Test <spec.test@example.com> - 1.2.3-1.rhel" ]
+        insist { @rpm.tags[:changelogtext] } == [ "- Package created with FPM" ]
+
+        File.unlink(@target)
+      end
+
+      it "should have the changelog in the release" do
+        subject.name = "example"
+        subject.attributes[:rpm_changelog] = <<CHANGELOG
+* Tue May 31 2016  Example Maintainers <fpm@example.com> - 1.0-1
+- First example package
+CHANGELOG
+        subject.version = "1.0"
+        @target = Stud::Temporary.pathname
+
+        # Write RPM
+        subject.output(@target)
+
+        @rpm = ::RPM::File.new(@target)
+        insist { @rpm.tags[:changelogtime] } == [ 1464696000 ]
+        insist { @rpm.tags[:changelogname] } == [ "Example Maintainers <fpm@example.com> - 1.0-1" ]
+        insist { @rpm.tags[:changelogtext] } == [ "- First example package" ]
+
+        File.unlink(@target)
+      end
+    end # changelog
   end # #output
 
   describe "prefix attribute" do

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -260,4 +260,4 @@ fi
 <% end -%>
 
 %changelog
-<%= attributes[:rpm_changelog] %>
+<%= changelog %>


### PR DESCRIPTION
`rpmlint` considers a lack of a changelog an error.

this is a similar behaviour to the DEB packager, where a generic default changelog is generated unless one is provided explicitly.