### PR TITLE
Honor `SOURCE_DATE_EPOCH` for the rpm `%changelog` date

### DIFF
--- a/lib/fpm/package.rb
+++ b/lib/fpm/package.rb
@@ -322,6 +322,21 @@ class FPM::Package
       .collect { |path| path[staging_path.length + 1.. -1] }
   end # def files
 
+  # The timestamp to use in place of anything that would otherwise vary between builds,
+  # as a string holding seconds since the UNIX epoch, or nil if none is available.
+  #
+  # An input package type may set :source_date_epoch when it discovers a release date of
+  # its own; see FPM::Package::Gem. That takes precedence over the fallback given by
+  # --source-date-epoch-default, which defaults to the SOURCE_DATE_EPOCH environment
+  # variable.
+  #
+  # Package code should read this rather than attributes[:source_date_epoch].
+  #
+  # See https://reproducible-builds.org/specs/source-date-epoch
+  def source_date_epoch
+    attributes[:source_date_epoch] || attributes[:source_date_epoch_default]
+  end # def source_date_epoch
+
   def template_dir
     File.expand_path(File.join(File.dirname(__FILE__), "..", "..", "templates"))
   end # def template_dir
@@ -555,5 +570,5 @@ class FPM::Package
 
   # Package internal public api
   public(:cleanup_staging, :cleanup_build, :staging_path, :converted_from,
-         :edit_file, :build_path)
+         :edit_file, :build_path, :source_date_epoch)
 end # class FPM::Package

--- a/lib/fpm/package/deb.rb
+++ b/lib/fpm/package/deb.rb
@@ -526,18 +526,15 @@ class FPM::Package::Deb < FPM::Package
       end
     end
 
-    if attributes[:source_date_epoch].nil? and not attributes[:source_date_epoch_default].nil?
-      attributes[:source_date_epoch] = attributes[:source_date_epoch_default]
-    end
-    if attributes[:source_date_epoch] == "0"
+    if source_date_epoch == "0"
       logger.error("Alas, ruby's Zlib::GzipWriter does not support setting an mtime of zero.  Aborting.")
       raise FPM::InvalidPackageConfiguration, "#{name}: source_date_epoch of 0 not supported."
     end
-    if not attributes[:source_date_epoch].nil? and not ar_cmd_deterministic?
+    if not source_date_epoch.nil? and not ar_cmd_deterministic?
       logger.error("Alas, could not find an ar that can handle -D option. Try installing recent gnu binutils. Aborting.")
       raise FPM::InvalidPackageConfiguration, "#{name}: ar is insufficient to support source_date_epoch."
     end
-    if not attributes[:source_date_epoch].nil? and not tar_cmd_supports_sort_names_and_set_mtime?
+    if not source_date_epoch.nil? and not tar_cmd_supports_sort_names_and_set_mtime?
       logger.error("Alas, could not find a tar that can set mtime and sort.  Try installing recent gnu tar. Aborting.")
       raise FPM::InvalidPackageConfiguration, "#{name}: tar is insufficient to support source_date_epoch."
     end
@@ -612,8 +609,8 @@ class FPM::Package::Deb < FPM::Package
     mkdir_p(File.dirname(dest_changelog))
     File.new(dest_changelog, "wb", 0644).tap do |changelog|
       Zlib::GzipWriter.new(changelog, Zlib::BEST_COMPRESSION).tap do |changelog_gz|
-        if not attributes[:source_date_epoch].nil?
-          changelog_gz.mtime = attributes[:source_date_epoch].to_i
+        if not source_date_epoch.nil?
+          changelog_gz.mtime = source_date_epoch.to_i
         end
         if attributes[:deb_changelog]
           logger.info("Writing user-specified changelog", :source => attributes[:deb_changelog])
@@ -634,8 +631,8 @@ class FPM::Package::Deb < FPM::Package
     if attributes[:deb_upstream_changelog]
       File.new(dest_upstream_changelog, "wb", 0644).tap do |changelog|
         Zlib::GzipWriter.new(changelog, Zlib::BEST_COMPRESSION).tap do |changelog_gz|
-            if not attributes[:source_date_epoch].nil?
-              changelog_gz.mtime = attributes[:source_date_epoch].to_i
+            if not source_date_epoch.nil?
+              changelog_gz.mtime = source_date_epoch.to_i
             end
             logger.info("Writing user-specified upstream changelog", :source => attributes[:deb_upstream_changelog])
             File.new(attributes[:deb_upstream_changelog]).tap do |fd|
@@ -704,7 +701,7 @@ class FPM::Package::Deb < FPM::Package
         compression_flags = ["-z"]
       # gnu tar obeys GZIP environment variable with options for gzip; -n = forget original filename and date
         compressor_options = {"GZIP" => "-#{self.attributes[:deb_compression_level] || 9}" +
-            "#{'n' if tar_cmd_supports_sort_names_and_set_mtime? and not attributes[:source_date_epoch].nil?}"}
+            "#{'n' if tar_cmd_supports_sort_names_and_set_mtime? and not source_date_epoch.nil?}"}
       when "bzip2"
         datatar = build_path("data.tar.bz2")
         controltar = build_path("control.tar.gz")
