### PR TITLE
Fix DEB relationship field

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -49,7 +49,7 @@ class FPM::Package::Deb < FPM::Package
     (?:-[A-Za-z0-9+~.]+)?  # debian_revision
   /x # Version field pattern
   RELATIONSHIP_FIELD_PATTERN = /^
-    (?<name>[A-z0-9+][A-z0-9_.-]+)
+    (?<name>[A-z0-9][A-z0-9+~.-]+)
     (?:\s*\((?<relation>[<>=]+)\s(?<version>#{VERSION_FIELD_PATTERN})\))?
   $/x # Relationship field pattern
 

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -49,7 +49,7 @@ class FPM::Package::Deb < FPM::Package
     (?:-[A-Za-z0-9+~.]+)?  # debian_revision
   /x # Version field pattern
   RELATIONSHIP_FIELD_PATTERN = /^
-    (?<name>[A-z0-9][A-z0-9_.-]+)
+    (?<name>[A-z0-9+][A-z0-9_.-]+)
     (?:\s*\((?<relation>[<>=]+)\s(?<version>#{VERSION_FIELD_PATTERN})\))?
   $/x # Relationship field pattern
 
@@ -733,7 +733,7 @@ class FPM::Package::Deb < FPM::Package
         else
           # Also replace '::' in the perl module name with '-'
           modulename = m["name"].gsub("::", "-")
-         
+
           # Fix any upper-casing or other naming concerns Debian has about packages
           name = "#{attributes[:cpan_package_name_prefix]}-#{modulename}"
 


### PR DESCRIPTION
I faced an issue packaging ImageMagick for Ubuntu 20.04 where `fpm` complained about an invalid relationship field for a package.

According to https://www.debian.org/doc/debian-policy/ch-controlfields.html#version, I believe the field should support more characters.

> The version number of a package. The format is: [epoch:]upstream_version[-debian_revision].
> (...)
> The upstream_version must contain only alphanumerics [6](https://www.debian.org/doc/debian-policy/ch-controlfields.html#id21) and the characters . + - ~ (full stop, plus, hyphen, tilde) and should start with a digit. If there is no debian_revision then hyphens are not allowed.

Also, according to https://www.debian.org/doc/debian-policy/ch-relationships.html#syntax-of-relationship-fields,

> All of the fields may restrict their applicability to particular versions of each named package. This is done in parentheses after each individual package name; **the parentheses should contain a relation from the list below followed by a version number, in the format described in [Version](https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-version).**