### PR TITLE
Filter newer style bash functions out of shell script template's .ins…

### DIFF
--- a/templates/sh.erb
+++ b/templates/sh.erb
@@ -137,7 +137,7 @@ function save_environment(){
 
     # just piping env to a file doesn't quote the variables. This does
     # filter out multiline junk, _, and functions. _ is a readonly variable.
-    env | grep -v "^_=" | grep -v "^[^=(]*()=" | egrep "^[^ ]+=" | while read ENVVAR ; do
+    env | grep -v "^_=" | grep -v "^[^=(]*()=" | grep -v "^BASH_FUNC_.*%%=" |egrep "^[^ ]+=" | while read ENVVAR ; do
         local NAME=${ENVVAR%%=*}
         # sed is to preserve variable values with dollars (for escaped variables or $() style command replacement),
         # and command replacement backticks


### PR DESCRIPTION
…tall-metadata file.

Exported bash functions take the format of `BASH_FUNC_function_name%%`. Including them in the .install-metadata file causes export errors, so update the filtering logic to account for them. 