@@ -730,9 +727,9 @@ class FPM::Package::Deb < FPM::Package
           "Unknown compression type '#{self.attributes[:deb_compression]}'"
     end
     args = [ tar_cmd, "-C", staging_path ] + compression_flags + data_tar_flags + [ "-cf", datatar, "." ]
-    if tar_cmd_supports_sort_names_and_set_mtime? and not attributes[:source_date_epoch].nil?
+    if tar_cmd_supports_sort_names_and_set_mtime? and not source_date_epoch.nil?
       # Use gnu tar options to force deterministic file order and timestamp
-      args += ["--sort=name", ("--mtime=@%s" % attributes[:source_date_epoch])]
+      args += ["--sort=name", ("--mtime=@%s" % source_date_epoch)]
     end
     args.unshift(compressor_options)
     safesystem(*args)
@@ -1043,7 +1040,7 @@ class FPM::Package::Deb < FPM::Package
         compression_flags = ["-z"]
         # gnu tar obeys GZIP environment variable with options for gzip; -n = forget original filename and date
         compressor_options = {"GZIP" => "-#{self.attributes[:deb_compression_level] || 9}" +
-            "#{'n' if tar_cmd_supports_sort_names_and_set_mtime? and not attributes[:source_date_epoch].nil?}"}
+            "#{'n' if tar_cmd_supports_sort_names_and_set_mtime? and not source_date_epoch.nil?}"}
       when "xz"
         controltar = "control.tar.xz"
         compression_flags = ["-J"]
@@ -1067,9 +1064,9 @@ class FPM::Package::Deb < FPM::Package
 
       args = [ tar_cmd, "-C", control_path ] + compression_flags + [ "-cf", controltar,
         "--owner=0", "--group=0", "--numeric-owner", "." ]
-      if tar_cmd_supports_sort_names_and_set_mtime? and not attributes[:source_date_epoch].nil?
+      if tar_cmd_supports_sort_names_and_set_mtime? and not source_date_epoch.nil?
         # Force deterministic file order and timestamp
-        args += ["--sort=name", ("--mtime=@%s" % attributes[:source_date_epoch])]
+        args += ["--sort=name", ("--mtime=@%s" % source_date_epoch)]
       end
       args.unshift(compressor_options)
       safesystem(*args)

--- a/lib/fpm/package/rpm.rb
+++ b/lib/fpm/package/rpm.rb
@@ -288,10 +288,13 @@ class FPM::Package::RPM < FPM::Package
       return attributes[:rpm_changelog]
     end
 
-    reldate = if attributes[:source_date_epoch].nil?
+    # rpm stores this date in the CHANGELOGTIME header, so it has to be fixed for the
+    # output to be reproducible. Format it in UTC, the time zone SOURCE_DATE_EPOCH is
+    # defined in, so that the time zone of the build machine cannot shift the date.
+    reldate = if source_date_epoch.nil?
                 Time.now()
               else
-                Time.at(attributes[:source_date_epoch].to_i)
+                Time.at(source_date_epoch.to_i).utc
               end
     changed = reldate.strftime("%a %b %_e %Y")
     changev = "#{version}-#{iteration}"

--- a/spec/fpm/package/deb_spec.rb
+++ b/spec/fpm/package/deb_spec.rb
@@ -510,12 +510,15 @@ describe FPM::Package::Deb do
     end
   end
 
-  describe "#reproducible" do
+  # A date an input type discovered for itself and the --source-date-epoch-default fallback
+  # both have to reach every generated file, so exercise the two attributes separately.
+  [:source_date_epoch, :source_date_epoch_default].each do |epoch_attribute|
+  describe "#reproducible with #{epoch_attribute}" do
 
     let(:package) {
        # Turn on reproducible build behavior by setting SOURCE_DATE_EPOCH like user would
        val = FPM::Package::Deb.new
-       val.attributes[:source_date_epoch] = '1'  # one second into Jan 1 1970 UTC... '0' not supported by zlib binding :-(
+       val.attributes[epoch_attribute] = '1'  # one second into Jan 1 1970 UTC... '0' not supported by zlib binding :-(
        val
     }
 
@@ -562,6 +565,7 @@ describe FPM::Package::Deb do
       expect(FileUtils.compare_file(target, target + '.orig')).to be true
     end
   end # #reproducible
