### PR TITLE
"Fix: Handle .zip files when generating Python packages"

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -173,11 +173,17 @@ class FPM::Package::Python < FPM::Package
       # If we expect `pip` to leave an unknown-named file in the `build_path` directory, let's check for
       # a single file and unpack it.  I don't know if it will /always/ be a .tar.gz though.
       files = ::Dir.glob(File.join(build_path, "*.tar.gz"))
+      files += ::Dir.glob(File.join(build_path, "*.zip"))
       if files.length != 1
         raise "Unexpected directory layout after `pip download ...`. This might be an fpm bug? The directory is #{build_path}"
       end
-
-      safesystem("tar", "-zxf", files[0], "-C", target)
+      
+      if /\.zip/ =~ files[0]
+        safesystem("unzip", files[0], "-d", target)
+      else
+        safesystem("tar", "-zxf", files[0], "-C", target)
+      end
+    
     else
       # no pip, use easy_install
       logger.debug("no pip, defaulting to easy_install", :easy_install => attributes[:python_easyinstall])


### PR DESCRIPTION
### Title: Fix: Handle `.zip` Files When Generating Python Packages

### Description:

This Pull Request addresses an issue where `fpm` fails to properly generate a package when the Python module is downloaded in `.zip` format via `pip`. Previously, `fpm` expected only `.tar.gz` archives and would throw an error when encountering a `.zip` file due to an unexpected directory layout.

#### Changes made:
- Added logic to detect if the downloaded Python package is in `.zip` format.
- Implemented functionality to properly extract `.zip` files using the `unzip` command and handle the packaging process as usual.
- Maintained backward compatibility for `.tar.gz` files.
  
#### Testing:
- Verified the fix by packaging Python modules provided in both `.zip` and `.tar.gz` formats.
- Both archive types now process correctly, and the expected packages are generated without errors.

This PR resolves issue https://github.com/jordansissel/fpm/issues/2072, where users encountered a runtime error when `pip` fetched `.zip` files during the `fpm` packaging process.

--- 

Feel free to tweak the wording to better fit the specifics of your implementation!