### PR TITLE
Update rpm.rb

### DIFF
--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -474,6 +474,7 @@ class FPM::Package::RPM < FPM::Package
 
     args += [
       "--buildroot", "#{build_path}/BUILD",
+      "--define", "buildroot #{build_path}/BUILD",
       "--define", "_topdir #{build_path}",
       "--define", "_sourcedir #{build_path}",
       "--define", "_rpmdir #{build_path}/RPMS",

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -473,7 +473,7 @@ class FPM::Package::RPM < FPM::Package
     args += ["--define", "dist .#{attributes[:rpm_dist]}"] if attributes[:rpm_dist]
 
     args += [
-      "--define", "buildroot #{build_path}/BUILD",
+      "--buildroot", "#{build_path}/BUILD",
       "--define", "_topdir #{build_path}",
       "--define", "_sourcedir #{build_path}",
       "--define", "_rpmdir #{build_path}/RPMS",


### PR DESCRIPTION
Fix how buildroot is specified to better conform with the rpmbuild CLI. The old way was failing with `File not found` errors.