### PR TITLE
Escape the pylib path when using it in a shell command

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -79,7 +79,7 @@ class FPM::Package::Python < FPM::Package
   option "--setup-py-arguments", "setup_py_argument",
     "Arbitrary argument(s) to be passed to setup.py",
     :multivalued => true, :attribute_name => :python_setup_py_arguments,
-    :default => [] 
+    :default => []
   option "--internal-pip", :flag,
     "Use the pip module within python to install modules - aka 'python -m pip'. This is the recommended usage since Python 3.4 (2014) instead of invoking the 'pip' script",
     :attribute_name => :python_internal_pip,
@@ -230,7 +230,7 @@ class FPM::Package::Python < FPM::Package
 
     output = ::Dir.chdir(setup_dir) do
       tmp = build_path("metadata.json")
-      setup_cmd = "env PYTHONPATH=#{pylib}:$PYTHONPATH #{attributes[:python_bin]} " \
+      setup_cmd = "env PYTHONPATH=#{pylib.shellescape}:$PYTHONPATH #{attributes[:python_bin]} " \
         "setup.py --command-packages=pyfpm get_metadata --output=#{tmp}"
 
       if attributes[:python_obey_requirements_txt?]


### PR DESCRIPTION
Ran into an error creating a deb package from a python package when the current working directory contains spaces.
```
{:timestamp=>"2024-05-16T15:17:42.793044+0000", :message=>"Process failed: /bin/bash failed (exit code 127). Full command was:[\"/bin/bash\", \"-c\", \"env PYTHONPATH=/var/lib/jenkins-swarm-client/workspace/publiq packages/packages/vendor/bundle/ruby/2.7.0/gems/fpm-1.15.1/lib/fpm/package:$PYTHONPATH python3 setup.py --command-packages=pyfpm get_metadata --output=/tmp/package-python-build-627893c057255449a6af5622973a2c6df56cf6dde757466135f518e6bcdc/metadata.json\"]", :level=>:error}
```
The pylib variable gets passed to a shell command unescaped which causes the problem.
Adding a simple `.shellescape` solves the problem locally.