### PR TITLE
Add option to specify python version for virtualenv

### DIFF
--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -112,9 +112,9 @@ class FPM::Package::Virtualenv < FPM::Package
         virtualenv_args << virtualenv_build_folder
     end
 
-    if self.attributes[:python?]
-      logger.info("Creating virtualenv with python executable #{self.attributes[:python]}")
-      virtualenv_args.concat(["--python", self.attributes[:python]])
+    if self.attributes[:virtualenv_python]
+      logger.info("Creating virtualenv with python executable #{self.attributes[:virtualenv_python]}")
+      virtualenv_args.concat(["--python", self.attributes[:virtualenv_python]])
     end
 
     safesystem(*virtualenv_args)

--- a/lib/fpm/package/virtualenv.rb
+++ b/lib/fpm/package/virtualenv.rb
@@ -48,6 +48,11 @@ class FPM::Package::Virtualenv < FPM::Package
     :multivalued => true, :attribute_name => :virtualenv_find_links_urls,
     :default => nil
 
+  option "--python", "PYTHON_EXECUTABLE", "interpreter based on what to create environment "\
+    "(path/identifier) - by default use the interpreter where virtualenv is installed - "\
+    "first found wins",
+    :default => nil
+
   private
 
   # Input a package.
@@ -100,12 +105,19 @@ class FPM::Package::Virtualenv < FPM::Package
 
     ::FileUtils.mkdir_p(virtualenv_build_folder)
 
+    virtualenv_args = ["virtualenv", virtualenv_build_folder]
+
     if self.attributes[:virtualenv_system_site_packages?]
         logger.info("Creating virtualenv with --system-site-packages")
-        safesystem("virtualenv", "--system-site-packages", virtualenv_build_folder)
-    else
-        safesystem("virtualenv", virtualenv_build_folder)
+        virtualenv_args << virtualenv_build_folder
     end
+
+    if self.attributes[:python?]
+      logger.info("Creating virtualenv with python executable #{self.attributes[:python]}")
+      virtualenv_args.concat(["--python", self.attributes[:python]])
+    end
+
+    safesystem(*virtualenv_args)
 
     pip_exe = File.join(virtualenv_build_folder, "bin", "pip")
     python_exe = File.join(virtualenv_build_folder, "bin", "python")


### PR DESCRIPTION
I sometimes want to package virtualenvs with other python version than my system default. This adds another cli option to specify an alternative python executable. Naming is the same as for virtualenv
https://virtualenv.pypa.io/en/latest/cli_interface.html

I decided not to check for a valid executable in this code as virtualenv will forward the error anyways

I hope the code is fine as is, I'm not really versed in Ruby, but this might serve as a proposal for the requested change.

Tested it locally and works on my linux machine with a caveat though:
1. virtualenv should not be installed in environments, instead it should be installed in the global interpreter or (preferred) via pipx
2. virtualenv-tools can misfunction if you're trying to run it on a virtualenv, that has a different version than the one it's running on
E.g. having Python3.10 as base, running
virtualenv --python python3.12 environment_name
cd environment_name 
virtualenv-tools --update-path /some/path

will throw an error while updating the .pycs


So given the example of having Python3.10 as your base python, but you want to build your virtualenv for Py3.12, you need to install virtualenv with pipx, then create a Py3.12 environment, install virtualenv-tools3 in there and run fpm in this environment. 
It is a bit finicky, but that would need solving in virtualenv-tools, I guess. Atleast that enables fpm to build virtualenvs for different Python versions