### PR TITLE
add zst to rpm generation

### DIFF
--- a/docs/cli-reference.rst
+++ b/docs/cli-reference.rst
@@ -482,7 +482,7 @@ rpm
     - Enable RPM's AutoReqProv option
 * ``--rpm-changelog FILEPATH``
     - Add changelog from FILEPATH contents
-* ``--rpm-compression none|xz|xzmt|gzip|bzip2``
+* ``--rpm-compression none|xz|xzmt|zst|gzip|bzip2``
     - Select a compression method. gzip works on the most platforms.
 * ``--rpm-compression-level [0-9]``
     - Select a compression level. 0 is store-only. 9 is max compression.

--- a/docs/packages/cli/rpm.rst
+++ b/docs/packages/cli/rpm.rst
@@ -12,7 +12,7 @@
     - Enable RPM's AutoReqProv option
 * ``--rpm-changelog FILEPATH``
     - Add changelog from FILEPATH contents
-* ``--rpm-compression none|xz|xzmt|gzip|bzip2``
+* ``--rpm-compression none|xz|xzmt|zst|gzip|bzip2``
     - Select a compression method. gzip works on the most platforms.
 * ``--rpm-compression-level [0-9]``
     - Select a compression level. 0 is store-only. 9 is max compression.

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -30,7 +30,8 @@ class FPM::Package::RPM < FPM::Package
     "xz" => ".xzdio",
     "xzmt" => "T.xzdio",
     "gzip" => ".gzdio",
-    "bzip2" => ".bzdio"
+    "bzip2" => ".bzdio",
+    "zst" => ".zstdio"
   } unless defined?(COMPRESSION_MAP)
 
   option "--use-file-permissions", :flag,


### PR DESCRIPTION
Adds the `--rpm-compression zst` option. Not sure how to run the tests in the project, but I can confirm that it successfully generates zstd compressed packages:

```bash
[m@M spc-packages]$ rpm -qp --qf '%{PAYLOADFORMAT} %{PAYLOADCOMPRESSOR}\n' dist/rpm/php-zts-cli-8.5.0beta3-1.x86_64.rpm 
cpio zstd
```

closes https://github.com/jordansissel/fpm/issues/2097