### PR TITLE
fix(rpm): replace perl dependency by perl-interpreter

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -277,7 +277,19 @@ class FPM::Package::RPM < FPM::Package
 
   # See FPM::Package#converted_from
   def converted_from(origin)
-    if origin == FPM::Package::Gem
+    if origin == FPM::Package::CPAN
+      fixed_deps = []
+      self.dependencies.collect do |dep|
+        # RPM package "perl" is a metapackage which install all the Perl bits and core modules, then gcc...
+        # this must be replaced by perl-interpreter
+        if name=/^perl([\s<>=].*)$/.match(dep)
+          fixed_deps.push("perl-interpreter#{name[1]}")
+        else
+          fixed_deps.push(dep)
+        end
+      end
+      self.dependencies = fixed_deps
+    elsif origin == FPM::Package::Gem
       fixed_deps = []
       self.dependencies.collect do |dep|
         # Gem dependency operator "~>" is not compatible with rpm. Translate any found.


### PR DESCRIPTION
`perl` rpm package is a metapackages which install all the Perl bits and core modules
Then, `perl-devel`, `gcc` and lot of useless dependencies are installed
This should be replaced by `perl-interpreter`

<details>
  <summary><i>perl dependencies</i></summary>
  <pre><code>
  # dnf repoquery --requires perl
  Last metadata expiration check: 0:35:46 ago on Fri Sep  6 07:47:45 2024.
  perl(:MODULE_COMPAT_5.32.1)
  perl-Archive-Tar
  perl-Attribute-Handlers
  perl-AutoLoader
  perl-AutoSplit
  perl-B
  perl-Benchmark
  perl-CPAN
  perl-CPAN-Meta
  perl-CPAN-Meta-Requirements
  perl-CPAN-Meta-YAML
  perl-Carp
  perl-Class-Struct
  perl-Compress-Raw-Bzip2
  perl-Compress-Raw-Zlib
  perl-Config-Extensions
  perl-Config-Perl-V
  perl-DBM_Filter
  perl-DB_File
  perl-Data-Dumper
  perl-Devel-PPPort
  perl-Devel-Peek
  perl-Devel-SelfStubber
  perl-Digest
  perl-Digest-MD5
  perl-Digest-SHA
  perl-DirHandle
  perl-Dumpvalue
  perl-DynaLoader
  perl-Encode
  perl-Encode-devel
  perl-English
  perl-Env
  perl-Errno
  perl-Exporter
  perl-ExtUtils-CBuilder
  perl-ExtUtils-Command
  perl-ExtUtils-Constant
  perl-ExtUtils-Embed
  perl-ExtUtils-Install
  perl-ExtUtils-MM-Utils
  perl-ExtUtils-MakeMaker
  perl-ExtUtils-Manifest
  perl-ExtUtils-Miniperl
  perl-ExtUtils-ParseXS
  perl-Fcntl
  perl-File-Basename
  perl-File-Compare
  perl-File-Copy
  perl-File-DosGlob
  perl-File-Fetch
  perl-File-Find
  perl-File-Path
  perl-File-Temp
  perl-File-stat
  perl-FileCache
  perl-FileHandle
  perl-Filter
  perl-Filter-Simple
  perl-FindBin
  perl-GDBM_File
  perl-Getopt-Long
  perl-Getopt-Std
  perl-HTTP-Tiny
  perl-Hash-Util
  perl-Hash-Util-FieldHash
  perl-I18N-Collate
  perl-I18N-LangTags
  perl-I18N-Langinfo
  perl-IO
  perl-IO-Compress
  perl-IO-Socket-IP
  perl-IO-Zlib
  perl-IPC-Cmd
  perl-IPC-Open3
  perl-IPC-SysV
  perl-JSON-PP
  perl-Locale-Maketext
  perl-Locale-Maketext-Simple
  perl-MIME-Base64
  perl-Math-BigInt
  perl-Math-BigInt-FastCalc
  perl-Math-BigRat
  perl-Math-Complex
  perl-Memoize
  perl-Module-CoreList
  perl-Module-CoreList-tools
  perl-Module-Load
  perl-Module-Load-Conditional
  perl-Module-Loaded
  perl-Module-Metadata
  perl-NDBM_File
  perl-NEXT
  perl-Net
  perl-Net-Ping
  perl-ODBM_File
  perl-Opcode
  perl-POSIX
  perl-Params-Check
  perl-PathTools
  perl-Perl-OSType
  perl-PerlIO-via-QuotedPrint
  perl-Pod-Checker
  perl-Pod-Escapes
  perl-Pod-Functions
  perl-Pod-Html
  perl-Pod-Perldoc
  perl-Pod-Simple
  perl-Pod-Usage
  perl-Safe
  perl-Scalar-List-Utils
  perl-Search-Dict
  perl-SelectSaver
  perl-SelfLoader
  perl-Socket
  perl-Storable
  perl-Symbol
  perl-Sys-Hostname
  perl-Sys-Syslog
  perl-Term-ANSIColor
  perl-Term-Cap
  perl-Term-Complete
  perl-Term-ReadLine
  perl-Test
  perl-Test-Harness
  perl-Test-Simple
  perl-Text-Abbrev
  perl-Text-Balanced
  perl-Text-ParseWords
  perl-Text-Tabs+Wrap
  perl-Thread
  perl-Thread-Queue
  perl-Thread-Semaphore
  perl-Tie
  perl-Tie-File
  perl-Tie-Memoize
  perl-Tie-RefHash
  perl-Time
  perl-Time-HiRes
  perl-Time-Local
  perl-Time-Piece
  perl-Unicode-Collate
  perl-Unicode-Normalize
  perl-Unicode-UCD
  perl-User-pwent
  perl-autodie
  perl-autouse
  perl-base
  perl-bignum
  perl-blib
  perl-constant
  perl-debugger
  perl-deprecate
  perl-devel(x86-64) = 4:5.32.1-481.el9
  perl-diagnostics
  perl-doc
  perl-encoding
  perl-encoding-warnings
  perl-experimental
  perl-fields
  perl-filetest
  perl-if
  perl-interpreter(x86-64) = 4:5.32.1-481.el9
  perl-less
  perl-lib
  perl-libnet
  perl-libnetcfg
  perl-libs(x86-64) = 4:5.32.1-481.el9
  perl-locale
  perl-macros
  perl-meta-notation
  perl-mro
  perl-open
  perl-overload
  perl-overloading
  perl-parent
  perl-perlfaq
  perl-ph
  perl-podlators
  perl-sigtrap
  perl-sort
  perl-subs
  perl-threads
  perl-threads-shared
  perl-utils
  perl-vars
  perl-version
  perl-vmsish
 </code></pre>
</details>