### PR TITLE
Only hardlink if the source is a hardlink.

### DIFF
--- a/lib/fpm/command.rb
+++ b/lib/fpm/command.rb
@@ -3,7 +3,6 @@ require "fpm/namespace"
 require "fpm/version"
 require "fpm/util"
 require "clamp"
-require "ostruct"
 require "fpm"
 require "tmpdir" # for Dir.tmpdir
 

--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -3,7 +3,6 @@ require "fpm/util" # local
 require "pathname" # stdlib
 require "find"
 require "tmpdir" # stdlib
-require "ostruct"
 require "backports/latest"
 require "socket" # stdlib, for Socket.gethostname
 require "shellwords" # stdlib, for Shellwords.escape

--- a/lib/fpm/package/dir.rb
+++ b/lib/fpm/package/dir.rb
@@ -197,10 +197,6 @@ class FPM::Package::Dir < FPM::Package
     else
       # Otherwise try copying the file.
       begin
-        logger.debug("Linking", :source => source, :destination => destination)
-        File.link(source, destination)
-      rescue Errno::ENOENT, Errno::EXDEV, Errno::EPERM
-        # Hardlink attempt failed, copy it instead
         logger.debug("Copying", :source => source, :destination => destination)
         copy_entry(source, destination)
       rescue Errno::EEXIST

--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -340,7 +340,6 @@ module FPM::Util
       st.ftype
     end
 
-      
     case filetype
     when 'fifo'
       if File.respond_to?(:mkfifo)
@@ -366,7 +365,7 @@ module FPM::Util
       known_entry = copied_entries[[st.dev, st.ino]]
       if known_entry
         FileUtils.ln(known_entry, dst)
-        logger.debug("Found already-copied file [dev:#{st.dev}, ino:#{st.ino}]", :src => src, :dst => dst)
+        logger.debug("Copying hardlink", :src => src, :dst => dst, :link => known_entry)
       else
         FileUtils.copy_entry(src, dst, preserve, false,
                              remove_destination)


### PR DESCRIPTION
In #2102, it was found that fpm would hardlink any file that's included in the package multiple times.

For example:

```
% echo "Hello world" > /tmp/one

# Create a package with /tmp/one installed in two locations using path mapping:
% fpm -s dir -t deb -n example /tmp/one=/opt/example/one /tmp/one=/var/lib/example/one

% dpkg-deb --fsys-tarfile example_1.0_amd64.deb| tar -vt | grep 'one'
-rw-r--r-- 0/0              12 2025-09-21 21:43 ./var/lib/example/one
hrw-r--r-- 0/0               0 2025-09-21 21:43 ./opt/example/one link to ./var/lib/example/one
```

Notice above, /opt/example/one is a hardlink to /var/lib/example/one.

This behavior is not the intended behavior of fpm. The  intended behavior (introduced in #365) was to ensure hardlinks in the original files are correctly kept as hardlinks in the package. The example in #365 was for git-core which has over 100 files hardlinked to the `git` executable  such as `git-add`, `git-apply`, etc. The problem in #365 was that fpm was copying these as individual files which resulted in hundreds of copies of the same file, and in git's case, the `git` binary is 18 megs.

Now, in this PR, the intent is to retain the solution to #365 (#623) while removing the unintended behavior.

```
# Copy /etc/zshrc into a two locations.
% fpm -s dir -t deb -n example /etc/zshrc=/zshrc1 /etc/zshrc=/zshrc2

% dpkg-deb --fsys-tarfile example_1.0_amd64.deb | tar -vt | grep /zshrc
-rw-r--r-- 0/0            1164 2025-01-18 16:00 ./zshrc2
hrw-r--r-- 0/0               0 2025-01-18 16:00 ./zshrc1 link to ./zshrc2
```

The above shows the buggy behavior.

With this PR, the package created looks like this:

```
% dpkg-deb --fsys-tarfile example_1.0_amd64.deb | tar -vt | grep /zshrc
-rw-r--r-- 0/0            1164 2025-01-18 16:00 ./zshrc2
-rw-r--r-- 0/0            1164 2025-01-18 16:00 ./zshrc1
```

Correctly two files, not hardlinked.