### PR TITLE
Add all valid file extensions for systemd units

### DIFF
--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -542,6 +542,20 @@ class FPM::Package::Deb < FPM::Package
       raise FPM::InvalidPackageConfiguration, "#{name}: tar is insufficient to support source_date_epoch."
     end
 
+    systemd_file_extensions = [
+        ".service",
+        ".socket",
+        ".device",
+        ".mount",
+        ".automount",
+        ".swap",
+        ".target",
+        ".path",
+        ".timer",
+        ".slice",
+        ".scope",
+    ]
+
     attributes[:deb_systemd] = []
     attributes.fetch(:deb_systemd_list, []).each do |systemd|
       name = File.basename(systemd)
@@ -549,7 +563,7 @@ class FPM::Package::Deb < FPM::Package
 
       name_with_extension = if extname.empty?
                               "#{name}.service"
-                            elsif [".service", ".timer"].include?(extname)
+                            elsif systemd_file_extensions.include?(extname)
                               name
                             else
                               raise FPM::InvalidPackageConfiguration, "Invalid systemd unit file extension: #{extname}. Expected .service or .timer, or no extension."


### PR DESCRIPTION
See https://github.com/jordansissel/fpm/issues/2100

Adds the following to the list of valid extensions for systemd units:

- `.socket`
- `.device`
- `.mount`
- `.automount`
- `.swap`
- `.target`
- `.path`
- `.slice`
- `.scope`