### PR TITLE
Fix for Build ID conflicts - disabling build id generation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Release Notes and Change Log
 ============================
 
+Unreleased
+^^^^^^^^^^
+
+* rpm: Disable build-id links by default to prevent file conflicts when multiple packages include pre-built ELF binaries with the same build-ids, such as Electron apps. (`#2142`_; Matthew Rathbone)
+
 1.17.0 (October 2, 2025)
 ^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -138,6 +138,25 @@ describe FPM::Package::RPM do
         expect(subject.rpmspec).to include('%defattr(-,some_user,some_group,-')
       end
     end # context
+
+    context "build-id links disabled by default" do
+      before :each do
+        FileUtils.mkdir_p(subject.staging_path(File.dirname(__FILE__)))
+        FileUtils.cp(__FILE__, subject.staging_path(__FILE__))
+        def subject.files; [__FILE__]; end
+        def subject.rpmspec; @rpmspec; end
+        def subject.render_template; @rpmspec = template("rpm.erb").result(binding); end
+        subject.render_template
+      end
+
+      after :each do
+        subject.cleanup
+      end
+
+      it "should disable build-id link generation" do
+        expect(subject.rpmspec).to include('%define _build_id_links none')
+      end
+    end # context
   end
 
   describe "#output" do

--- a/templates/rpm.erb
+++ b/templates/rpm.erb
@@ -20,6 +20,10 @@
 # Allow building noarch packages that contain binaries
 %define _binaries_in_noarch_packages_terminate_build 0
 
+# Disable build_id links to prevent file conflicts between packages
+# with pre-built ELF binaries sharing the same build-ids
+%define _build_id_links none
+
 # Use <%= attributes[:rpm_digest] %> file digest method. 
 # The first macro is the one used in RPM v4.9.1.1
 %define _binary_filedigest_algorithm <%= digest_algorithm %>


### PR DESCRIPTION
Full disclosure: This fix is generated by Claude. I did review it and did a bit of research on the purpose of Build IDs. Seems like they're mostly used for debugging, and it doesn't really hurt to remove them in FPM's case?

This adds %define _build_id_links none to the spec template, consistent with how FPM already disables other rpmbuild post-processing defaults.

Users who need build-id links can override with:
  --rpm-rpmbuild-define '_build_id_links compat'

Fixes #2142