### PR TITLE
Add --cpan-metacpan-api-url flag for custom MetaCPAN instances

### DIFF
--- a/lib/fpm/package/cpan.rb
+++ b/lib/fpm/package/cpan.rb
@@ -44,6 +44,10 @@ class FPM::Package::CPAN < FPM::Package
   option "--cpanm-force", :flag,
     "Pass the --force parameter to cpanm", :default => false
 
+  option "--metacpan-api-url", "URL",
+    "URL for the MetaCPAN api",
+    :default => "https://fastapi.metacpan.org"
+
   private
   def input(package)
     #if RUBY_VERSION =~ /^1\.8/
@@ -328,7 +332,7 @@ class FPM::Package::CPAN < FPM::Package
     end
 
     # Search metacpan to get download URL for this version of the module
-    metacpan_search_url = "https://fastapi.metacpan.org/v1/release/_search?_source=download_url"
+    metacpan_search_url = "#{attributes[:cpan_metacpan_api_url]}/v1/release/_search?_source=download_url"
     metacpan_search_query = {"query":{"term":{"name": "#{distribution}-#{self.version}" } } }.to_json
     begin
       search_response = httppost(metacpan_search_url,metacpan_search_query)
@@ -369,7 +373,7 @@ class FPM::Package::CPAN < FPM::Package
 
   def search_module(module_name, version=nil)
     logger.info("Asking metacpan about a module", :module => module_name, :version => version)
-    metacpan_api_url = "https://fastapi.metacpan.org/v1/module/_search"
+    metacpan_api_url = "#{attributes[:cpan_metacpan_api_url]}/v1/module/_search"
     metacpan_api_query = <<-EOS
 {
   "query": {
@@ -405,7 +409,7 @@ EOS
     logger.info("Asking metacpan about a releases provided modules",
                 :distribution => distribution,
                 :version => version)
-    metacpan_api_url = "https://fastapi.metacpan.org/v1/module/_search?_source=module.name,module.version"
+    metacpan_api_url = "#{attributes[:cpan_metacpan_api_url]}/v1/module/_search?_source=module.name,module.version"
     metacpan_api_query = <<-EOS
 {
   "query": {

--- a/spec/fpm/package/cpan_spec.rb
+++ b/spec/fpm/package/cpan_spec.rb
@@ -146,4 +146,13 @@ describe FPM::Package::CPAN do
       subject.input("IPC::Session")
     end
   end
+
+  it "should default metacpan api url to https://fastapi.metacpan.org" do
+    insist { subject.attributes[:cpan_metacpan_api_url] } == "https://fastapi.metacpan.org"
+  end
+
+  it "should use custom metacpan api url" do
+    subject.attributes[:cpan_metacpan_api_url] = "https://localhost.invalid"
+    insist { subject.instance_eval { search_module("File::Temp") } }.raises Exception
+  end
 end # describe FPM::Package::CPAN


### PR DESCRIPTION
This PR adds a new flag `--cpan-metacpan-api-url`, which can be used to point fpm to a custom MetaCPAN instance. Currently we already have a flag `--cpan-mirror` for pointing fpm to a custom CPAN mirror instead of the official CPAN. However, in the case that somebody both has a custom CPAN mirror and they are serving a custom MetaCPAN instance on top of that mirror, they need a way to point fpm at both. Without this flag, fpm will query the official MetaCPAN to resolve module metadata, but then attempt to fetch the tarball from the custom CPAN mirror. If the mirror contains modules or versions that aren't indexed by the official MetaCPAN, those lookups will fail.