### PR TITLE
Create FreeBSD packages with correct architecture

### DIFF
--- a/docs/cli-reference.rst
+++ b/docs/cli-reference.rst
@@ -246,6 +246,9 @@ General Options
 * ``--freebsd-origin ABI``
     - (freebsd only) Sets the FreeBSD 'origin' pkg field
 
+* ``--freebsd-osversion VERSION``
+    - (freebsd only) Sets the FreeBSD 'version' pkg field, ie. 12 or 13, use '*' for all.
+
 * ``--gem-bin-path DIRECTORY``
     - (gem only) The directory to install gem executables
 
@@ -765,6 +768,9 @@ freebsd
 
 * ``--freebsd-origin ABI``
     - Sets the FreeBSD 'origin' pkg field
+
+* ``--freebsd-osversion VERSION``
+    - Sets the FreeBSD 'version' pkg field, ie. 12 or 13, use '*' for all.
 
 gem
 ---

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -56,9 +56,14 @@ when it lists the FPM gem:
 If your system doesn't have `bsdtar` by default, make sure to install it or some
 tests will fail:
 
-    apt-get install bsdtar
+    apt-get install bsdtar || apt install libarchive-tools
     
     yum install bsdtar
+
+
+You also need these tools:
+
+    apt-get install lintian cpanminus
 
 Next, run make in root of the FPM repo. If there are any problems (such as
 missing dependencies) you should receive an error

--- a/docs/packages/cli/freebsd.rst
+++ b/docs/packages/cli/freebsd.rst
@@ -1,3 +1,5 @@
 * ``--freebsd-origin ABI``
     - Sets the FreeBSD 'origin' pkg field
+* ``--freebsd-osversion VERSION``
+    - Sets the FreeBSD 'version' pkg field, ie. 12 or 13, use '*' for all.
 

--- a/lib/fpm/package/freebsd.rb
+++ b/lib/fpm/package/freebsd.rb
@@ -16,6 +16,10 @@ class FPM::Package::FreeBSD < FPM::Package
          "Sets the FreeBSD 'origin' pkg field",
          :default => "fpm/<name>"
 
+  option "--osversion", "VERSION",
+         "Sets the FreeBSD 'version' pkg field, ie 12 or 13, use '*' for all.",
+         :default => "13"
+
   def output(output_path)
     output_check(output_path)
 
@@ -90,28 +94,36 @@ class FPM::Package::FreeBSD < FPM::Package
   end # def output
 
   # Handle architecture naming conversion:
-  # <osname>:<osversion>:<arch>:<wordsize>[.other]
+  # <osname>:<osversion>:<arch>
   def architecture
-    osname    = %x{uname -s}.chomp
-    osversion = %x{uname -r}.chomp.split('.').first
+    osname    = 'FreeBSD'
 
-    # Essentially because no testing on other platforms
-    arch = 'x86'
-
-    wordsize = case @architecture
+    arch = case @architecture
     when nil, 'native'
       %x{getconf LONG_BIT}.chomp # 'native' is current arch
     when 'arm64'
-      '64'
+      'arm64'
+    when 'aarch64'
+      'arm64'
     when 'amd64'
-      '64'
+      'amd64'
+    when 'x86_64'
+      'amd64'
     when 'i386'
-      '32'
+      'i386'
+    when 'i686'
+      'i386'
+    when 'any'
+      '*'
+    when 'all'
+      '*'
+    when 'noarch'
+      '*'
     else
       %x{getconf LONG_BIT}.chomp # default to native, the current arch
     end
 
-    return [osname, osversion, arch, wordsize].join(':')
+    return [osname, attributes[:freebsd_osversion], arch].join(':')
   end
 
   def add_path(tar, tar_path, path)


### PR DESCRIPTION
- Sets (hardcodes) name of OS as `FreeBSD`
- Allows specifying the FreeBSD version the package is for, defaults to `13` and allows `all` or `noarch`.
- Correctly honors `--architecture` input.
- Fixes #1880
- Tested on Freebsd 13. Using `--architecture` as `12`, `13`, and `*`. 
  - Using `12` correctly produces a wrong architecture message. 
  - Using `13` and `*` work. Meaning `pkg add` does not return error.