+  end
 
   describe "compression" do
     {

--- a/spec/fpm/package/rpm_spec.rb
+++ b/spec/fpm/package/rpm_spec.rb
@@ -522,6 +522,49 @@ CHANGELOG
 
         File.unlink(@target)
       end
+
+      # In these two, 1700000000 is 2023-11-14 22:13:20 UTC. rpm stores the date of a
+      # changelog entry as noon UTC on the day it names, so a correctly dated entry gives
+      # 1699963200.
+      it "should date the generated changelog from source_date_epoch, in UTC" do
+        subject.name = "example"
+        subject.version = "1.0"
+        subject.attributes[:source_date_epoch] = "1700000000"
+        @target = Stud::Temporary.pathname
+
+        # The epoch above is late enough in the day that formatting it in a time zone east
+        # of UTC names the next day instead, which would give 1700049600. Spelled as a
+        # POSIX TZ string rather than a zoneinfo name, so this does not quietly fall back
+        # to UTC on a host without a time zone database installed.
+        saved_tz = ENV["TZ"]
+        begin
+          ENV["TZ"] = "JST-9"
+          # Write RPM
+          subject.output(@target)
+        ensure
+          ENV["TZ"] = saved_tz
+        end
+
+        @rpm = ::RPM::File.new(@target)
+        insist { @rpm.tags[:changelogtime] } == [ 1699963200 ]
+
+        File.unlink(@target)
+      end
+
+      it "should date the generated changelog from source_date_epoch_default" do
+        subject.name = "example"
+        subject.version = "1.0"
+        subject.attributes[:source_date_epoch_default] = "1700000000"
+        @target = Stud::Temporary.pathname
+
+        # Write RPM
+        subject.output(@target)
+
+        @rpm = ::RPM::File.new(@target)
+        insist { @rpm.tags[:changelogtime] } == [ 1699963200 ]
+
+        File.unlink(@target)
+      end
     end # changelog
   end # #output
 

--- a/spec/fpm/package_spec.rb
+++ b/spec/fpm/package_spec.rb
@@ -216,4 +216,21 @@ describe FPM::Package do
       expect(subject.staging_path("hello2")).to(include("staging"))
     end
   end
+
+  describe "#source_date_epoch (internal method)" do
+    it "should be nil when neither attribute is set" do
+      insist { subject.source_date_epoch }.nil?
+    end
+
+    it "should fall back to attributes[:source_date_epoch_default]" do
+      subject.attributes[:source_date_epoch_default] = "1700000000"
+      insist { subject.source_date_epoch } == "1700000000"
+    end
+
+    it "should prefer attributes[:source_date_epoch]" do
+      subject.attributes[:source_date_epoch] = "1699000000"
+      subject.attributes[:source_date_epoch_default] = "1700000000"
+      insist { subject.source_date_epoch } == "1699000000"
+    end
+  end
 end # describe FPM::Package

--- a/templates/deb/changelog.erb
+++ b/templates/deb/changelog.erb
@@ -2,4 +2,4 @@
 
   * Package created with FPM.
 
- -- <%= maintainer %>  <%= (if attributes[:source_date_epoch].nil? then Time.now() else Time.at(attributes[:source_date_epoch].to_i) end).strftime("%a, %d %b %Y %T %z") %>
+ -- <%= maintainer %>  <%= (if source_date_epoch.nil? then Time.now() else Time.at(source_date_epoch.to_i).utc end).strftime("%a, %d %b %Y %T %z") %>

--- a/templates/deb/deb.changes.erb
+++ b/templates/deb/deb.changes.erb
@@ -1,5 +1,5 @@
 Format: 1.8
-Date: <%= (if attributes[:source_date_epoch].nil? then Time.now() else Time.at(attributes[:source_date_epoch].to_i) end).strftime("%a, %d %b %Y %T %z") %>
+Date: <%= (if source_date_epoch.nil? then Time.now() else Time.at(source_date_epoch.to_i).utc end).strftime("%a, %d %b %Y %T %z") %>
 Source: <%= name %>
 Binary: <%= name %>
 Architecture: <%= architecture %>


### PR DESCRIPTION
Fixes #2154 

`FPM::Package::RPM#changelog` reads `attributes[:source_date_epoch]`, but the only code resolving `--source-date-epoch-default` (and thus the `SOURCE_DATE_EPOCH` environment variable) into that attribute lived in `FPM::Package::Deb#output`. So the rpm output dated the entry it generates from the wall clock, and since rpm parses that date into the `CHANGELOGTIME` header, the same input packaged on two different days produced two different rpms.

Move the precedence into `FPM::Package#source_date_epoch`, so every package type gets the same answer, and read that from the deb and rpm code. An input type that discovers a release date of its own still wins, as `FPM::Package::Gem` does.

The deb changelog and .changes templates read the attribute directly and relied on `Deb#output` having overwritten it first, so they read the accessor now too. Without that they would have gone back to dating themselves from the wall clock.

Also format these dates in UTC. `SOURCE_DATE_EPOCH` is defined as UTC, but strftime rendered it in the local time zone, so a build machine east of UTC could name the following day. Only the fixed-epoch case changes; when no epoch is given the timestamp is still local wall clock time.