### PR TITLE
Fix for #1627

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -824,6 +824,12 @@ class FPM::Package::Deb < FPM::Package
       return dep
     end
 
+    if dep.include?("rpmlib")
+      logger.warn("Blanking 'dependency' field '#{dep}' because it's invalid")
+      dep = ""
+      return dep
+    end
+
     name_re = /^[^ \(]+/
     name = dep[name_re]
     if name =~ /[A-Z]/

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -911,6 +911,11 @@ class FPM::Package::Deb < FPM::Package
       provides = ""
     end
 
+    if provides.start_with?("/")
+      logger.warn("Blanking 'provides' field '#{provides}' because it's invalid")
+      provides = ""
+    end
+
     if m = provides.match(/^([A-Za-z0-9_-]+)\s*=\s*(\d+.*$)/)
       logger.warn("Replacing 'provides' entry #{provides} with syntax 'name (= version)'")
       provides = "#{m[1]} (= #{m[2]})"


### PR DESCRIPTION
When packaging a deb sometimes the architecture comes through as part of the provides (not sure why) but this causes problems with the deb package as it seems to only ever expect one set of round brackets which is the version indicator
Also fixed another issue where ppc64le packages from RPM wouldn't install properly on DEB based systems as they use ppc64el.
Also fixed another issue where invalid dependencies were being put in the control file (rpmlib dependencies and file path dependencies i.e. RPMs that depend on /bin/sh)

This has got fpm working for RPMs->DEBs on our systems for ppc64le packages. Appreciate that this fix might not be "complete" or comprehensive in any way, shape or form so any feedback is welcome.