### PR TITLE
Fix multiple backwards compatibility issues found in fpm v1.17.0

### DIFF
--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -453,7 +453,7 @@ class FPM::Package::Python < FPM::Package
 
       safesystem(*setup_cmd)
 
-      files = ::Dir.entries(target).filter { |entry| entry =~ /\.(whl|tgz|tar\.gz|zip)$/ }
+      files = ::Dir.entries(target).select { |entry| entry =~ /\.(whl|tgz|tar\.gz|zip)$/ }
       if files.length != 1
         raise "Unexpected directory layout after `pip download ...`. This might be an fpm bug? The directory contains these files: #{files.inspect}"
       end

--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -148,11 +148,11 @@ class FPM::Package::Python < FPM::Package
           # Per Python core-metadata spec:
           # > Changed in version 2.1: This field may be specified in the message body instead.
           #return PythonMetadata.new(headers, s.string[s.pos ...])
-          return headers, s.string[s.pos ... ]
+          return headers, s.string[s.pos .. -1]
         elsif headers["Metadata-Version"].to_f >= 2.0
           # dnspython v1.15.0 has a description body and Metadata-Version 2.0 
           # this seems out of spec, but let's accept it anyway.
-          return headers, s.string[s.pos ... ]
+          return headers, s.string[s.pos .. -1]
         else
           raise "After reading METADATA headers, extra data is in the file but was not expected. This may be a bug in fpm."
         end
@@ -166,7 +166,7 @@ class FPM::Package::Python < FPM::Package
       puts "---"
       puts input
       puts "==="
-      puts input[s.pointer...]
+      puts input[s.pointer..-1]
       puts "---"
       raise e
     end # self.parse

--- a/lib/fpm/package/python.rb
+++ b/lib/fpm/package/python.rb
@@ -119,7 +119,7 @@ class FPM::Package::Python < FPM::Package
         headers[field] = []
       end
 
-      while !s.eos? and !s.scan("\n") do 
+      while !s.eos? and !s.scan(/\n/) do 
         # Field is non-space up, but excluding the colon
         field = s.scan(/[^\s:]+/)
 

--- a/spec/fpm/util_spec.rb
+++ b/spec/fpm/util_spec.rb
@@ -25,7 +25,7 @@ describe FPM::Util do
             ta = File.join(target, "a")
             tb = File.join(target, "b")
             subject.copy_entry(a, ta)
-            subject.copy_entry(b, tb, true, true)
+            subject.copy_entry(b, tb, false, true)
 
             # This seems to work to compare file stat calls.
             # target 'a' and 'b' should have the same stat result because


### PR DESCRIPTION
Fixes:
* Avoid endless range, use `-1` as end of range if appropriate. (introduced in ruby 2.6.0)
* Avoid using String arg for StringScanner#scan(), use regex instead. (was introduced in ruby 2.7.0)
* Avoid Array#filter, use Array#select instead (was introduced in ruby 2.6.0)

Fixes #2120 