### PR TITLE
Support pip download returning a zip file

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -171,13 +171,19 @@ class FPM::Package::Python < FPM::Package
       # behind a directory with the Python package extracted and ready to be used.
       # For example, `pip download ... Django` puts `Django-4.0.4.tar.tz` into the build_path directory.
       # If we expect `pip` to leave an unknown-named file in the `build_path` directory, let's check for
-      # a single file and unpack it.  I don't know if it will /always/ be a .tar.gz though.
-      files = ::Dir.glob(File.join(build_path, "*.tar.gz"))
+      # a single file and unpack it.
+      files = ::Dir.glob(File.join(build_path, "*.{tar.gz,zip}"))
       if files.length != 1
         raise "Unexpected directory layout after `pip download ...`. This might be an fpm bug? The directory is #{build_path}"
       end
 
-      safesystem("tar", "-zxf", files[0], "-C", target)
+      if files[0].end_with?("tar.gz")
+        safesystem("tar", "-zxf", files[0], "-C", target)
+      elsif files[0].end_with?("zip")
+        safesystem("unzip", files[0], "-d", target)
+      else
+        raise "Unexpected file format after `pip download ...`. This might be an fpm bug? The file is #{files[0]}"
+      end
     else
       # no pip, use easy_install
       logger.debug("no pip, defaulting to easy_install", :easy_install => attributes[:python_easyinstall])


### PR DESCRIPTION
It seems that `debugpy` on pip returns a `zip` file instead of a `tar.gz`