### PR TITLE
[fix] Do not add symbol table in ar utility

### DIFF
--- a/lib/fpm/util.rb
+++ b/lib/fpm/util.rb
@@ -250,7 +250,7 @@ module FPM::Util
       end
     end
     # If no combination of ar and options omits timestamps, fall back to default.
-    @@ar_cmd = ["ar", "-qc"]
+    @@ar_cmd = ["ar", "-qcS"]
     FileUtils.rm_f([testarchive, emptyfile])
     return @@ar_cmd
   end # def ar_cmd


### PR DESCRIPTION
## Description
Xcode 26.4 and later enabled symbol table generation by default. This behavior causes ar to ignore all non-macho files leaving only SYMDEF entry and results in corrupted archive.

## Compatibility
-S flag is already included in all ar impls: bsd (FreeBSD 13.5), llvm-ar (FreeBSD 15.0), gnu (ArchLinux, Ubuntu 16.04), Apple (MacOS 10.10) so this change is fully backward-compatible will all these tools and should not cause any undesirable behavior.

Closes #2148 